### PR TITLE
graphai_2_0_3

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^16.4.7",
     "fluent-ffmpeg": "^2.1.3",
     "google-auth-library": "^9.15.1",
-    "graphai": "^2.0.2",
+    "graphai": "^2.0.3",
     "inquirer": "^12.6.1",
     "marked": "^15.0.11",
     "ora": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,10 +1903,10 @@ gopd@^1.2.0:
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graphai@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/graphai/-/graphai-2.0.2.tgz#6a5c68c78c7efe645c27cfed400f09fa3ff93f86"
-  integrity sha512-P9Pa2lhNVFLB7mhLm512mVtmWWjAPuzaj8rCQv8k6bIOmG9QZtMoYs2OH5/Hq097Lo9XermZc/3wmnCgI4aO2g==
+graphai@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/graphai/-/graphai-2.0.3.tgz#de792e459e27a1b8802c07370e595896bbceae6e"
+  integrity sha512-VmmT0/cQKx5EwgDJzxnK0ee2TRKS6HGYPqw9Plia+uofkrFvHDdmiSFdTD8ClIOuf++Fdzy+orzdfBHN2RiQBg==
 
 graphemer@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
inputs.params の変更を有効にするには、graphaiを2.0.3にアップデートする必要があります。