### PR TITLE
Mermaid appendix

### DIFF
--- a/scripts/samples/mulmocast.json
+++ b/scripts/samples/mulmocast.json
@@ -23,7 +23,8 @@
         "code": {
           "kind": "path",
           "path": "./mulmocast.txt"
-        }
+        },
+        "appendix": "style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF"
       }
     }
   ]

--- a/scripts/samples/mulmocast.json
+++ b/scripts/samples/mulmocast.json
@@ -24,7 +24,10 @@
           "kind": "path",
           "path": "./mulmocast.txt"
         },
-        "appendix": "style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF"
+        "appendix": [
+          "style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF",
+          "style MulmoScript color:#FFFFFF, fill:#00AAFF, stroke:#00AAFF"
+        ]
       }
     }
   ]

--- a/scripts/samples/mulmocast.json
+++ b/scripts/samples/mulmocast.json
@@ -24,10 +24,7 @@
           "kind": "path",
           "path": "./mulmocast.txt"
         },
-        "appendix": [
-          "style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF",
-          "style MulmoScript color:#FFFFFF, fill:#00AAFF, stroke:#00AAFF"
-        ]
+        "appendix": ["style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF", "style MulmoScript color:#FFFFFF, fill:#00AAFF, stroke:#00AAFF"]
       }
     }
   ]

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -111,7 +111,7 @@ export const mulmoMermaidMediaSchema = z
     type: z.literal("mermaid"),
     title: z.string().describe("The title of the diagram"),
     code: mediaSourceSchema.describe("The code of the mermaid diagram"),
-    appendix: z.string().optional().describe("The appendix of the mermaid diagram; typically, style information."),
+    appendix: z.array(z.string()).optional().describe("The appendix of the mermaid diagram; typically, style information."),
   })
   .strict();
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -111,6 +111,7 @@ export const mulmoMermaidMediaSchema = z
     type: z.literal("mermaid"),
     title: z.string().describe("The title of the diagram"),
     code: mediaSourceSchema.describe("The code of the mermaid diagram"),
+    appendix: z.string().optional().describe("The appendix of the mermaid diagram; typically, style information."),
   })
   .strict();
 

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -15,7 +15,7 @@ const processMermaid = async (params: ImageProcessorParams) => {
   if (diagram_code) {
     const htmlData = interpolate(template, {
       title: beat.image.title,
-      diagram_code,
+      diagram_code: `${diagram_code}\n${beat.image.appendix ?? ""}`,
     });
     await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height);
   }

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -15,7 +15,7 @@ const processMermaid = async (params: ImageProcessorParams) => {
   if (diagram_code) {
     const htmlData = interpolate(template, {
       title: beat.image.title,
-      diagram_code: `${diagram_code}\n${beat.image.appendix ?? ""}`,
+      diagram_code: `${diagram_code}\n${beat.image.appendix?.join("\n") ?? ""}`,
     });
     await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height);
   }


### PR DESCRIPTION
mermaid に appendixという仕組みで beat ごとにノードのスタイルを調整できるようにしました。これにより、複数のページで同じダイアグラムを説明するときに、対象の色を変えることが出来ます。

```
      "image": {
        "type": "mermaid",
        "title": "MulmoCast",
        "code": {
          "kind": "path",
          "path": "./mulmocast.txt"
        },
        "appendix": ["style MulmoCast color:#FFFFFF, fill:#AA00FF, stroke:#AA00FF", "style MulmoScript color:#FFFFFF, fill:#00AAFF, stroke:#00AAFF"]
      }
```