### PR TITLE
[POC] Use zod-to-json-schema in scripting

### DIFF
--- a/assets/templates/audio_standard.json
+++ b/assets/templates/audio_standard.json
@@ -1,0 +1,3 @@
+{
+  "systemPrompt": "Please generate a podcast script based on the topic provided by the user."
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "marked": "^15.0.11",
     "puppeteer": "^24.7.2",
     "yargs": "^17.7.2",
-    "zod": "^3.24.3"
+    "zod": "^3.24.3",
+    "zod-to-json-schema": "^3.24.5"
   },
   "devDependencies": {
     "@receptron/test_utils": "^1.0.3",

--- a/src/methods/mulmo_script_template.ts
+++ b/src/methods/mulmo_script_template.ts
@@ -1,7 +1,19 @@
+import zodToJsonSchema from "zod-to-json-schema";
 import { MulmoScriptTemplate } from "../types";
+import { mulmoScriptSchema } from "../types/schema";
 
 export const MulmoScriptTemplateMethods = {
   getSystemPrompt(template: MulmoScriptTemplate): string {
-    return `${template.systemPrompt}\n\`\`\`JSON\n${JSON.stringify(template.script)}\n\`\`\``;
+    const schema = zodToJsonSchema(mulmoScriptSchema, {
+      strictUnions: true,
+    });
+
+    return `
+**${template.systemPrompt}**
+
+The output should follow the JSON format specified below. Please provide your response as valid JSON within \`\`\`json code blocks for clarity.
+
+${JSON.stringify(schema)}
+`.trim();
   },
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -221,7 +221,6 @@ export const mulmoStudioSchema = z
 export const mulmoScriptTemplateSchema = z
   .object({
     systemPrompt: z.string(),
-    script: mulmoScriptSchema,
   })
   .strict();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2650,7 +2650,7 @@ yoctocolors-cjs@^2.1.2:
   resolved "https://registry.yarnpkg.com/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz#f4b905a840a37506813a7acaa28febe97767a242"
   integrity sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==
 
-zod-to-json-schema@^3.24.1:
+zod-to-json-schema@^3.24.1, zod-to-json-schema@^3.24.5:
   version "3.24.5"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz#d1095440b147fb7c2093812a53c54df8d5df50a3"
   integrity sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==


### PR DESCRIPTION
zod-to-json-schemaを使って、LLMにMulmoScriptSchemaを伝えるPOCです。

## 背景と提案
現在は、template配下のjsonにてSystemPromptとMulmoScriptSchemaの構造の簡易版を定義し、それをprompt化してLLMに渡すことでMulmoScriptを生成してもらっています。

とてもシンプルで良いと思うのですが、ただ以下の点で少し課題があるように思いました。

- schemaアップデートの追従が面倒（testで担保しているとしても）
- templateを気軽に追加できない（本当に変更したいsystem promptだけでなく、MulmoScriptの構造を逐次書く必要があるので）

そこで、MCPのTypeScript SDKの [zod-to-json-schemaを使ってLLMに出力を強制している](https://github.com/modelcontextprotocol/typescript-sdk/blob/621ccea997bf318ee99c7f64ce19609e838615fa/src/server/mcp.ts#L118-L121) 実装をヒントに、MulmoScriptSchemaをJSON Schema化して、それをLLMに渡す実装を試してみました。

実装箇所
https://github.com/receptron/mulmocast-cli/pull/159/files#diff-5e9bc73188d5c848c77bc84c13ffdcd2bd15260eeb88120a2cefeda6d09c7051R5-R17

```ts
export const MulmoScriptTemplateMethods = {
  getSystemPrompt(template: MulmoScriptTemplate): string {
    const schema = zodToJsonSchema(mulmoScriptSchema, {
      strictUnions: true,
    });

    return `
**${template.systemPrompt}**
The output should follow the JSON format specified below. Please provide your response as valid JSON within \`\`\`json code blocks for clarity.
${JSON.stringify(schema)}
`.trim();
```
これであれば、Schema管理は一箇所にまとめられます。また、template追加の際も、system promptに簡単な指示を書くだけです。schemaの構造も完璧に渡せるので精度高くscriptの生成が期待できます。