### PR TITLE
retry:3 for image generation

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -95,6 +95,7 @@ const graph_data: GraphData = {
           imageGenerator: {
             if: ":preprocessor.prompt",
             agent: ":imageAgentInfo.agent",
+            retry: 3,
             inputs: {
               prompt: ":preprocessor.prompt",
               file: ":preprocessor.path", // only for fileCacheAgentFilter


### PR DESCRIPTION
image generationが失敗した際にリトライするように設定を変えました。
OpenAIは、作った画像が著作権侵害にあたると判断するとエラーを返してきます。
たまにしか起こりませんが、その際のエラーメッセージが分かりにくいだけでなく、もう一度トライすれば良いことがユーザーには分かりにくいので、リトライを入れました。