### PR TITLE
textSlide style inheritance

### DIFF
--- a/scripts/slides/test_slide.json
+++ b/scripts/slides/test_slide.json
@@ -23,10 +23,7 @@
       "speaker": "Presenter",
       "text": "The evolution of humans is a complex journey that spans millions of years, shaped by biology, environment, and culture. Here's a high-level summary of the key stages in human evolution",
       "textSlideParams": {
-        "cssStyles": [
-          "body { background:#ffffcc }",
-          "h1 { color:green }"
-        ]
+        "cssStyles": ["body { background:#ffffcc }", "h1 { color:green }"]
       },
       "media": {
         "type": "textSlide",

--- a/scripts/slides/test_slide.json
+++ b/scripts/slides/test_slide.json
@@ -3,7 +3,7 @@
   "textSlideParams": {
     "cssStyles": [
       "body { margin: 40px; margin-top: 60px; color:#333 }",
-      "h1 { font-size: 60px; text-align: center; color:green }",
+      "h1 { font-size: 60px; text-align: center; color:red }",
       "ul { margin-left: 40px } ",
       "li { font-size: 48px }"
     ]

--- a/scripts/slides/test_slide.json
+++ b/scripts/slides/test_slide.json
@@ -22,6 +22,12 @@
     {
       "speaker": "Presenter",
       "text": "The evolution of humans is a complex journey that spans millions of years, shaped by biology, environment, and culture. Here's a high-level summary of the key stages in human evolution",
+      "textSlideParams": {
+        "cssStyles": [
+          "body { background:#ffffcc }",
+          "h1 { color:green }"
+        ]
+      },
       "media": {
         "type": "textSlide",
         "slide": {

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -17,13 +17,6 @@ dotenv.config();
 // const openai = new OpenAI();
 import { GoogleAuth } from "google-auth-library";
 
-const defaultStyles = [
-  "body { margin: 40px; margin-top: 60px; color:#333 }",
-  "h1 { font-size: 60px; text-align: center }",
-  "ul { margin-left: 40px } ",
-  "li { font-size: 48px }",
-];
-
 const preprocess_agent = async (namedInputs: { beat: MulmoStudioBeat; index: number; suffix: string; studio: MulmoStudio; imageDirPath: string }) => {
   const { beat, index, suffix, studio, imageDirPath } = namedInputs;
   const imageParams = { ...studio.script.imageParams, ...beat.imageParams };
@@ -35,11 +28,11 @@ const preprocess_agent = async (namedInputs: { beat: MulmoStudioBeat; index: num
       const slide = beat.media.slide;
       const markdown: string = `# ${slide.title}` + slide.bullets.map((text) => `- ${text}`).join("\n");
       // NOTE: If we want to support per-beat CSS style, we need to add textSlideParams to MulmoBeat and process it here.
-      await convertMarkdownToImage(markdown, studio.script.textSlideParams?.cssStyles ?? defaultStyles, imagePath);
+      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script), imagePath);
     } else if (beat.media.type === "markdown") {
       const markdown: string = beat.media.markdown.join("\n");
       // NOTE: If we want to support per-beat CSS style, we need to add textSlideParams to MulmoBeat and process it here.
-      await convertMarkdownToImage(markdown, studio.script.textSlideParams?.cssStyles ?? defaultStyles, imagePath);
+      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script), imagePath);
     }
   }
   const aspectRatio = MulmoScriptMethods.getAspectRatio(studio.script);

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -28,11 +28,11 @@ const preprocess_agent = async (namedInputs: { beat: MulmoStudioBeat; index: num
       const slide = beat.media.slide;
       const markdown: string = `# ${slide.title}` + slide.bullets.map((text) => `- ${text}`).join("\n");
       // NOTE: If we want to support per-beat CSS style, we need to add textSlideParams to MulmoBeat and process it here.
-      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script), imagePath);
+      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script, beat), imagePath);
     } else if (beat.media.type === "markdown") {
       const markdown: string = beat.media.markdown.join("\n");
       // NOTE: If we want to support per-beat CSS style, we need to add textSlideParams to MulmoBeat and process it here.
-      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script), imagePath);
+      await convertMarkdownToImage(markdown, MulmoScriptMethods.getTextSlideStyle(studio.script, beat), imagePath);
     }
   }
   const aspectRatio = MulmoScriptMethods.getAspectRatio(studio.script);

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -1,5 +1,12 @@
 import { MulmoDimension, MulmoScript } from "../types";
 
