### PR TITLE
Default image model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ brew install ffmpeg
 
 Create a `.env` file in your project directory with the following API keys:
 
+### Required
 ```
 OPENAI_API_KEY=your_openai_api_key
-GOOGLE_PROJECT_ID=your_google_project_id # optional for movie, image generation
-NIJIVOICE_API_KEY=your_nijivoice_api_key # optional for movie, audio generation
-BROWSERLESS_API_TOKEN=your_browserless_api_token # optional for scripting from web content
+```
+### Optional
+```
+DEFAULT_OPENAI_IMAGE_MODEL=gpt-image-1 # for the advanced image geneartion model
+GOOGLE_PROJECT_ID=your_google_project_id # for Google's image generation model
+NIJIVOICE_API_KEY=your_nijivoice_api_key # for Nijivoice's TTS model
+BROWSERLESS_API_TOKEN=your_browserless_api_token # to access web in mulmo-tool
 ```
 
 ## Workflow

--- a/assets/templates/business.json
+++ b/assets/templates/business.json
@@ -13,9 +13,7 @@
       "height": 1024
     },
     "imageParams": {
-      "style": "Style appropriate for business environment.",
-      "model": "gpt-image-1",
-      "size": "1536x1024"
+      "style": "Style appropriate for business environment."
     },
     "speechParams": {
       "speakers": {

--- a/assets/templates/children_book.json
+++ b/assets/templates/children_book.json
@@ -13,9 +13,7 @@
       "height": 1024
     },
     "imageParams": {
-      "style": "A hand-drawn style illustration with a warm, nostalgic atmosphere. The background is rich with natural scenery—lush forests, cloudy skies, and traditional Japanese architecture. Characters have expressive eyes, soft facial features, and are portrayed with gentle lighting and subtle shading. The color palette is muted yet vivid, using earthy tones and watercolor-like textures. The overall scene feels magical and peaceful, with a sense of quiet wonder and emotional depth, reminiscent of classic 1980s and 1990s Japanese animation.",
-      "model": "gpt-image-1",
-      "size": "1536x1024"
+      "style": "A hand-drawn style illustration with a warm, nostalgic atmosphere. The background is rich with natural scenery—lush forests, cloudy skies, and traditional Japanese architecture. Characters have expressive eyes, soft facial features, and are portrayed with gentle lighting and subtle shading. The color palette is muted yet vivid, using earthy tones and watercolor-like textures. The overall scene feels magical and peaceful, with a sense of quiet wonder and emotional depth, reminiscent of classic 1980s and 1990s Japanese animation."
     },
     "speechParams": {
       "speakers": {

--- a/assets/templates/coding.json
+++ b/assets/templates/coding.json
@@ -13,9 +13,7 @@
       "height": 1024
     },
     "imageParams": {
-      "style": "Style appropriate for software presentation.",
-      "model": "gpt-image-1",
-      "size": "1536x1024"
+      "style": "Style appropriate for software presentation."
     },
     "speechParams": {
       "speakers": {

--- a/scripts/test/test_media.json
+++ b/scripts/test/test_media.json
@@ -42,6 +42,11 @@
           "path": "../../assets/audio/local_voice.mp3"
         }
       }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This is a generated image",
+      "imagePrompt": "Blue sky in Hawaii"
     }
   ]
 }

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -50,11 +50,11 @@ const graph_data: GraphData = {
   nodes: {
     context: {},
     imageDirPath: {},
-    text2imageAgent: {},
+    imageAgentInfo: {},
     outputStudioFilePath: {},
     map: {
       agent: "mapAgent",
-      inputs: { rows: ":context.studio.beats", context: ":context", text2imageAgent: ":text2imageAgent", imageDirPath: ":imageDirPath" },
+      inputs: { rows: ":context.studio.beats", context: ":context", imageAgentInfo: ":imageAgentInfo", imageDirPath: ":imageDirPath" },
       isResult: true,
       params: {
         rowKey: "beat",
@@ -74,7 +74,7 @@ const graph_data: GraphData = {
           },
           imageGenerator: {
             if: ":preprocessor.prompt",
-            agent: ":text2imageAgent",
+            agent: ":imageAgentInfo.agent",
             params: {
               model: ":preprocessor.imageParams.model",
               size: ":preprocessor.imageParams.size",
@@ -166,9 +166,9 @@ export const images = async (context: MulmoStudioContext) => {
     };
   }
 
-  const injections: Record<string, string | MulmoImageParams | MulmoStudioContext | undefined> = {
+  const injections: Record<string, { agent: string } | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
-    text2imageAgent: MulmoScriptMethods.getText2imageAgent(studio.script),
+    imageAgentInfo: MulmoScriptMethods.getImageAgentInfo(studio.script),
     outputStudioFilePath: getOutputStudioFilePath(outDirPath, studio.filename),
     imageDirPath,
   };

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -160,8 +160,11 @@ export const images = async (context: MulmoStudioContext) => {
   const options: GraphOptions = {
     agentFilters,
   };
+
+  const imageAgentInfo = MulmoScriptMethods.getImageAgentInfo(studio.script);
+
   // We need to get google's auth token only if the google is the text2image provider.
-  if (MulmoScriptMethods.getImageProvider(studio.script) === "google") {
+  if (imageAgentInfo.provider === "google") {
     console.log("google was specified as text2image engine");
     const token = await googleAuth();
     options.config = {
@@ -172,7 +175,6 @@ export const images = async (context: MulmoStudioContext) => {
     };
   }
 
-  const imageAgentInfo = MulmoScriptMethods.getImageAgentInfo(studio.script);
   console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent} defaultModel=${imageAgentInfo.defaultModel}`);
   const injections: Record<string, Text2ImageAgentInfo | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -166,9 +166,11 @@ export const images = async (context: MulmoStudioContext) => {
     };
   }
 
+  const imageAgentInfo = MulmoScriptMethods.getImageAgentInfo(studio.script);
+  console.log(`text2image agent = ${imageAgentInfo.agent}`);
   const injections: Record<string, { agent: string } | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
-    imageAgentInfo: MulmoScriptMethods.getImageAgentInfo(studio.script),
+    imageAgentInfo,
     outputStudioFilePath: getOutputStudioFilePath(outDirPath, studio.filename),
     imageDirPath,
   };

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -16,7 +16,14 @@ dotenv.config();
 // const openai = new OpenAI();
 import { GoogleAuth } from "google-auth-library";
 
-const preprocess_agent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoStudioBeat; index: number; suffix: string; imageDirPath: string, imageAgentInfo: Text2ImageAgentInfo }) => {
+const preprocess_agent = async (namedInputs: {
+  context: MulmoStudioContext;
+  beat: MulmoStudioBeat;
+  index: number;
+  suffix: string;
+  imageDirPath: string;
+  imageAgentInfo: Text2ImageAgentInfo;
+}) => {
   const { context, beat, index, suffix, imageDirPath, imageAgentInfo } = namedInputs;
   const imageParams = { ...imageAgentInfo.imageParams, ...beat.imageParams };
   const prompt = (beat.imagePrompt || beat.text) + "\n" + (imageParams.style || "");
@@ -70,7 +77,7 @@ const graph_data: GraphData = {
               index: ":__mapIndex",
               suffix: "p",
               imageDirPath: ":imageDirPath",
-              imageAgentInfo: ":imageAgentInfo"
+              imageAgentInfo: ":imageAgentInfo",
             },
           },
           imageGenerator: {
@@ -170,7 +177,7 @@ export const images = async (context: MulmoStudioContext) => {
     };
   }
 
-  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent} model=${imageAgentInfo.imageParams.model}`);
+  console.log(`text2image: provider=${imageAgentInfo.provider} model=${imageAgentInfo.imageParams.model}`);
   const injections: Record<string, Text2ImageAgentInfo | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
     imageAgentInfo,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -18,15 +18,10 @@ import { GoogleAuth } from "google-auth-library";
 
 const preprocess_agent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoStudioBeat; index: number; suffix: string; imageDirPath: string, imageAgentInfo: Text2ImageAgentInfo }) => {
   const { context, beat, index, suffix, imageDirPath, imageAgentInfo } = namedInputs;
-  const imageParams = { ...context.studio.script.imageParams, ...beat.imageParams };
+  const imageParams = { ...imageAgentInfo.imageParams, ...beat.imageParams };
   const prompt = (beat.imagePrompt || beat.text) + "\n" + (imageParams.style || "");
   const imagePath = `${imageDirPath}/${context.studio.filename}/${index}${suffix}.png`;
   const aspectRatio = MulmoScriptMethods.getAspectRatio(context.studio.script);
-
-  if (!imageParams.model) {
-    console.log("***DEBUG", imageAgentInfo.defaultModel);
-    imageParams.model = imageAgentInfo.defaultModel;
-  }
 
   if (beat.image) {
     if (beat.image.type === "textSlide") {
@@ -175,7 +170,7 @@ export const images = async (context: MulmoStudioContext) => {
     };
   }
 
-  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent} defaultModel=${imageAgentInfo.defaultModel}`);
+  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent} model=${imageAgentInfo.imageParams.model}`);
   const injections: Record<string, Text2ImageAgentInfo | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
     imageAgentInfo,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -16,12 +16,14 @@ dotenv.config();
 // const openai = new OpenAI();
 import { GoogleAuth } from "google-auth-library";
 
-const preprocess_agent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoStudioBeat; index: number; suffix: string; imageDirPath: string }) => {
-  const { context, beat, index, suffix, imageDirPath } = namedInputs;
+const preprocess_agent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoStudioBeat; index: number; suffix: string; imageDirPath: string, imageAgentInfo: Text2ImageAgentInfo }) => {
+  const { context, beat, index, suffix, imageDirPath, imageAgentInfo } = namedInputs;
   const imageParams = { ...context.studio.script.imageParams, ...beat.imageParams };
   const prompt = (beat.imagePrompt || beat.text) + "\n" + (imageParams.style || "");
   const imagePath = `${imageDirPath}/${context.studio.filename}/${index}${suffix}.png`;
   const aspectRatio = MulmoScriptMethods.getAspectRatio(context.studio.script);
+
+  console.log("***DEBUG", imageAgentInfo);
 
   if (beat.image) {
     if (beat.image.type === "textSlide") {
@@ -70,6 +72,7 @@ const graph_data: GraphData = {
               index: ":__mapIndex",
               suffix: "p",
               imageDirPath: ":imageDirPath",
+              imageAgentInfo: ":imageAgentInfo"
             },
           },
           imageGenerator: {

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -167,7 +167,7 @@ export const images = async (context: MulmoStudioContext) => {
   }
 
   const imageAgentInfo = MulmoScriptMethods.getImageAgentInfo(studio.script);
-  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent}`);
+  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent} defaultModel=${imageAgentInfo.defaultModel}`);
   const injections: Record<string, Text2ImageAgentInfo | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
     imageAgentInfo,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -10,7 +10,7 @@ import { fileCacheAgentFilter } from "../utils/filters";
 import { convertMarkdownToImage } from "../utils/markdown";
 import imageGoogleAgent from "../agents/image_google_agent";
 import imageOpenaiAgent from "../agents/image_openai_agent";
-import { MulmoScriptMethods, MulmoStudioContextMethods } from "../methods";
+import { MulmoScriptMethods, MulmoStudioContextMethods, Text2ImageAgentInfo } from "../methods";
 
 dotenv.config();
 // const openai = new OpenAI();
@@ -167,8 +167,8 @@ export const images = async (context: MulmoStudioContext) => {
   }
 
   const imageAgentInfo = MulmoScriptMethods.getImageAgentInfo(studio.script);
-  console.log(`text2image agent = ${imageAgentInfo.agent}`);
-  const injections: Record<string, { agent: string } | string | MulmoImageParams | MulmoStudioContext | undefined> = {
+  console.log(`text2image: provider=${imageAgentInfo.provider} agent=${imageAgentInfo.agent}`);
+  const injections: Record<string, Text2ImageAgentInfo | string | MulmoImageParams | MulmoStudioContext | undefined> = {
     context,
     imageAgentInfo,
     outputStudioFilePath: getOutputStudioFilePath(outDirPath, studio.filename),

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -23,7 +23,10 @@ const preprocess_agent = async (namedInputs: { context: MulmoStudioContext; beat
   const imagePath = `${imageDirPath}/${context.studio.filename}/${index}${suffix}.png`;
   const aspectRatio = MulmoScriptMethods.getAspectRatio(context.studio.script);
 
-  console.log("***DEBUG", imageAgentInfo);
+  if (!imageParams.model) {
+    console.log("***DEBUG", imageAgentInfo.defaultModel);
+    imageParams.model = imageAgentInfo.defaultModel;
+  }
 
   if (beat.image) {
     if (beat.image.type === "textSlide") {

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -32,7 +32,7 @@ export const imageOpenaiAgent: AgentFunction<
     model: model ?? "dall-e-3",
     prompt,
     n: 1,
-    size: size || "1792x1024",
+    size: size || (model === "gpt-image-1")? "1536x1024" : "1792x1024",
   };
   if (model === "gpt-image-1") {
     imageOptions.moderation = moderation || "auto";

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -32,7 +32,7 @@ export const imageOpenaiAgent: AgentFunction<
     model: model ?? "dall-e-3",
     prompt,
     n: 1,
-    size: size || (model === "gpt-image-1")? "1536x1024" : "1792x1024",
+    size: size || model === "gpt-image-1" ? "1536x1024" : "1792x1024",
   };
   if (model === "gpt-image-1") {
     imageOptions.moderation = moderation || "auto";

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -41,7 +41,9 @@ export const MulmoScriptMethods = {
     return { ...script.speechParams.speakers[beat.speaker].speechOptions, ...beat.speechOptions };
   },
 
-  getText2imageAgent(script: MulmoScript): string {
-    return this.getImageProvider(script) === "google" ? "imageGoogleAgent" : "imageOpenaiAgent";
+  getImageAgentInfo(script: MulmoScript): { agent: string } {
+    return {
+      agent: this.getImageProvider(script) === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
+    };
   },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -46,6 +46,8 @@ export const MulmoScriptMethods = {
   },
 
   getImageAgentInfo(script: MulmoScript): Text2ImageAgentInfo {
+    // Notice that we copy imageParams from script and update
+    // provider and model appropriately.
     const provider = script.imageParams?.provider ?? "openai";
     const imageAgentInfo: Text2ImageAgentInfo = {
       provider,

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -35,9 +35,6 @@ export const MulmoScriptMethods = {
   getSpeechProvider(script: MulmoScript): string {
     return script.speechParams?.provider ?? "openai";
   },
-  getImageProvider(script: MulmoScript): string {
-    return script.imageParams?.provider ?? "openai";
-  },
   getTextSlideStyle(script: MulmoScript, beat: MulmoBeat): string {
     const styles = script.textSlideParams?.cssStyles ?? defaultTextSlideStyles;
     // NOTES: Taking advantage of CSS override rule (you can redefine it to override)
@@ -49,7 +46,7 @@ export const MulmoScriptMethods = {
   },
 
   getImageAgentInfo(script: MulmoScript): Text2ImageAgentInfo {
-    const provider = this.getImageProvider(script);
+    const provider = script.imageParams?.provider ?? "openai";
     const imageAgentInfo: Text2ImageAgentInfo = {
       provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -53,6 +53,9 @@ export const MulmoScriptMethods = {
       provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
     };
+    if (provider === "openai") {
+      imageAgentInfo.defaultModel = "dall-e-3";
+    }
     return imageAgentInfo;
   },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -12,6 +12,12 @@ const defaultTextSlideStyles = [
   "tr:nth-child(even) { background-color: #eee }",
 ];
 
+export type Text2ImageAgentInfo = {
+  provider: string,
+  agent: string;
+  defaultModel?: string;
+};
+
 export const MulmoScriptMethods = {
   getPadding(script: MulmoScript): number {
     return script.videoParams?.padding ?? 1000; // msec
@@ -41,10 +47,12 @@ export const MulmoScriptMethods = {
     return { ...script.speechParams.speakers[beat.speaker].speechOptions, ...beat.speechOptions };
   },
 
-  getImageAgentInfo(script: MulmoScript): { agent: string } {
+  getImageAgentInfo(script: MulmoScript): Text2ImageAgentInfo {
     const provider = this.getImageProvider(script);
-    return {
+    const imageAgentInfo: Text2ImageAgentInfo = {
+      provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
     };
+    return imageAgentInfo;
   },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -14,7 +14,7 @@ const defaultTextSlideStyles = [
 ];
 
 export type Text2ImageAgentInfo = {
-  provider: Text2ImageProvider,
+  provider: Text2ImageProvider;
   agent: string;
   imageParams: MulmoImageParams;
 };
@@ -49,13 +49,13 @@ export const MulmoScriptMethods = {
     // Notice that we copy imageParams from script and update
     // provider and model appropriately.
     const provider = script.imageParams?.provider ?? "openai";
-    const defaultImageParams:MulmoImageParams = { model: (provider === "openai") ? process.env.DEFAULT_OPENAI_IMAGE_MODEL : undefined };
-    const imageAgentInfo: Text2ImageAgentInfo = {
+    const defaultImageParams: MulmoImageParams = {
+      model: provider === "openai" ? process.env.DEFAULT_OPENAI_IMAGE_MODEL : undefined,
+    };
+    return {
       provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
-      imageParams: { ...defaultImageParams, ...script.imageParams }
+      imageParams: { ...defaultImageParams, ...script.imageParams },
     };
-    console.log(imageAgentInfo.imageParams);
-    return imageAgentInfo;
   },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { MulmoDimension, MulmoScript, MulmoBeat, SpeechOptions } from "../types";
 
 const defaultTextSlideStyles = [
@@ -54,6 +55,7 @@ export const MulmoScriptMethods = {
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
     };
     if (provider === "openai") {
+      console.log("env", process.env.DEFAULT_OPENAI_IMAGE_MODEL);
       imageAgentInfo.defaultModel = "dall-e-3";
     }
     return imageAgentInfo;

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { MulmoDimension, MulmoScript, MulmoBeat, SpeechOptions } from "../types";
+import { MulmoDimension, MulmoScript, MulmoBeat, SpeechOptions, Text2ImageProvider, MulmoImageParams } from "../types";
 
 const defaultTextSlideStyles = [
   "body { margin: 40px; margin-top: 60px; color:#333; font-size: 48px }",
@@ -14,9 +14,9 @@ const defaultTextSlideStyles = [
 ];
 
 export type Text2ImageAgentInfo = {
-  provider: string,
+  provider: Text2ImageProvider,
   agent: string;
-  defaultModel?: string;
+  imageParams: MulmoImageParams;
 };
 
 export const MulmoScriptMethods = {
@@ -50,10 +50,11 @@ export const MulmoScriptMethods = {
     const imageAgentInfo: Text2ImageAgentInfo = {
       provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
+      imageParams: script.imageParams ?? {}
     };
-    if (provider === "openai") {
+    if (!imageAgentInfo.imageParams.model && provider === "openai") {
       console.log("env", process.env.DEFAULT_OPENAI_IMAGE_MODEL);
-      imageAgentInfo.defaultModel = "dall-e-3";
+      imageAgentInfo.imageParams.model = "dall-e-3";
     }
     return imageAgentInfo;
   },

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -49,15 +49,13 @@ export const MulmoScriptMethods = {
     // Notice that we copy imageParams from script and update
     // provider and model appropriately.
     const provider = script.imageParams?.provider ?? "openai";
+    const defaultImageParams:MulmoImageParams = { model: (provider === "openai") ? process.env.DEFAULT_OPENAI_IMAGE_MODEL : undefined };
     const imageAgentInfo: Text2ImageAgentInfo = {
       provider,
       agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
-      imageParams: script.imageParams ?? {}
+      imageParams: { ...defaultImageParams, ...script.imageParams }
     };
-    if (!imageAgentInfo.imageParams.model && provider === "openai") {
-      console.log("env", process.env.DEFAULT_OPENAI_IMAGE_MODEL);
-      imageAgentInfo.imageParams.model = "dall-e-3";
-    }
+    console.log(imageAgentInfo.imageParams);
     return imageAgentInfo;
   },
 };

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -42,8 +42,9 @@ export const MulmoScriptMethods = {
   },
 
   getImageAgentInfo(script: MulmoScript): { agent: string } {
+    const provider = this.getImageProvider(script);
     return {
-      agent: this.getImageProvider(script) === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
+      agent: provider === "google" ? "imageGoogleAgent" : "imageOpenaiAgent",
     };
   },
 };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -181,10 +181,7 @@ export const mulmoSpeechParamsSchema = z
   })
   .strict();
 
-export const text2ImageProviderSchema = z.union([
-  z.literal("openai"),
-  z.literal("google")
-]);
+export const text2ImageProviderSchema = z.union([z.literal("openai"), z.literal("google")]);
 
 export const mulmoScriptSchema = z
   .object({

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -181,6 +181,11 @@ export const mulmoSpeechParamsSchema = z
   })
   .strict();
 
+export const text2ImageProviderSchema = z.union([
+  z.literal("openai"),
+  z.literal("google")
+]);
+
 export const mulmoScriptSchema = z
   .object({
     // global settings
@@ -197,7 +202,7 @@ export const mulmoScriptSchema = z
 
     imageParams: mulmoImageParamsSchema
       .extend({
-        provider: z.string().optional(),
+        provider: text2ImageProviderSchema.optional(),
       })
       .optional(),
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -12,6 +12,7 @@ import {
   speechOptionsSchema,
   mulmoDimensionSchema,
   mulmoScriptTemplateSchema,
+  text2ImageProviderSchema,
 } from "./schema";
 import { z } from "zod";
 
@@ -22,6 +23,7 @@ export type MulmoSpeechParams = z.infer<typeof mulmoSpeechParamsSchema>;
 export type SpeechOptions = z.infer<typeof speechOptionsSchema>;
 export type MulmoImageParams = z.infer<typeof mulmoImageParamsSchema>;
 export type TextSlideParams = z.infer<typeof textSlideParamsSchema>;
+export type Text2ImageProvider = z.infer<typeof text2ImageProviderSchema>;
 export type LocalizedText = z.infer<typeof localizedTextSchema>;
 export type MulmoScript = z.infer<typeof mulmoScriptSchema>;
 export type MulmoDimension = z.infer<typeof mulmoDimensionSchema>;


### PR DESCRIPTION
1. テンプレートで画像モデルを指定するのをやめました
2. デフォルトは、openai の dall-e-3 です（本人認証は不要）
3. .env の DEFAULT_OPENAI_IMAGE_MODEL でデフォルトを"gpt-image-1"に変更することが可能です。
4. スクリプトやbeatにimageParams.modelが指定されている場合はそちらが使われます。
5. imageParams.provider は "openai" と "google" しか指定できないため、literal の union にすることにより、validation および auto-complete が効くようになりました。
6. READMEのconfigurationセクションにDEFAULT_OPENAI_IMAGE_MODELについての記述を追加
