### PR TITLE
Session state: beatState

### DIFF
--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -101,6 +101,9 @@ const graph_tts: GraphData = {
         text: ":preprocessor.text",
         file: ":preprocessor.audioPath",
         force: ":context.force",
+        studio: ":context.studio", // for cache
+        index: ":__mapIndex", // for cache
+        sessionType: "audio", // for cache
       },
       params: {
         voice: ":preprocessor.voiceId",

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -21,31 +21,36 @@ const graph_data: GraphData = {
       },
       graph: {
         nodes: {
-          test: {
+          generateCaption: {
             agent: async (namedInputs: { beat: MulmoBeat; context: MulmoStudioContext; index: number }) => {
               const { beat, context, index } = namedInputs;
-              const { fileDirs } = namedInputs.context;
-              const { caption } = context;
-              const { imageDirPath } = fileDirs;
-              const { canvasSize } = context.studio.script;
-              const imagePath = `${imageDirPath}/${context.studio.filename}/${index}_caption.png`;
-              const template = getHTMLFile("caption");
-              const text = (() => {
-                const multiLingual = context.studio.multiLingual;
-                if (caption && multiLingual) {
-                  return multiLingual[index].multiLingualTexts[caption].text;
-                }
-                GraphAILogger.warn(`No multiLingual caption found for beat ${index}, lang: ${caption}`);
-                return beat.text;
-              })();
-              const htmlData = interpolate(template, {
-                caption: text,
-                width: `${canvasSize.width}`,
-                height: `${canvasSize.height}`,
-              });
-              await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height, false, true);
-              context.studio.beats[index].captionFile = imagePath;
-              return imagePath;
+              try {
+                MulmoStudioMethods.setBeatSessionState(context.studio, "caption", index, true);
+                const { fileDirs } = namedInputs.context;
+                const { caption } = context;
+                const { imageDirPath } = fileDirs;
+                const { canvasSize } = context.studio.script;
+                const imagePath = `${imageDirPath}/${context.studio.filename}/${index}_caption.png`;
+                const template = getHTMLFile("caption");
+                const text = (() => {
+                  const multiLingual = context.studio.multiLingual;
+                  if (caption && multiLingual) {
+                    return multiLingual[index].multiLingualTexts[caption].text;
+                  }
+                  GraphAILogger.warn(`No multiLingual caption found for beat ${index}, lang: ${caption}`);
+                  return beat.text;
+                })();
+                const htmlData = interpolate(template, {
+                  caption: text,
+                  width: `${canvasSize.width}`,
+                  height: `${canvasSize.height}`,
+                });
+                await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height, false, true);
+                context.studio.beats[index].captionFile = imagePath;
+                return imagePath;
+              } finally {
+                MulmoStudioMethods.setBeatSessionState(context.studio, "caption", index, false);
+              }
             },
             inputs: {
               beat: ":beat",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -53,7 +53,7 @@ const imagePreprocessAgent = async (namedInputs: {
         const path = await plugin.process(processorParams);
         // undefined prompt indicates that image generation is not needed
         return { path, ...returnValue };
-        } finally {
+      } finally {
         MulmoStudioMethods.setBeatSessionState(context.studio, "image", index, false);
       }
     }

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -47,10 +47,15 @@ const imagePreprocessAgent = async (namedInputs: {
   if (beat.image) {
     const plugin = imagePlugins.find((plugin) => plugin.imageType === beat?.image?.type);
     if (plugin) {
-      const processorParams = { beat, context, imagePath, ...htmlStyle(context.studio.script, beat) };
-      const path = await plugin.process(processorParams);
-      // undefined prompt indicates that image generation is not needed
-      return { path, ...returnValue };
+      try {
+        MulmoStudioMethods.setBeatSessionState(context.studio, "image", index, true);
+        const processorParams = { beat, context, imagePath, ...htmlStyle(context.studio.script, beat) };
+        const path = await plugin.process(processorParams);
+        // undefined prompt indicates that image generation is not needed
+        return { path, ...returnValue };
+        } finally {
+        MulmoStudioMethods.setBeatSessionState(context.studio, "image", index, false);
+      }
     }
   }
 

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -101,6 +101,9 @@ const graph_data: GraphData = {
               file: ":preprocessor.path", // only for fileCacheAgentFilter
               text: ":preprocessor.prompt", // only for fileCacheAgentFilter
               force: ":context.force",
+              studio: ":context.studio", // for cache
+              index: ":__mapIndex", // for cache
+              sessionType: "image", // for cache
             },
             defaultValue: {},
           },

--- a/src/methods/mulmo_studio.ts
+++ b/src/methods/mulmo_studio.ts
@@ -2,15 +2,29 @@ import { MulmoStudio } from "../types/index.js";
 import { GraphAILogger } from "graphai";
 
 type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "pdf";
+type BeatSessionType = "audio" | "image" | "multiLingual" | "caption";
 
 const notifyStateChange = (studio: MulmoStudio, sessionType: SessionType) => {
   const prefix = studio.state.inSession[sessionType] ? "<" : ">";
   GraphAILogger.info(`${prefix} ${sessionType}`);
 };
 
+const notifyBeatStateChange = (studio: MulmoStudio, sessionType: BeatSessionType, index: number) => {
+  const prefix = studio.state.inBeatSession[sessionType].has(index) ? "{" : "}";
+  GraphAILogger.info(`${prefix} ${sessionType} ${index}`);
+};
+
 export const MulmoStudioMethods = {
   setSessionState(studio: MulmoStudio, sessionType: SessionType, value: boolean) {
     studio.state.inSession[sessionType] = value;
     notifyStateChange(studio, sessionType);
+  },
+  setBeatSessionState(studio: MulmoStudio, sessionType: BeatSessionType, index: number, value: boolean) {
+    if (value) {
+      studio.state.inBeatSession[sessionType].add(index);
+    } else {
+      studio.state.inBeatSession[sessionType].delete(index);
+    }
+    notifyBeatStateChange(studio, sessionType, index);
   },
 };

--- a/src/methods/mulmo_studio.ts
+++ b/src/methods/mulmo_studio.ts
@@ -5,12 +5,12 @@ type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "p
 type BeatSessionType = "audio" | "image" | "multiLingual" | "caption";
 
 const notifyStateChange = (studio: MulmoStudio, sessionType: SessionType) => {
-  const prefix = studio.state.inSession[sessionType] ? "<" : ">";
+  const prefix = studio.state.inSession[sessionType] ? "<" : " >";
   GraphAILogger.info(`${prefix} ${sessionType}`);
 };
 
 const notifyBeatStateChange = (studio: MulmoStudio, sessionType: BeatSessionType, index: number) => {
-  const prefix = studio.state.inBeatSession[sessionType].has(index) ? "{" : "}";
+  const prefix = studio.state.inBeatSession[sessionType].has(index) ? "{" : " }";
   GraphAILogger.info(`${prefix} ${sessionType} ${index}`);
 };
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -313,6 +313,12 @@ export const mulmoSessionStateSchema = z.object({
     caption: z.boolean(),
     pdf: z.boolean(),
   }),
+  inBeatSession: z.object({
+    audio: z.set(z.number()),
+    image: z.set(z.number()),
+    multiLingual: z.set(z.number()),
+    caption: z.set(z.number()),
+  }),
 });
 
 export const mulmoStudioSchema = z
@@ -329,6 +335,12 @@ export const mulmoStudioSchema = z
         multiLingual: false,
         caption: false,
         pdf: false,
+      },
+      inBeatSession: {
+        audio: new Set(),
+        image: new Set(),
+        multiLingual: new Set(),
+        caption: new Set(),
       },
     }),
   })

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -166,7 +166,7 @@ export const getAvailableTemplates = (): (MulmoScriptTemplate & { filename: stri
 };
 
 export const writingMessage = (filePath: string) => {
-  GraphAILogger.info(`writing: ${filePath}`);
+  // GraphAILogger.info(`writing: ${filePath}`);
 };
 
 export const resolveMediaSource = (source: MulmoMediaSource, context: MulmoStudioContext) => {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -166,7 +166,7 @@ export const getAvailableTemplates = (): (MulmoScriptTemplate & { filename: stri
 };
 
 export const writingMessage = (filePath: string) => {
-  // GraphAILogger.info(`writing: ${filePath}`);
+  GraphAILogger.debug(`writing: ${filePath}`);
 };
 
 export const resolveMediaSource = (source: MulmoMediaSource, context: MulmoStudioContext) => {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -6,10 +6,11 @@ import type { AgentFilterFunction } from "graphai";
 import { GraphAILogger } from "graphai";
 import { writingMessage } from "./file.js";
 import { text2hash } from "./utils.js";
+import { MulmoStudioMethods } from "../methods/mulmo_studio.js";
 
 export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) => {
   const { namedInputs } = context;
-  const { file, text, force } = namedInputs;
+  const { file, text, force, studio, index, sessionType } = namedInputs;
 
   const shouldUseCache = async () => {
     if (force) {
@@ -28,15 +29,20 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     GraphAILogger.info("cache hit: " + elements[elements.length - 1], text.slice(0, 10));
     return true;
   }
-  const output = (await next(context)) as { buffer: Buffer };
-  const buffer = output ? output["buffer"] : undefined;
-  if (buffer) {
-    writingMessage(file);
-    await fsPromise.writeFile(file, buffer);
-    return true;
+  try {
+    MulmoStudioMethods.setBeatSessionState(studio, sessionType, index, true);
+    const output = (await next(context)) as { buffer: Buffer };
+    const buffer = output ? output["buffer"] : undefined;
+    if (buffer) {
+      writingMessage(file);
+      await fsPromise.writeFile(file, buffer);
+      return true;
+    }
+    GraphAILogger.log("no cache, no buffer: " + file);
+    return false;
+  } finally {
+    MulmoStudioMethods.setBeatSessionState(studio, sessionType, index, false);
   }
-  GraphAILogger.log("no cache, no buffer: " + file);
-  return false;
 };
 
 export const browserlessCacheGenerator = (cacheDir: string) => {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -26,7 +26,6 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
 
   if (await shouldUseCache()) {
     const elements = file.split("/");
-    GraphAILogger.info("cache hit: " + elements[elements.length - 1], text.slice(0, 10));
     return true;
   }
   try {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -10,7 +10,7 @@ import { MulmoStudioMethods } from "../methods/mulmo_studio.js";
 
 export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) => {
   const { namedInputs } = context;
-  const { file, text, force, studio, index, sessionType } = namedInputs;
+  const { file, force, studio, index, sessionType } = namedInputs;
 
   const shouldUseCache = async () => {
     if (force) {
@@ -25,7 +25,6 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   };
 
   if (await shouldUseCache()) {
-    const elements = file.split("/");
     return true;
   }
   try {

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,4 +1,3 @@
-import { GraphAILogger } from "graphai";
 import { marked } from "marked";
 import puppeteer from "puppeteer";
 

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -37,7 +37,6 @@ export const renderHTMLToImage = async (
   await page.screenshot({ path: outputPath, omitBackground: omitBackground });
 
   await browser.close();
-  GraphAILogger.info(`HTML image rendered to ${outputPath}`);
 };
 
 export const renderMarkdownToImage = async (markdown: string, style: string, outputPath: string, width: number, height: number) => {

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -74,6 +74,12 @@ test("test createOrUpdateStudioData", async () => {
         caption: false,
         pdf: false,
       },
+      inBeatSession: {
+        audio: new Set(),
+        image: new Set(),
+        multiLingual: new Set(),
+        caption: new Set(),
+      },
     },
   };
   assert.deepStrictEqual(studio, expect);


### PR DESCRIPTION
beatごとの image, audio, caption, translation を状態管理するようにしています。キャッシュが再利用できた場合には状態遷移を省略するように作っています。consoleには、始まりと終わりが分かるように、

```
{ image 0
{ image 1
{ image 2
{ image 3
 } image 0
{ image 4
 } image 4
 } image 1
 } image 2
 } image 3
```
のように表示し、他のoutputは極力見せないようにしています。

注意点：
- 一部で"prop: prompt is not hit"が表示されてしまう（消し方が分からなくなった）
- これを追加して気がつきましたが、translationのキャッシュがうまく機能していないように見えます。