### PR TITLE
Add story to script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "scripting": "npx tsx ./src/cli/bin.ts tool scripting",
     "prompt": "npx tsx ./src/cli/bin.ts tool prompt",
     "schema": "npx tsx ./src/cli/bin.ts tool schema",
-    "story_to_script": "npx tsx ./src/tools/story_to_script.ts",
+    "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",
     "latest": "yarn upgrade-interactive  --latest",
     "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'"
   },

--- a/src/cli/commands/tool/index.ts
+++ b/src/cli/commands/tool/index.ts
@@ -2,11 +2,12 @@ import { ToolCliArgs } from "@/src/types/cli_types.js";
 import * as scriptingCmd from "./scripting/index.js";
 import * as promptCmd from "./prompt/index.js";
 import * as schemaCmd from "./schema/index.js";
+import * as storyToScriptCmd from "./story_to_script/index.js";
 import { Argv } from "yargs";
 
 export const command = "tool <command>";
 export const desc = "Generate Mulmo script and other tools";
 
-export const builder = (y: Argv) => y.command(scriptingCmd).command(promptCmd).command(schemaCmd).demandCommand().strict();
+export const builder = (y: Argv) => y.command(scriptingCmd).command(promptCmd).command(schemaCmd).command(storyToScriptCmd).demandCommand().strict();
 
 export const handler = (__argv: ToolCliArgs) => {};

--- a/src/cli/commands/tool/story_to_script/builder.ts
+++ b/src/cli/commands/tool/story_to_script/builder.ts
@@ -1,0 +1,44 @@
+import { Argv } from "yargs";
+import { getAvailableTemplates } from "../../../../utils/file.js";
+
+const availableTemplateNames = getAvailableTemplates().map((template) => template.filename);
+
+export const builder = (yargs: Argv) => {
+  return yargs
+    .option("o", {
+      alias: "outdir",
+      description: "output dir",
+      demandOption: false,
+      type: "string",
+    })
+    .option("b", {
+      alias: "basedir",
+      description: "base dir",
+      demandOption: false,
+      type: "string",
+    })
+    .option("t", {
+      alias: "template",
+      description: "Template name to use",
+      demandOption: false,
+      choices: availableTemplateNames,
+      type: "string",
+    })
+    .option("s", {
+      alias: "script",
+      description: "script filename",
+      demandOption: false,
+      default: "script",
+      type: "string",
+    })
+    .option("beats_per_scene", {
+      description: "beats per scene",
+      demandOption: false,
+      default: 3,
+      type: "number",
+    })
+    .positional("file", {
+      description: "story file path",
+      type: "string",
+    });
+};

--- a/src/cli/commands/tool/story_to_script/handler.ts
+++ b/src/cli/commands/tool/story_to_script/handler.ts
@@ -1,0 +1,46 @@
+import { ToolCliArgs } from "@/src/types/cli_types.js";
+import { selectTemplate } from "@/src/utils/inquirer.js";
+import { setGraphAILogger } from "@/src/cli/helpers.js";
+import { storyToScript } from "@/src/tools/story_to_script.js";
+import { mulmoStoryboardSchema } from "@/src/types/schema.js";
+import { getBaseDirPath, getFullPath, readAndParseJson } from "@/src/utils/file.js";
+import { outDirName } from "@/src/utils/const.js";
+
+export const handler = async (
+  argv: ToolCliArgs<{
+    o?: string;
+    b?: string;
+    t?: string;
+    s?: string;
+    beats_per_scene?: number;
+    file?: string;
+  }>,
+) => {
+  const { v: verbose, s: filename, file, o: outdir, b: basedir, beats_per_scene } = argv;
+  let { t: template } = argv;
+
+  const baseDirPath = getBaseDirPath(basedir as string);
+  const outDirPath = getFullPath(baseDirPath, (outdir as string) ?? outDirName);
+
+  if (!template) {
+    template = await selectTemplate();
+  }
+
+  setGraphAILogger(verbose, {
+    outdir: outDirPath,
+    basedir: baseDirPath,
+    template,
+    fileName: filename as string,
+    beatsPerScene: beats_per_scene as number,
+    storyFilePath: file as string,
+  });
+
+  const parsedStory = readAndParseJson(file as string, mulmoStoryboardSchema);
+  await storyToScript({
+    story: parsedStory,
+    beatsPerScene: beats_per_scene as number,
+    templateName: template,
+    outdir: outDirPath,
+    fileName: filename as string,
+  });
+};

--- a/src/cli/commands/tool/story_to_script/index.ts
+++ b/src/cli/commands/tool/story_to_script/index.ts
@@ -1,0 +1,4 @@
+export const command = "story_to_script <file>";
+export const desc = "Generate Mulmo script from story";
+export { builder } from "./builder.js";
+export { handler } from "./handler.js";

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -8,6 +8,7 @@ import { MulmoScriptTemplateMethods } from "../methods/mulmo_script_template.js"
 import { MulmoStudioContextMethods } from "../methods/index.js";
 import { mulmoScriptTemplateSchema } from "../types/schema.js";
 import { PDFMode } from "../types/index.js";
+import { ZodSchema } from "zod";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -176,4 +177,11 @@ export const resolveMediaSource = (source: MulmoMediaSource, context: MulmoStudi
     return source.url;
   }
   return null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const readAndParseJson = <S extends ZodSchema<any>>(filePath: string, schema: S): ReturnType<S["parse"]> => {
+  const fileContent = fs.readFileSync(filePath, "utf-8");
+  const json = JSON.parse(fileContent);
+  return schema.parse(json);
 };


### PR DESCRIPTION
story_to_scriptのコマンドを追加しました。

```
mulmo tool story_to_script <file>

Generate Mulmo script from story

Positionals:
  file  story file path                                      [string] [required]

Options:
      --version          Show version number                           [boolean]
  -v, --verbose          verbose log       [boolean] [required] [default: false]
  -h, --help             Show help                                     [boolean]
  -o, --outdir           output dir                                     [string]
  -b, --basedir          base dir                                       [string]
  -t, --template         Template name to use
       [string] [choices: "business", "children_book", "coding", "comic_strips",
                         "ghibli_strips", "podcast_standard", "sensei_and_taro"]
  -s, --script           script filename            [string] [default: "script"]
      --beats_per_scene  beats per scene                   [number] [default: 3]
```


以下オプションは別PRで対応します。

- llm_model
- llm_agent
- generate_mode
- cache

