### PR TITLE
Add generate mode option

### DIFF
--- a/src/cli/commands/tool/story_to_script/builder.ts
+++ b/src/cli/commands/tool/story_to_script/builder.ts
@@ -51,7 +51,7 @@ export const builder = (yargs: Argv) => {
       type: "string",
     })
     .option("mode", {
-      description: "story to script mode",
+      description: "story to script generation mode",
       demandOption: false,
       choices: Object.values(storyToScriptGenerateMode),
       default: storyToScriptGenerateMode.stepWise,

--- a/src/cli/commands/tool/story_to_script/builder.ts
+++ b/src/cli/commands/tool/story_to_script/builder.ts
@@ -1,7 +1,7 @@
 import { Argv } from "yargs";
 import { getAvailableTemplates } from "../../../../utils/file.js";
 import { llm } from "../../../../utils/utils.js";
-import { story_to_script_modes } from "../../../../utils/const.js";
+import { storyToScriptGenerateMode } from "../../../../utils/const.js";
 
 const availableTemplateNames = getAvailableTemplates().map((template) => template.filename);
 
@@ -53,8 +53,8 @@ export const builder = (yargs: Argv) => {
     .option("mode", {
       description: "story to script mode",
       demandOption: false,
-      choices: Object.values(story_to_script_modes),
-      default: story_to_script_modes.step_wise,
+      choices: Object.values(storyToScriptGenerateMode),
+      default: storyToScriptGenerateMode.stepWise,
       type: "string",
     })
     .positional("file", {

--- a/src/cli/commands/tool/story_to_script/builder.ts
+++ b/src/cli/commands/tool/story_to_script/builder.ts
@@ -1,6 +1,7 @@
 import { Argv } from "yargs";
 import { getAvailableTemplates } from "../../../../utils/file.js";
 import { llm } from "../../../../utils/utils.js";
+import { story_to_script_modes } from "../../../../utils/const.js";
 
 const availableTemplateNames = getAvailableTemplates().map((template) => template.filename);
 
@@ -47,6 +48,13 @@ export const builder = (yargs: Argv) => {
     .option("llm_model", {
       description: "llm model",
       demandOption: false,
+      type: "string",
+    })
+    .option("mode", {
+      description: "story to script mode",
+      demandOption: false,
+      choices: Object.values(story_to_script_modes),
+      default: story_to_script_modes.step_wise,
       type: "string",
     })
     .positional("file", {

--- a/src/cli/commands/tool/story_to_script/handler.ts
+++ b/src/cli/commands/tool/story_to_script/handler.ts
@@ -6,7 +6,7 @@ import { mulmoStoryboardSchema } from "../../../../types/schema.js";
 import { getBaseDirPath, getFullPath, readAndParseJson } from "../../../../utils/file.js";
 import { outDirName } from "../../../../utils/const.js";
 import { LLM } from "../../../../utils/utils.js";
-import { StoryToScriptMode } from "../../../../types/type.js";
+import { StoryToScriptGenerateMode } from "../../../../types/type.js";
 
 export const handler = async (
   argv: ToolCliArgs<{
@@ -51,6 +51,6 @@ export const handler = async (
     fileName: filename as string,
     llm,
     llmModel: llm_model,
-    storyToScriptMode: mode as StoryToScriptMode,
+    generateMode: mode as StoryToScriptGenerateMode,
   });
 };

--- a/src/cli/commands/tool/story_to_script/handler.ts
+++ b/src/cli/commands/tool/story_to_script/handler.ts
@@ -6,6 +6,7 @@ import { mulmoStoryboardSchema } from "../../../../types/schema.js";
 import { getBaseDirPath, getFullPath, readAndParseJson } from "../../../../utils/file.js";
 import { outDirName } from "../../../../utils/const.js";
 import { LLM } from "../../../../utils/utils.js";
+import { StoryToScriptMode } from "../../../../types/type.js";
 
 export const handler = async (
   argv: ToolCliArgs<{
@@ -17,9 +18,10 @@ export const handler = async (
     file?: string;
     llm?: LLM;
     llm_model?: string;
+    mode?: string;
   }>,
 ) => {
-  const { v: verbose, s: filename, file, o: outdir, b: basedir, beats_per_scene, llm, llm_model } = argv;
+  const { v: verbose, s: filename, file, o: outdir, b: basedir, beats_per_scene, llm, llm_model, mode } = argv;
   let { t: template } = argv;
 
   const baseDirPath = getBaseDirPath(basedir as string);
@@ -49,5 +51,6 @@ export const handler = async (
     fileName: filename as string,
     llm,
     llmModel: llm_model,
+    storyToScriptMode: mode as StoryToScriptMode,
   });
 };

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -74,7 +74,7 @@ const createValidatedScriptGraphData = ({
   };
 };
 
-const graphData: GraphData = {
+const stepWiseGraphData: GraphData = {
   version: 0.5,
   nodes: {
     scenes: {
@@ -228,7 +228,7 @@ export const storyToScript = async ({
   const beatsPrompt = await generateBeatsPrompt(template, beatsPerScene, story);
   const scriptInfoPrompt = await generateScriptInfoPrompt(template, story);
 
-  const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
+  const graph = new GraphAI(stepWiseGraphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
 
   graph.injectValue("beatsPrompt", beatsPrompt);
   graph.injectValue("scriptInfoPrompt", scriptInfoPrompt);

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { getTemplateFilePath, readScriptFile, writingMessage } from "../utils/file.js";
 import { mulmoScriptSchema, mulmoScriptTemplateSchema } from "../types/schema.js";
-import { MulmoScriptTemplate, MulmoStoryboard, StoryToScriptMode } from "../types/index.js";
+import { MulmoScriptTemplate, MulmoStoryboard, StoryToScriptGenerateMode } from "../types/index.js";
 import { GraphAI, GraphAILogger, GraphData } from "graphai";
 import { openAIAgent } from "@graphai/openai_agent";
 import { anthropicAgent } from "@graphai/anthropic_agent";
@@ -280,7 +280,7 @@ export const storyToScript = async ({
   fileName,
   llm,
   llmModel,
-  storyToScriptMode,
+  generateMode,
 }: {
   story: MulmoStoryboard;
   beatsPerScene: number;
@@ -289,7 +289,7 @@ export const storyToScript = async ({
   fileName: string;
   llm?: LLM;
   llmModel?: string;
-  storyToScriptMode: StoryToScriptMode;
+  generateMode: StoryToScriptGenerateMode;
 }) => {
   const templatePath = getTemplateFilePath(templateName);
   const rowTemplate = await import(path.resolve(templatePath), { assert: { type: "json" } }).then((mod) => mod.default);
@@ -300,11 +300,11 @@ export const storyToScript = async ({
   const scriptInfoPrompt = await generateScriptInfoPrompt(template, story);
   const scriptPrompt = await generateScriptPrompt(template, beatsPerScene, story);
 
-  const graphData = storyToScriptMode === story_to_script_modes.step_wise ? stepWiseGraphData : oneStepGraphData;
+  const graphData = generateMode === story_to_script_modes.step_wise ? stepWiseGraphData : oneStepGraphData;
 
   const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
 
-  if (storyToScriptMode === story_to_script_modes.step_wise) {
+  if (generateMode === story_to_script_modes.step_wise) {
     graph.injectValue("scenes", story.scenes);
     graph.injectValue("beatsPrompt", beatsPrompt);
     graph.injectValue("scriptInfoPrompt", scriptInfoPrompt);

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -13,7 +13,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 import validateSchemaAgent from "../agents/validate_schema_agent.js";
 import { ZodSchema } from "zod";
 import { LLM, llmPair } from "../utils/utils.js";
-import { story_to_script_modes } from "../utils/const.js";
+import { storyToScriptGenerateMode } from "../utils/const.js";
 
 const { default: __, ...vanillaAgents } = agents;
 
@@ -300,11 +300,11 @@ export const storyToScript = async ({
   const scriptInfoPrompt = await generateScriptInfoPrompt(template, story);
   const scriptPrompt = await generateScriptPrompt(template, beatsPerScene, story);
 
-  const graphData = generateMode === story_to_script_modes.step_wise ? stepWiseGraphData : oneStepGraphData;
+  const graphData = generateMode === storyToScriptGenerateMode.stepWise ? stepWiseGraphData : oneStepGraphData;
 
   const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
 
-  if (generateMode === story_to_script_modes.step_wise) {
+  if (generateMode === storyToScriptGenerateMode.stepWise) {
     graph.injectValue("scenes", story.scenes);
     graph.injectValue("beatsPrompt", beatsPrompt);
     graph.injectValue("scriptInfoPrompt", scriptInfoPrompt);

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -1,18 +1,19 @@
 import path from "path";
 import { getTemplateFilePath, readScriptFile, writingMessage } from "../utils/file.js";
 import { mulmoScriptSchema, mulmoScriptTemplateSchema } from "../types/schema.js";
-import { MulmoScriptTemplate, MulmoStoryboard } from "../types/index.js";
+import { MulmoScriptTemplate, MulmoStoryboard, StoryToScriptMode } from "../types/index.js";
 import { GraphAI, GraphAILogger, GraphData } from "graphai";
 import { openAIAgent } from "@graphai/openai_agent";
 import { anthropicAgent } from "@graphai/anthropic_agent";
 import { geminiAgent } from "@graphai/gemini_agent";
 import { groqAgent } from "@graphai/groq_agent";
 import * as agents from "@graphai/vanilla";
-import { graphDataScriptGeneratePrompt, sceneToBeatsPrompt, storyToScriptInfoPrompt } from "../utils/prompt.js";
+import { graphDataScriptGeneratePrompt, sceneToBeatsPrompt, storyToScriptPrompt } from "../utils/prompt.js";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 import validateSchemaAgent from "../agents/validate_schema_agent.js";
 import { ZodSchema } from "zod";
 import { LLM, llmPair } from "../utils/utils.js";
+import { story_to_script_modes } from "../utils/const.js";
 
 const { default: __, ...vanillaAgents } = agents;
 
@@ -187,6 +188,68 @@ const stepWiseGraphData: GraphData = {
   },
 };
 
+const oneStepGraphData: GraphData = {
+  version: 0.5,
+  nodes: {
+    scenes: {
+      value: [],
+    },
+    prompt: {
+      value: "",
+    },
+    outdir: {
+      value: "",
+    },
+    fileName: {
+      value: "",
+    },
+    llmAgent: {
+      value: "",
+    },
+    llmModel: {
+      value: "",
+    },
+    maxTokens: {
+      value: 0,
+    },
+    script: {
+      agent: "nestedAgent",
+      inputs: {
+        prompt: ":prompt",
+        llmAgent: ":llmAgent",
+        llmModel: ":llmModel",
+        maxTokens: ":maxTokens",
+      },
+      graph: createValidatedScriptGraphData({
+        systemPrompt: "",
+        prompt: graphDataScriptGeneratePrompt("${:prompt}"),
+        schema: mulmoScriptSchema,
+        llmAgent: ":llmAgent",
+        llmModel: ":llmModel",
+        maxTokens: ":maxTokens",
+      }),
+    },
+    json: {
+      agent: "copyAgent",
+      inputs: {
+        json: ":script.validateSchema.data",
+      },
+      params: {
+        namedKey: "json",
+      },
+      isResult: true,
+    },
+    writeJSON: {
+      agent: "fileWriteAgent",
+      inputs: {
+        file: "${:outdir}/${:fileName}-${@now}.json",
+        text: ":json.toJSON()",
+      },
+      isResult: true,
+    },
+  },
+};
+
 const generateBeatsPrompt = async (template: MulmoScriptTemplate, beatsPerScene: number, story: MulmoStoryboard) => {
   const allScenes = story.scenes.map((scene) => scene.description).join("\n");
   const sampleBeats = template.scriptName ? readScriptFile(template.scriptName).beats : [];
@@ -200,7 +263,16 @@ const generateScriptInfoPrompt = async (template: MulmoScriptTemplate, story: Mu
   }
   const script = readScriptFile(template.scriptName);
   const { beats: __, ...scriptWithoutBeats } = script;
-  return storyToScriptInfoPrompt(scriptWithoutBeats, story);
+  return storyToScriptPrompt(scriptWithoutBeats, story);
+};
+
+const generateScriptPrompt = async (template: MulmoScriptTemplate, story: MulmoStoryboard) => {
+  if (!template.scriptName) {
+    // TODO: use default schema
+    throw new Error("script is not provided");
+  }
+  const script = readScriptFile(template.scriptName);
+  return storyToScriptPrompt(script, story);
 };
 
 export const storyToScript = async ({
@@ -211,6 +283,7 @@ export const storyToScript = async ({
   fileName,
   llm,
   llmModel,
+  storyToScriptMode,
 }: {
   story: MulmoStoryboard;
   beatsPerScene: number;
@@ -219,6 +292,7 @@ export const storyToScript = async ({
   fileName: string;
   llm?: LLM;
   llmModel?: string;
+  storyToScriptMode: StoryToScriptMode;
 }) => {
   const templatePath = getTemplateFilePath(templateName);
   const rowTemplate = await import(path.resolve(templatePath), { assert: { type: "json" } }).then((mod) => mod.default);
@@ -227,11 +301,19 @@ export const storyToScript = async ({
 
   const beatsPrompt = await generateBeatsPrompt(template, beatsPerScene, story);
   const scriptInfoPrompt = await generateScriptInfoPrompt(template, story);
+  const scriptPrompt = await generateScriptPrompt(template, story);
 
-  const graph = new GraphAI(stepWiseGraphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
+  const graphData = storyToScriptMode === story_to_script_modes.step_wise ? stepWiseGraphData : oneStepGraphData;
 
-  graph.injectValue("beatsPrompt", beatsPrompt);
-  graph.injectValue("scriptInfoPrompt", scriptInfoPrompt);
+  const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, anthropicAgent, geminiAgent, groqAgent, fileWriteAgent, validateSchemaAgent });
+
+  if (storyToScriptMode === story_to_script_modes.step_wise) {
+    graph.injectValue("beatsPrompt", beatsPrompt);
+    graph.injectValue("scriptInfoPrompt", scriptInfoPrompt);
+  } else {
+    graph.injectValue("prompt", scriptPrompt);
+  }
+
   graph.injectValue("scenes", story.scenes);
   graph.injectValue("outdir", outdir);
   graph.injectValue("fileName", fileName);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -28,7 +28,7 @@ import {
   mulmoChartMediaSchema,
   mediaSourceSchema,
 } from "./schema.js";
-import { pdf_modes, pdf_sizes, story_to_script_modes } from "../utils/const.js";
+import { pdf_modes, pdf_sizes, storyToScriptGenerateMode } from "../utils/const.js";
 import { LLM } from "../utils/utils.js";
 import { z } from "zod";
 
@@ -109,4 +109,4 @@ export type Text2ImageAgentInfo = {
 
 export type BeatMediaType = "movie" | "image";
 
-export type StoryToScriptGenerateMode = (typeof story_to_script_modes)[keyof typeof story_to_script_modes];
+export type StoryToScriptGenerateMode = (typeof storyToScriptGenerateMode)[keyof typeof storyToScriptGenerateMode];

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -109,4 +109,4 @@ export type Text2ImageAgentInfo = {
 
 export type BeatMediaType = "movie" | "image";
 
-export type StoryToScriptMode = (typeof story_to_script_modes)[keyof typeof story_to_script_modes];
+export type StoryToScriptGenerateMode = (typeof story_to_script_modes)[keyof typeof story_to_script_modes];

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -28,7 +28,7 @@ import {
   mulmoChartMediaSchema,
   mediaSourceSchema,
 } from "./schema.js";
-import { pdf_modes, pdf_sizes } from "../utils/const.js";
+import { pdf_modes, pdf_sizes, story_to_script_modes } from "../utils/const.js";
 import { LLM } from "../utils/utils.js";
 import { z } from "zod";
 
@@ -108,3 +108,5 @@ export type Text2ImageAgentInfo = {
 };
 
 export type BeatMediaType = "movie" | "image";
+
+export type StoryToScriptMode = (typeof story_to_script_modes)[keyof typeof story_to_script_modes];

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -7,7 +7,7 @@ export const pdf_modes = ["slide", "talk", "handout"];
 export const pdf_sizes = ["letter", "a4"];
 export const languages = ["en", "ja"];
 
-export const story_to_script_modes = {
-  step_wise: "step_wise",
-  one_step: "one_step",
+export const storyToScriptGenerateMode = {
+  stepWise: "step_wise",
+  oneStep: "one_step",
 };

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -6,3 +6,8 @@ export const cacheDirName = "cache";
 export const pdf_modes = ["slide", "talk", "handout"];
 export const pdf_sizes = ["letter", "a4"];
 export const languages = ["en", "ja"];
+
+export const story_to_script_modes = {
+  step_wise: "step_wise",
+  one_step: "one_step",
+};

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -60,7 +60,7 @@ ${allScenes}
 Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();
 };
 
-export const storyToScriptPrompt = (script: Omit<MulmoScript, "beats"> | MulmoScript, story: MulmoStoryboard) => {
+export const storyToScriptInfoPrompt = (script: Omit<MulmoScript, "beats">, story: MulmoStoryboard) => {
   return `Generate script for the given storyboard, following the structure of the sample scripts below.
 Storyboard:
 - title: ${story.title}
@@ -72,6 +72,24 @@ Sample script:
 ${JSON.stringify(script)}
 \`\`\`
 
+Only include keys that exist in the sample script.
+Do not add any keys that are not present in the sample script.
+Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();
+};
+
+export const storyToScriptPrompt = (script: MulmoScript, beatsPerScene: number, story: MulmoStoryboard) => {
+  return `Generate script for the given storyboard, following the structure of the sample scripts below.
+Storyboard:
+- title: ${story.title}
+- references: ${story.references?.map((reference) => JSON.stringify(reference)).join("\n")}
+- scenes: ${JSON.stringify(story.scenes)}
+
+Sample script:
+\`\`\`JSON
+${JSON.stringify(script)}
+\`\`\`
+
+Generate exactly ${beatsPerScene} scripts (beats) for each scene.
 Only include keys that exist in the sample script.
 Do not add any keys that are not present in the sample script.
 Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -60,7 +60,7 @@ ${allScenes}
 Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();
 };
 
-export const storyToScriptInfoPrompt = (scriptWithoutBeats: Omit<MulmoScript, "beats">, story: MulmoStoryboard) => {
+export const storyToScriptPrompt = (script: Omit<MulmoScript, "beats"> | MulmoScript, story: MulmoStoryboard) => {
   return `Generate script for the given storyboard, following the structure of the sample scripts below.
 Storyboard:
 - title: ${story.title}
@@ -69,7 +69,7 @@ Storyboard:
 
 Sample script:
 \`\`\`JSON
-${JSON.stringify(scriptWithoutBeats)}
+${JSON.stringify(script)}
 \`\`\`
 
 Only include keys that exist in the sample script.

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -60,7 +60,7 @@ ${allScenes}
 Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();
 };
 
-export const storyToScriptInfoPrompt = (script: Omit<MulmoScript, "beats">, story: MulmoStoryboard) => {
+export const storyToScriptInfoPrompt = (scriptWithoutBeats: Omit<MulmoScript, "beats">, story: MulmoStoryboard) => {
   return `Generate script for the given storyboard, following the structure of the sample scripts below.
 Storyboard:
 - title: ${story.title}
@@ -69,7 +69,7 @@ Storyboard:
 
 Sample script:
 \`\`\`JSON
-${JSON.stringify(script)}
+${JSON.stringify(scriptWithoutBeats)}
 \`\`\`
 
 Only include keys that exist in the sample script.


### PR DESCRIPTION
> オプションでStoryboardからScript直のルートも選べると良いと思います。

というコメントの件の対応です。
story_to_scriptに生成方法のオプションを追加しました

###  step_wise
senesからbeatsを個別に作り、scriptInfoを作り、最後にそれぞれをmegeしてMulmoScriptを作る

```bash
yarn run story_to_script scripts/test/mulmo_story.json --mode step_wise
```

### one_step
最初から一気にMulmoScriptを作る

```bash
yarn run story_to_script scripts/test/mulmo_story.json --mode one_step
```

### help

```diff
mulmo tool story_to_script <file>

Generate Mulmo script from story

Positionals:
  file  story file path                                      [string] [required]

Options:
      --version          Show version number                           [boolean]
  -v, --verbose          verbose log       [boolean] [required] [default: false]
  -h, --help             Show help                                     [boolean]
  -o, --outdir           output dir                                     [string]
  -b, --basedir          base dir                                       [string]
  -t, --template         Template name to use
       [string] [choices: "business", "children_book", "coding", "comic_strips",
                         "ghibli_strips", "podcast_standard", "sensei_and_taro"]
  -s, --script           script filename            [string] [default: "script"]
      --beats_per_scene  beats per scene                   [number] [default: 3]
      --llm              llm
                     [string] [choices: "openAI", "anthropic", "gemini", "groq"]
      --llm_model        llm model                                      [string]
+    --mode             story to script mode
+            [string] [choices: "step_wise", "one_step"] [default: "step_wise"]
```