### PR TITLE
Enable url reference in interactive mode

### DIFF
--- a/src/cli/tool-args.ts
+++ b/src/cli/tool-args.ts
@@ -10,6 +10,7 @@ export const args = commonOptions(yargs(hideBin(process.argv)))
     alias: "url",
     description: "URLs to reference (required when not in interactive mode)",
     demandOption: false,
+    default: [],
     type: "array",
     string: true,
   })

--- a/src/cli/tool-cli.ts
+++ b/src/cli/tool-cli.ts
@@ -26,8 +26,8 @@ const main = async () => {
 
   if (action === "scripting") {
     if (interactive) {
-      await createMulmoScriptWithInteractive({ outDirPath, templateName: template, filename });
-    } else if (urls) {
+      await createMulmoScriptWithInteractive({ outDirPath, templateName: template, urls: urls, filename });
+    } else if (urls.length > 0) {
       await createMulmoScriptFromUrl({ urls, templateName: template, outDirPath, filename });
     } else {
       throw new Error("urls is required when not in interactive mode");

--- a/src/tools/seed.ts
+++ b/src/tools/seed.ts
@@ -4,8 +4,61 @@ import * as agents from "@graphai/agents";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 import { readTemplatePrompt } from "../utils/file";
 import { ScriptingParams } from "../types";
+import { browserlessAgent } from "@graphai/browserless_agent";
 
 const agentHeader = "\x1b[34m● \x1b[0m\x1b[1mAgent\x1b[0m:\x1b[0m";
+
+const graphDataForScraping = {
+  version: 0.5,
+  nodes: {
+    urls: {
+      value: [],
+    },
+    fetchResults: {
+      agent: "mapAgent",
+      inputs: {
+        rows: ":urls",
+      },
+      params: {
+        compositeResult: true,
+      },
+      graph: {
+        nodes: {
+          fetcher: {
+            agent: "browserlessAgent",
+            inputs: {
+              url: ":row",
+              text_content: true,
+            },
+            params: {
+              throwError: true,
+            },
+          },
+          copyAgent: {
+            agent: "copyAgent",
+            inputs: {
+              text: "{ url: \"${:row}\", text: \"${:fetcher.text}\" }",
+            },
+            params: {
+              namedKey: "text",
+            },
+            isResult: true,
+          },
+        },
+      },
+    },
+    sourceText: {
+      agent: "arrayJoinAgent",
+      inputs: {
+        array: ":fetchResults.copyAgent",
+      },
+      params: {
+        separator: ",",
+      },
+      isResult: true,
+    },
+  }
+}
 
 const graphData = {
   version: 0.5,
@@ -88,14 +141,31 @@ const graphData = {
 
 const interactiveClarificationPrompt = `If there are any unclear points, be sure to ask the user questions and clarify them before generating the script.`;
 
-export const createMulmoScriptWithInteractive = async ({ outDirPath, filename, templateName }: Omit<ScriptingParams, "urls">) => {
+const scrapeWebContent = async (urls: string[]) => {
+  console.log(`${agentHeader} Scraping ${urls.length} URLs...\n`);
+
+  const graph = new GraphAI(graphDataForScraping, { ...agents, fileWriteAgent, browserlessAgent });
+  graph.injectValue("urls", urls);
+
+  const result = await graph.run() as { sourceText: { text: string } };
+  if (!result?.sourceText?.text) {
+    return ""
+  }
+  const prefixPrompt = "Here is the web content that can be used as reference material for the script:";
+  return `\n\n${prefixPrompt}\n${result?.sourceText.text}`;
+};
+
+export const createMulmoScriptWithInteractive = async ({ outDirPath, filename, templateName, urls }: ScriptingParams) => {
+  // if urls is not empty, scrape web content and reference it in the prompt
+  const webContentPrompt = urls.length > 0 ? await scrapeWebContent(urls) : "";
+   
   const graph = new GraphAI(graphData, { ...agents, fileWriteAgent });
 
   const prompt = readTemplatePrompt(templateName ?? "seed_interactive");
   graph.injectValue("messages", [
     {
       role: "system",
-      content: `${prompt}\n\n${interactiveClarificationPrompt}`,
+      content: `${prompt}\n\n${interactiveClarificationPrompt}${webContentPrompt}`,
     },
   ]);
   graph.injectValue("outdir", outDirPath);


### PR DESCRIPTION
Interactiveモードでもurlsのオプションで指定されたサイトのコンテンツを参照できるようにしました。

## 変更点

- interactiveモードでもurlsを利用するように修正
- urlsがある場合は、interactive modeに入る前にbrowserless agentを使いweb contentを取得
- interactive modeのpromptにweb contentを資料として使うように追加

## 動作例

```
yarn scripting -i -u https://ja.wikipedia.org/wiki/%E3%82%AB%E3%83%BC%E3%83%93%E3%82%A3%E3%81%AE%E3%82%A8%E3%82%A2%E3%83%A9%E3%82%A4%E3%83%89
```

![CleanShot 2025-05-04 at 21 00 55@2x](https://github.com/user-attachments/assets/3cc4f159-06a8-4841-a9b3-a616c98d10e1)
