### PR TITLE
image aspect ratio

### DIFF
--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -18,7 +18,9 @@ export const getVideoPart = (inputIndex: number, mediaType: BeatMediaType, durat
         `trim=duration=${duration}`,
         "fps=30",
         "setpts=PTS-STARTPTS",
-        `scale=${canvasInfo.width}:${canvasInfo.height}`,
+        `scale=w=${canvasInfo.width}:h=${canvasInfo.height}:force_original_aspect_ratio=decrease`,
+        // In case of the aspect ratio mismatch, we fill the extra space with black color.
+        `pad=${canvasInfo.width}:${canvasInfo.height}:(ow-iw)/2:(oh-ih)/2:color=black`,
         "setsar=1",
         "format=yuv420p",
       ]

--- a/test/utils/test_movie.ts
+++ b/test/utils/test_movie.ts
@@ -5,12 +5,18 @@ import { getVideoPart, getAudioPart } from "../../src/actions/movie.js";
 
 test("test getVideoParts image", async () => {
   const { videoPart } = getVideoPart(1, "image", 200, { width: 100, height: 300 });
-  assert.equal(videoPart, "[1:v]loop=loop=-1:size=1:start=0,trim=duration=200,fps=30,setpts=PTS-STARTPTS,scale=100:300,setsar=1,format=yuv420p[v1]");
+  assert.equal(
+    videoPart,
+    "[1:v]loop=loop=-1:size=1:start=0,trim=duration=200,fps=30,setpts=PTS-STARTPTS,scale=w=100:h=300:force_original_aspect_ratio=decrease,pad=100:300:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,format=yuv420p[v1]",
+  );
 });
 
 test("test getVideoParts movie", async () => {
   const { videoPart } = getVideoPart(1, "movie", 200, { width: 100, height: 300 });
-  assert.equal(videoPart, "[1:v]trim=duration=200,fps=30,setpts=PTS-STARTPTS,scale=100:300,setsar=1,format=yuv420p[v1]");
+  assert.equal(
+    videoPart,
+    "[1:v]trim=duration=200,fps=30,setpts=PTS-STARTPTS,scale=w=100:h=300:force_original_aspect_ratio=decrease,pad=100:300:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,format=yuv420p[v1]",
+  );
 });
 
 test("test getAudioPart movie", async () => {


### PR DESCRIPTION
貼り付けるイメージのアスペクト比がキャンバスのアスペクト比と一致しない場合に、オリジナルのアスペクト比を維持したまま、キャンバスにフィットするように表示するようにしました。