+const defaultTextSlideStyles = [
+  "body { margin: 40px; margin-top: 60px; color:#333 }",
+  "h1 { font-size: 60px; text-align: center }",
+  "ul { margin-left: 40px } ",
+  "li { font-size: 48px }",
+];
+
 export const MulmoScriptMethods = {
   getPadding(script: MulmoScript): number {
     return script.videoParams?.padding ?? 1000; // msec
@@ -16,4 +23,8 @@ export const MulmoScriptMethods = {
   getSpeechProvider(script: MulmoScript): string {
     return script.speechParams?.provider ?? "openai";
   },
+  getTextSlideStyle(script: MulmoScript): string {
+    const styles = script.textSlideParams?.cssStyles ?? defaultTextSlideStyles;
+    return styles.join('\n');
+  }
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -27,6 +27,6 @@ export const MulmoScriptMethods = {
     const styles = script.textSlideParams?.cssStyles ?? defaultTextSlideStyles;
     // NOTES: Taking advantage of CSS override rule (you can redefine it to override)
     const extraStyles = beat.textSlideParams?.cssStyles ?? [];
-    return [...styles, ...extraStyles].join('\n');
-  }
+    return [...styles, ...extraStyles].join("\n");
+  },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -1,4 +1,4 @@
-import { MulmoDimension, MulmoScript } from "../types";
+import { MulmoDimension, MulmoScript, MulmoBeat } from "../types";
 
 const defaultTextSlideStyles = [
   "body { margin: 40px; margin-top: 60px; color:#333 }",
@@ -23,8 +23,10 @@ export const MulmoScriptMethods = {
   getSpeechProvider(script: MulmoScript): string {
     return script.speechParams?.provider ?? "openai";
   },
-  getTextSlideStyle(script: MulmoScript): string {
+  getTextSlideStyle(script: MulmoScript, beat: MulmoBeat): string {
     const styles = script.textSlideParams?.cssStyles ?? defaultTextSlideStyles;
-    return styles.join('\n');
+    // NOTES: Taking advantage of CSS override rule (you can redefine it to override)
+    const extraStyles = beat.textSlideParams?.cssStyles ?? [];
+    return [...styles, ...extraStyles].join('\n');
   }
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -104,6 +104,7 @@ export const mulmoBeatSchema = z.object({
 
   imageParams: text2imageParamsSchema.optional(), // beat specific parameters
   speechParams: text2speechParamsSchema.optional(),
+  textSlideParams: textSlideParamsSchema.optional(),
   imagePrompt: z.string().optional(), // specified or inserted by preprocessor
   image: z.string().optional(), // path to the image
 });

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,9 +1,9 @@
 import { marked } from "marked";
 import puppeteer from "puppeteer";
 
-export const convertMarkdownToImage = async (markdown: string, styles: string[], outputPath: string) => {
+export const convertMarkdownToImage = async (markdown: string, style: string, outputPath: string) => {
   // Step 0: Prepare the header
-  const header = `<head><style>${styles.join("\n")}</style></head>`;
+  const header = `<head><style>${style}</style></head>`;
 
   // Step 1: Convert Markdown to HTML
   const body = await marked(markdown);


### PR DESCRIPTION
textSlideParams の style を beat でも指定できるようにした上で、script の style を引き継ぐ形にしました。CSSの場合、同じ属性のものが二つあると、後の方が優先されるので、beatのものを後に置くことにより、beatごとに色を変えたりすることを可能にしました。

それに加え、getTextStylleStyle を method 化することにより、二箇所で同じコードを書く必要をなくしました。
