### PR TITLE
Fix input url

### DIFF
--- a/src/cli/tool-cli.ts
+++ b/src/cli/tool-cli.ts
@@ -43,15 +43,11 @@ const main = async () => {
     }
   }
 
-  // If urls are not specified, prompt for interactive input
-  if (!interactive) {
-    urls = await getUrlsIfNeeded(urls);
-  }
-
   if (action === "scripting") {
     if (interactive) {
       await createMulmoScriptWithInteractive({ outDirPath, templateName: template, urls, filename, cacheDirPath });
     } else {
+      urls = await getUrlsIfNeeded(urls);
       await createMulmoScriptFromUrl({ urls, templateName: template, outDirPath, filename, cacheDirPath });
     }
   } else if (action === "prompt") {


### PR DESCRIPTION
https://singularitysociety.slack.com/archives/C08NV3JCC9J/p1746618991105069 の件の対応

URLの入力は、scriptingアクション&& interactiveでない && urlオプションがない場合のみに表示するようにしました
