### PR TITLE
Add llm options

### DIFF
--- a/src/cli/commands/tool/story_to_script/builder.ts
+++ b/src/cli/commands/tool/story_to_script/builder.ts
@@ -1,5 +1,6 @@
 import { Argv } from "yargs";
 import { getAvailableTemplates } from "../../../../utils/file.js";
+import { llmAgents } from "../../../../utils/utils.js";
 
 const availableTemplateNames = getAvailableTemplates().map((template) => template.filename);
 
@@ -36,6 +37,17 @@ export const builder = (yargs: Argv) => {
       demandOption: false,
       default: 3,
       type: "number",
+    })
+    .option("llm_agent", {
+      description: "llm agent",
+      demandOption: false,
+      choices: llmAgents,
+      type: "string",
+    })
+    .option("llm_model", {
+      description: "llm model",
+      demandOption: false,
+      type: "string",
     })
     .positional("file", {
       description: "story file path",

--- a/src/cli/commands/tool/story_to_script/handler.ts
+++ b/src/cli/commands/tool/story_to_script/handler.ts
@@ -14,9 +14,11 @@ export const handler = async (
     s?: string;
     beats_per_scene?: number;
     file?: string;
+    llm_agent?: string;
+    llm_model?: string;
   }>,
 ) => {
-  const { v: verbose, s: filename, file, o: outdir, b: basedir, beats_per_scene } = argv;
+  const { v: verbose, s: filename, file, o: outdir, b: basedir, beats_per_scene, llm_agent, llm_model } = argv;
   let { t: template } = argv;
 
   const baseDirPath = getBaseDirPath(basedir as string);
@@ -33,6 +35,8 @@ export const handler = async (
     fileName: filename as string,
     beatsPerScene: beats_per_scene as number,
     storyFilePath: file as string,
+    llmAgent: llm_agent,
+    llmModel: llm_model,
   });
 
   const parsedStory = readAndParseJson(file as string, mulmoStoryboardSchema);
@@ -42,5 +46,7 @@ export const handler = async (
     templateName: template,
     outdir: outDirPath,
     fileName: filename as string,
+    llmAgent: llm_agent,
+    llmModel: llm_model,
   });
 };

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -41,7 +41,7 @@ const createValidatedScriptGraphData = ({ systemPrompt, prompt, schema }: { syst
       continue: {
         agent: ({ isValid, counter }: { isValid: boolean; counter: number }) => {
           if (counter >= 3) {
-            GraphAILogger.error("Failed to generate a valid script. Please try again.");
+            GraphAILogger.info("Failed to generate a valid script. Please try again.");
             process.exit(1);
           }
           return !isValid;


### PR DESCRIPTION
llm_agentとllm_modelのオプションを追加しました。
anthoropicで動作確認済みです。

```diff
mulmo tool story_to_script <file>

Generate Mulmo script from story

Positionals:
  file  story file path                                      [string] [required]

Options:
      --version          Show version number                           [boolean]
  -v, --verbose          verbose log       [boolean] [required] [default: false]
  -h, --help             Show help                                     [boolean]
  -o, --outdir           output dir                                     [string]
  -b, --basedir          base dir                                       [string]
  -t, --template         Template name to use
       [string] [choices: "business", "children_book", "coding", "comic_strips",
                         "ghibli_strips", "podcast_standard", "sensei_and_taro"]
  -s, --script           script filename            [string] [default: "script"]
      --beats_per_scene  beats per scene                   [number] [default: 3]
+      --llm_agent        llm agent
              [string] [choices: "openAIAgent", "anthropicAgent", "geminiAgent",
                                                                    "groqAgent"]
+      --llm_model        llm model
```
