### PR TITLE
Article references and fix captions order

### DIFF
--- a/assets/templates/comic_strips.json
+++ b/assets/templates/comic_strips.json
@@ -1,7 +1,7 @@
 {
   "title": "American Comic Strips",
   "description": "Template for Dilbert-style comic strips.",
-  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Use the JSON below as a template.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
   "script": {
     "$mulmocast": {
       "version": "1.0",
@@ -25,7 +25,7 @@
     ],
     "beats": [
       {
-        "text": "Today we're exploring a fascinating concept that has shaped some of the most innovative companies and leaders of our time: the Reality Distortion Field. This term has become synonymous with visionary leadership and the ability to accomplish seemingly impossible goals."
+        "text": "Today we're exploring a fascinating concept that has shaped some of the most innovative companies and leaders of our time. This story is based on an Awesome News articled, titled 'The reality distortion field'. This term has become synonymous with visionary leadership and the ability to accomplish seemingly impossible goals."
       },
       {
         "text": "The Reality Distortion Field is a concept that was first introduced by Steve Jobs, the co-founder of Apple. It refers to the ability of a leader to convince people that something is possible, even if it seems impossible."

--- a/assets/templates/ghibli_strips.json
+++ b/assets/templates/ghibli_strips.json
@@ -1,7 +1,7 @@
 {
   "title": "American Comic Strips",
   "description": "Template for Dilbert-style comic strips.",
-  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Use the JSON below as a template.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
   "script": {
     "$mulmocast": {
       "version": "1.0",
@@ -19,13 +19,13 @@
     "references": [
       {
         "url": "https://www.somegreatwebsite.com/article/123",
-        "title": "Title of the article we are referencing",
+        "title": "The Awesome News: The reality distortion field",
         "type": "article"
       }
     ],
     "beats": [
       {
-        "text": "Today we're exploring a fascinating concept that has shaped some of the most innovative companies and leaders of our time: the Reality Distortion Field. This term has become synonymous with visionary leadership and the ability to accomplish seemingly impossible goals."
+        "text": "Today we're exploring a fascinating concept that has shaped some of the most innovative companies and leaders of our time. This story is based on an Awesome News articled, titled 'The reality distortion field'. This term has become synonymous with visionary leadership and the ability to accomplish seemingly impossible goals."
       },
       {
         "text": "The Reality Distortion Field is a concept that was first introduced by Steve Jobs, the co-founder of Apple. It refers to the ability of a leader to convince people that something is possible, even if it seems impossible."

--- a/scripts/test/test_media.json
+++ b/scripts/test/test_media.json
@@ -20,6 +20,12 @@
       }
     }
   },
+  "audioParams": {
+    "introPadding": 0,
+    "padding": 1.0,
+    "closingPadding": 5.0,
+    "outroPadding": 0
+  },
   "beats": [
     {
       "speaker": "Presenter",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -111,11 +111,11 @@ export const main = async () => {
     await images(context);
   }
   if (action === "movie") {
+    await audio(context);
+    await images(context);
     if (caption) {
       await captions(context);
     }
-    await audio(context);
-    await images(context);
     await movie(context);
   }
   if (action === "pdf") {


### PR DESCRIPTION
1. comic_strips と ghibli_strips に参照資料を紹介するようなプロンプトを追加しました。
2. images よりも先に captions を呼ぶとimagesフォルダーが作られていないので、順序を入れ替えました。