### PR TITLE
Add workaround for esm

### DIFF
--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -1,8 +1,15 @@
 import { TransactionLog } from "graphai";
-import ora from "ora";
 
-const spinner = ora();
-spinner.prefixText = "\n";
+// workaround for ora which is a pure ESM package
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let spinner: any = { start: () => {}, stop: () => {}, prefixText: "" };
+const initSpinner = async () => {
+  const ora = await import("ora");
+  spinner = ora.default();
+  spinner.prefixText = "\n";
+};
+
+initSpinner().catch(console.error);
 
 export const cliLoadingPlugin =
   ({ nodeId, message }: { nodeId: string; message: string }) =>


### PR DESCRIPTION
oraがpure esmパッケージであるためnode22以前のcommon jsのmodule解決ではエラーになる問題を解消しました。
