### PR TITLE
extra text on image prompt

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -51,7 +51,7 @@ const imagePreprocessAgent = async (namedInputs: {
     }
   }
 
-  const prompt = (beat.imagePrompt || beat.text) + "\n" + (imageParams.style || "");
+  const prompt = (beat.imagePrompt || `generate image appropriate for the text. text: ${beat.text}`) + "\n" + (imageParams.style || "");
   return { path: imagePath, prompt, ...returnValue };
 };
 


### PR DESCRIPTION
imagePromptがない場合、text だけを渡してもイメージの生成に失敗するケースがあるので、頭に"generate image appropriate for the text. text:"をつけるようにしました。textは、
"コード解析ができるって、具体的にどういうことなんですか？"
です。