### PR TITLE
Remove workaround

### DIFF
--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -1,15 +1,8 @@
 import { TransactionLog } from "graphai";
+import ora from "ora";
 
-// workaround for ora which is a pure ESM package
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let spinner: any = { start: () => {}, stop: () => {}, prefixText: "" };
-const initSpinner = async () => {
-  const ora = await import("ora");
-  spinner = ora.default();
-  spinner.prefixText = "\n";
-};
-
-initSpinner().catch(console.error);
+const spinner = ora();
+spinner.prefixText = "\n";
 
 export const cliLoadingPlugin =
   ({ nodeId, message }: { nodeId: string; message: string }) =>


### PR DESCRIPTION
#220 のESM対応でworkaroundが不要になったので元の実装に戻しました。
