### PR TITLE
Add story to script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cli": "npx tsx ./src/cli/run.ts",
     "scripting": "npx tsx ./src/cli/tool-cli.ts scripting",
     "dump_prompt": "npx tsx ./src/cli/tool-cli.ts prompt",
+    "story_to_script": "npx tsx ./src/tools/story_to_script.ts",
     "latest": "yarn upgrade-interactive  --latest",
     "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'"
   },

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -1,0 +1,109 @@
+import path from "path";
+import { getBaseDirPath, getTemplateFilePath } from "../utils/file.js";
+import { mulmoScriptTemplateSchema, mulmoStoryboardSchema } from "../types/schema.js";
+import { MulmoStoryboard } from "../types/index.js";
+import { GraphAI, GraphData } from "graphai";
+import { openAIAgent } from "@graphai/openai_agent";
+import * as agents from "@graphai/vanilla";
+
+const { default: __, ...vanillaAgents } = agents;
+
+const graphData: GraphData = {
+  version: 0.5,
+  nodes: {
+    scenes: {
+      value: [],
+    },
+    prompt: {
+      value: "",
+    },
+    script: {
+      agent: "mapAgent",
+      inputs: {
+        rows: ":scenes",
+        prompt: ":prompt",
+      },
+      graph: {
+        nodes: {
+          llm: {
+            agent: "openAIAgent",
+            inputs: {
+              model: "gpt-4o",
+              system: ":prompt",
+              prompt: "Please generate a script from the following scenes: ${:row}",
+            },
+          },
+          json: {
+            agent: "copyAgent",
+            inputs: {
+              json: ":llm.text.codeBlock().jsonParse()",
+            },
+            params: {
+              namedKey: "json",
+            },
+            isResult: true,
+          },
+        },
+      },
+    },
+    beatJoin: {
+      agent: ({ array }: { array: { json: unknown[] }[] }) => {
+        return array.map((item) => item.json).flat();
+      },
+      inputs: {
+        array: ":script",
+      },
+      isResult: true,
+    },
+    // TODO: create script file and write it
+  },
+};
+
+// TODO: refactor this part
+const generatePrompt = async (templateName: string, beatsPerScene: number, allScenes: string) => {
+  const templatePath = getTemplateFilePath(templateName);
+  const rowTemplate = await import(path.resolve(templatePath), { assert: { type: "json" } }).then((mod) => mod.default);
+  const template = mulmoScriptTemplateSchema.parse(rowTemplate);
+
+  const sampleBeats = template.script?.beats;
+
+  return `
+Generate a script for the given scenes, following the structure of the sample script below.
+\`\`\`JSON
+${JSON.stringify(sampleBeats)}
+\`\`\`
+For each scene, you must generate exactly ${beatsPerScene} beats.
+The beats should be created considering the overall content of the scenes.
+The scenes are as follows:
+\`\`\`
+${allScenes}
+\`\`\`
+Please provide your response as valid JSON within \`\`\`json code blocks for clarity.
+`.trim();
+};
+
+const storyToScript = async ({ story, beatsPerScene, templateName }: { story: MulmoStoryboard; beatsPerScene: number; templateName: string }) => {
+  const allScenes = story.scenes.map((scene) => scene.description).join("\n");
+  const prompt = await generatePrompt(templateName, beatsPerScene, allScenes);
+
+  const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent });
+  graph.injectValue("prompt", prompt);
+  graph.injectValue("scenes", story.scenes);
+
+  const result = await graph.run();
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(result.beatJoin, null, 2));
+};
+
+const main = async () => {
+  const beatsPerScene = 3;
+  const templateName = "business";
+  const storyPath = "./assets/storyboards/attention.json";
+
+  const storyRaw = await import(path.resolve(getBaseDirPath(), storyPath), { assert: { type: "json" } }).then((mod) => mod.default);
+  const story = mulmoStoryboardSchema.parse(storyRaw);
+
+  await storyToScript({ story, beatsPerScene, templateName });
+};
+
+main();


### PR DESCRIPTION
StoryboardからMulmoScriptのbeatを生成する処理を仮実装しました。

一旦以下のみ実装しています。

- sceneからbeatを生成する
  - beatの生成時にはsampleのscriptと、全体のsceneを与える
  - sceneの生成はmap agentで回す
- 出力されたbeatを結合する

方向性がずれていないかご確認お願いします。