### PR TITLE
Adjust layouts of text and chart

### DIFF
--- a/assets/html/chart.html
+++ b/assets/html/chart.html
@@ -7,7 +7,7 @@
     <style>
         ${style}
         .chart-container {
-            width: ${width}px;
+            width: ${chart_width}px;
             margin: 0 auto;
         }
     </style>

--- a/assets/html/mermaid.html
+++ b/assets/html/mermaid.html
@@ -23,7 +23,7 @@
         }
         .mermaid svg {
             max-width: 100%;
-            max-height: 100%;
+            max-height: 80%;
             height: auto;
             width: auto;
         }

--- a/assets/templates/business.json
+++ b/assets/templates/business.json
@@ -30,9 +30,6 @@
             "title": "This is the title of this slide",
             "bullets": []
           }
-        },
-        "textSlideParams": {
-          "cssStyles": ["h1 { margin-top: 300px }"]
         }
       },
       {

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -15,7 +15,16 @@
       "image": {
         "type": "textSlide",
         "slide": {
-          "title": "Title Only",
+          "title": "Title Only"
+        }
+      }
+    },
+    {
+      "text": "",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Title and Subtitle",
           "bullets": []
         }
       }

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -24,8 +24,8 @@
       "image": {
         "type": "textSlide",
         "slide": {
-          "title": "Title and Subtitle",
-          "bullets": []
+          "title": "Title",
+          "subtitle": "Subtitle"
         }
       }
     },

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -1,0 +1,101 @@
+{
+  "$mulmocast": {
+    "version": "1.0"
+  },
+  "title": "Layout Test",
+  "beats": [
+    {
+      "text": "",
+      "duration": 0.5,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Title Only",
+          "bullets": []
+        }
+      }
+    },
+    {
+      "text": "",
+      "duration": 0.5,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Human Evolution",
+          "bullets": [
+            "Early Primates",
+            "Hominids and Hominins",
+            "Australopithecus",
+            "Genus Homo Emerges",
+            "Homo erectus and Migration",
+            "Neanderthals and Other Archaic Humans",
+            "Homo sapiens"
+          ]
+        }
+      }
+    },
+    {
+      "text": "",
+      "duration": 0.5,
+      "image": {
+        "type": "markdown",
+        "markdown": [
+          "# Markdown Table Example",
+          "### Table",
+          "| Item              | In Stock | Price |",
+          "| :---------------- | :------: | ----: |",
+          "| Python Hat        |   True   | 23.99 |",
+          "| SQL Hat           |   True   | 23.99 |",
+          "| Codecademy Tee    |  False   | 19.99 |",
+          "| Codecademy Hoodie |  False   | 42.99 |"
+        ]
+      }
+    },
+    {
+      "text": "",
+      "duration": 0.5,
+      "image": {
+        "type": "chart",
+        "title": "Sales and Profits (from Jan to June)",
+        "chartData": {
+          "type": "bar",
+          "data": {
+            "labels": ["January", "February", "March", "April", "May", "June"],
+            "datasets": [
+              {
+                "label": "Revenue ($1000s)",
+                "data": [120, 135, 180, 155, 170, 190],
+                "backgroundColor": "rgba(54, 162, 235, 0.5)",
+                "borderColor": "rgba(54, 162, 235, 1)",
+                "borderWidth": 1
+              },
+              {
+                "label": "Profit ($1000s)",
+                "data": [45, 52, 68, 53, 61, 73],
+                "backgroundColor": "rgba(75, 192, 192, 0.5)",
+                "borderColor": "rgba(75, 192, 192, 1)",
+                "borderWidth": 1
+              }
+            ]
+          },
+          "options": {
+            "responsive": true,
+            "animation": false
+          }
+        }
+      }
+    },
+    {
+      "text": "",
+      "duration": 0.5,
+      "image": {
+        "type": "mermaid",
+        "title": "Business Process Flow",
+        "code": {
+          "kind": "text",
+          "text": "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -136,6 +136,17 @@
           "text": "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A"
         }
       }
+    },
+    {
+      "text": "",
+      "image": {
+        "type": "mermaid",
+        "title": "Business Process Flow",
+        "code": {
+          "kind": "text",
+          "text": "graph TB\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A"
+        }
+      }
     }
   ]
 }

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -99,6 +99,36 @@
     {
       "text": "",
       "image": {
+        "type": "chart",
+        "title": "Sales and Profits (from Jan to June)",
+        "chartData": {
+          "type": "pie",
+          "data": {
+            "labels": ["OpenAIと投資家の取り分", "マイクロソフトの取り分"],
+            "datasets": [
+              {
+                "data": [90, 10],
+                "backgroundColor": ["rgba(75, 192, 192, 0.5)", "rgba(54, 162, 235, 0.5)"],
+                "borderColor": ["rgba(75, 192, 192, 1)", "rgba(54, 162, 235, 1)"],
+                "borderWidth": 1
+              }
+            ]
+          },
+          "options": {
+            "responsive": true,
+            "animation": false,
+            "plugins": {
+              "legend": {
+                "position": "bottom"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "",
+      "image": {
         "type": "mermaid",
         "title": "Business Process Flow",
         "code": {

--- a/scripts/test/test_layout.json
+++ b/scripts/test/test_layout.json
@@ -3,10 +3,15 @@
     "version": "1.0"
   },
   "title": "Layout Test",
+  "audioParams": {
+    "introPadding": 0,
+    "padding": 0.1,
+    "closingPadding": 0,
+    "outroPadding": 0
+  },
   "beats": [
     {
       "text": "",
-      "duration": 0.5,
       "image": {
         "type": "textSlide",
         "slide": {
@@ -17,7 +22,6 @@
     },
     {
       "text": "",
-      "duration": 0.5,
       "image": {
         "type": "textSlide",
         "slide": {
@@ -36,7 +40,6 @@
     },
     {
       "text": "",
-      "duration": 0.5,
       "image": {
         "type": "markdown",
         "markdown": [
@@ -53,7 +56,6 @@
     },
     {
       "text": "",
-      "duration": 0.5,
       "image": {
         "type": "chart",
         "title": "Sales and Profits (from Jan to June)",
@@ -65,14 +67,14 @@
               {
                 "label": "Revenue ($1000s)",
                 "data": [120, 135, 180, 155, 170, 190],
-                "backgroundColor": "rgba(54, 162, 235, 0.5)",
+                "backgroundColor": "rgba(54, 162, 235, 0.1)",
                 "borderColor": "rgba(54, 162, 235, 1)",
                 "borderWidth": 1
               },
               {
                 "label": "Profit ($1000s)",
                 "data": [45, 52, 68, 53, 61, 73],
-                "backgroundColor": "rgba(75, 192, 192, 0.5)",
+                "backgroundColor": "rgba(75, 192, 192, 0.1)",
                 "borderColor": "rgba(75, 192, 192, 1)",
                 "borderWidth": 1
               }
@@ -87,7 +89,6 @@
     },
     {
       "text": "",
-      "duration": 0.5,
       "image": {
         "type": "mermaid",
         "title": "Business Process Flow",

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -14,8 +14,8 @@ import { text2ImageProviderSchema, text2SpeechProviderSchema, mulmoCanvasDimensi
 const defaultTextSlideStyles = [
   '*,*::before,*::after{box-sizing:border-box}body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}ul[role="list"],ol[role="list"]{list-style:none}html:focus-within{scroll-behavior:smooth}body{min-height:100vh;text-rendering:optimizeSpeed;line-height:1.5}a:not([class]){text-decoration-skip-ink:auto}img,picture{max-width:100%;display:block}input,button,textarea,select{font:inherit}@media(prefers-reduced-motion:reduce){html:focus-within{scroll-behavior:auto}*,*::before,*::after{animation-duration:.01ms !important;animation-iteration-count:1 !important;transition-duration:.01ms !important;scroll-behavior:auto !important}}',
   "body { margin: 60px; margin-top: 40px; color:#333; font-size: 30px; font-family: Arial, sans-serif; box-sizing: border-box; height: 100vh }",
-  "h1 { font-size: 56px; margin-bottom: 20px; text-align: center; }",
-  "h2 { font-size: 48px }",
+  "h1 { font-size: 56px; margin-bottom: 20px; text-align: center }",
+  "h2 { font-size: 48px; text-align: center }",
   "h3 { font-size: 36px }",
   "ul { margin-left: 40px } ",
   "pre { background: #eeeecc; font-size: 16px; padding:4px }",
@@ -39,11 +39,11 @@ export const MulmoScriptMethods = {
     return text2SpeechProviderSchema.parse(script.speechParams?.provider);
   },
   getTextSlideStyle(script: MulmoScript, beat: MulmoBeat): string {
-    const styles = script.textSlideParams?.cssStyles ?? defaultTextSlideStyles;
+    const styles = script.textSlideParams?.cssStyles ?? [];
     // NOTES: Taking advantage of CSS override rule (you can redefine it to override)
     const extraStyles = beat.textSlideParams?.cssStyles ?? [];
     // This code allows us to support both string and array of strings for cssStyles
-    return [...[styles], ...[extraStyles]].flat().join("\n");
+    return [...defaultTextSlideStyles, ...[styles], ...[extraStyles]].flat().join("\n");
   },
   getSpeechOptions(script: MulmoScript, beat: MulmoBeat): SpeechOptions | undefined {
     return { ...script.speechParams.speakers[beat.speaker].speechOptions, ...beat.speechOptions };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -93,6 +93,7 @@ export const mulmoTextSlideMediaSchema = z
     type: z.literal("textSlide"),
     slide: z.object({
       title: z.string(),
+      subtitle: z.string().optional(),
       bullets: z.array(z.string()).optional(),
     }),
   })

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -93,7 +93,7 @@ export const mulmoTextSlideMediaSchema = z
     type: z.literal("textSlide"),
     slide: z.object({
       title: z.string(),
-      bullets: z.array(z.string()),
+      bullets: z.array(z.string()).optional(),
     }),
   })
   .strict();

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -8,11 +8,17 @@ const processChart = async (params: ImageProcessorParams) => {
   const { beat, imagePath, canvasSize, textSlideStyle } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
+  const isCircular =
+    beat.image.chartData.type === "pie" ||
+    beat.image.chartData.type === "doughnut" ||
+    beat.image.chartData.type === "polarArea" ||
+    beat.image.chartData.type === "radar";
+  const chart_width = isCircular ? Math.min(canvasSize.width, canvasSize.height) * 0.75 : canvasSize.width * 0.75;
   const template = getHTMLFile("chart");
   const htmlData = interpolate(template, {
     title: beat.image.title,
     style: textSlideStyle,
-    width: Math.round(canvasSize.width * 0.625).toString(),
+    chart_width: chart_width.toString(),
     chart_data: JSON.stringify(beat.image.chartData),
   });
   await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height);

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -8,8 +8,17 @@ const processTextSlide = async (params: ImageProcessorParams) => {
   if (!beat.image || beat.image.type !== imageType) return;
 
   const slide = beat.image.slide;
-  const markdown = `# ${slide.title}\n` + (slide.bullets ?? []).map((text) => `- ${text}`).join("\n");
-  await renderMarkdownToImage(markdown, textSlideStyle, imagePath, canvasSize.width, canvasSize.height);
+  const markdown = `# ${slide.title}\n`
+    + (slide.subtitle ? `## ${slide.subtitle}\n` : "")
+    + (slide.bullets ?? []).map((text) => `- ${text}`).join("\n");
+  const topMargin = (() => {
+    if (slide.bullets?.length && slide.bullets.length > 0) {
+      return "";
+    }
+    const marginTop = slide.subtitle ? canvasSize.height * 0.4 : canvasSize.height * 0.45;
+    return `body {margin-top: ${marginTop}px;}`;
+  })();
+  await renderMarkdownToImage(markdown, textSlideStyle + topMargin, imagePath, canvasSize.width, canvasSize.height);
   return imagePath;
 };
 

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -8,7 +8,7 @@ const processTextSlide = async (params: ImageProcessorParams) => {
   if (!beat.image || beat.image.type !== imageType) return;
 
   const slide = beat.image.slide;
-  const markdown = `# ${slide.title}\n` + slide.bullets.map((text) => `- ${text}`).join("\n");
+  const markdown = `# ${slide.title}\n` + (slide.bullets ?? []).map((text) => `- ${text}`).join("\n");
   await renderMarkdownToImage(markdown, textSlideStyle, imagePath, canvasSize.width, canvasSize.height);
   return imagePath;
 };

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -8,9 +8,7 @@ const processTextSlide = async (params: ImageProcessorParams) => {
   if (!beat.image || beat.image.type !== imageType) return;
 
   const slide = beat.image.slide;
-  const markdown = `# ${slide.title}\n`
-    + (slide.subtitle ? `## ${slide.subtitle}\n` : "")
-    + (slide.bullets ?? []).map((text) => `- ${text}`).join("\n");
+  const markdown = `# ${slide.title}\n` + (slide.subtitle ? `## ${slide.subtitle}\n` : "") + (slide.bullets ?? []).map((text) => `- ${text}`).join("\n");
   const topMargin = (() => {
     if (slide.bullets?.length && slide.bullets.length > 0) {
       return "";


### PR DESCRIPTION
レイアウトのテスト専用のテストスクリプト、test_layout.json を追加
TextSlide: subtitle を追加
TextSlide: bullets[] はオプションに
TextSlide: bulletsがない場合は、上下にセンタリング
Chart: 円グラフなどアスペクト比が１：１のグラフは高さも考慮して描画
Mermaid: 縦長のグラフの表示を考慮してレイアウト