### PR TITLE
Remove presenters

### DIFF
--- a/scripts/templates/business.json
+++ b/scripts/templates/business.json
@@ -4,17 +4,6 @@
     "credit": "closing"
   },
   "title": "Sample Title",
-  "speechParams": {
-    "speakers": {
-      "Presenter": {
-        "voiceId": "shimmer",
-        "displayName": {
-          "en": "Presenter",
-          "ja": "語り手"
-        }
-      }
-    }
-  },
   "references": [
     {
       "url": "https://www.somegreatwebsite.com/article/123",
@@ -25,7 +14,6 @@
   "lang": "en",
   "beats": [
     {
-      "speaker": "Presenter",
       "text": "Today we're exploring a fascinating concept that has shaped some of the most innovative companies and leaders of our time: the Reality Distortion Field.",
       "image": {
         "type": "textSlide",
@@ -45,7 +33,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "The evolution of humans is a complex journey that spans millions of years, shaped by biology, environment, and culture. Here's a high-level summary of the key stages in human evolution",
       "image": {
         "type": "textSlide",
@@ -64,7 +51,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "This is a table of items in the store.",
       "image": {
         "type": "markdown",
@@ -80,7 +66,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "This page shows the sales and profits of this company from January 2024 to June 2024.",
       "image": {
         "type": "chart",
@@ -144,7 +129,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "Next, let's look at a diagram of our business process flow. This illustrates the key steps from product development to sales.",
       "image": {
         "type": "mermaid",
@@ -156,7 +140,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "This is a tailwind html format.",
       "image": {
         "type": "html_tailwind",
@@ -205,7 +188,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "This is the image of the future of enterprise applications.",
       "image": {
         "type": "image",

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -1,5 +1,5 @@
 import path from "path";
-import { getTemplateFilePath, readScriptFile, writingMessage } from "../utils/file.js";
+import { getTemplateFilePath, readScriptTemplateFile, writingMessage } from "../utils/file.js";
 import { mulmoScriptSchema, mulmoScriptTemplateSchema } from "../types/schema.js";
 import { MulmoScriptTemplate, MulmoStoryboard, StoryToScriptGenerateMode } from "../types/index.js";
 import { GraphAI, GraphAILogger, GraphData } from "graphai";
@@ -249,7 +249,7 @@ const oneStepGraphData: GraphData = {
 
 const generateBeatsPrompt = async (template: MulmoScriptTemplate, beatsPerScene: number, story: MulmoStoryboard) => {
   const allScenes = story.scenes.map((scene) => scene.description).join("\n");
-  const sampleBeats = template.scriptName ? readScriptFile(template.scriptName).beats : [];
+  const sampleBeats = template.scriptName ? readScriptTemplateFile(template.scriptName).beats : [];
   return sceneToBeatsPrompt({ sampleBeats, beatsPerScene, allScenes });
 };
 
@@ -258,7 +258,7 @@ const generateScriptInfoPrompt = async (template: MulmoScriptTemplate, story: Mu
     // TODO: use default schema
     throw new Error("script is not provided");
   }
-  const script = readScriptFile(template.scriptName);
+  const script = readScriptTemplateFile(template.scriptName);
   const { beats: __, ...scriptWithoutBeats } = script;
   return storyToScriptInfoPrompt(scriptWithoutBeats, story);
 };
@@ -268,7 +268,7 @@ const generateScriptPrompt = async (template: MulmoScriptTemplate, beatsPerScene
     // TODO: use default schema
     throw new Error("script is not provided");
   }
-  const script = readScriptFile(template.scriptName);
+  const script = readScriptTemplateFile(template.scriptName);
   return storyToScriptPrompt(script, beatsPerScene, story);
 };
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -140,10 +140,11 @@ export const getFullPath = (baseDirPath: string | undefined, file: string) => {
   return path.resolve(file);
 };
 
-export const readScriptFile = (scriptName: string) => {
+export const readScriptTemplateFile = (scriptName: string) => {
   const scriptPath = path.resolve(__dirname, "../../scripts/templates", scriptName);
   const scriptData = fs.readFileSync(scriptPath, "utf-8");
-  return mulmoScriptSchema.parse(JSON.parse(scriptData));
+  // NOTE: We don't want to schema parse the script here to eliminate default values.
+  return JSON.parse(scriptData);
 };
 
 export const readTemplatePrompt = (templateName: string) => {
@@ -153,7 +154,7 @@ export const readTemplatePrompt = (templateName: string) => {
 
   const script = (() => {
     if (template.scriptName) {
-      return readScriptFile(template.scriptName);
+      return readScriptTemplateFile(template.scriptName);
     }
     return undefined;
   })();

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -6,7 +6,7 @@ import { GraphAILogger } from "graphai";
 import { MulmoScript, MulmoScriptTemplate, MulmoMediaSource, MulmoStudioContext } from "../types/index.js";
 import { MulmoScriptTemplateMethods } from "../methods/mulmo_script_template.js";
 import { MulmoStudioContextMethods } from "../methods/index.js";
-import { mulmoScriptSchema, mulmoScriptTemplateSchema } from "../types/schema.js";
+import { mulmoScriptTemplateSchema } from "../types/schema.js";
 import { PDFMode } from "../types/index.js";
 import { ZodSchema } from "zod";
 


### PR DESCRIPTION
LLMにサンプルスクリプトを渡してMulmoScriptを生成する際、余計なものを隠した方が良いので、一人で話す場合には、speechParamsとpresenterを含めないようにしました。
ちなみに、スキーマでparseすると、デフォルトが指定されたものは追加されてしまうので、注意が必要です。実行時にはそれで良いのですが、プロンプトとしてLLMに渡す場合は、それらはない方が良いケースが多いのです。