### PR TITLE
Image edit

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -5,7 +5,7 @@ import * as agents from "@graphai/vanilla";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { MulmoStudioContext, MulmoBeat, MulmoScript, MulmoStudioBeat, MulmoImageParams, Text2ImageAgentInfo } from "../types/index.js";
-import { getOutputStudioFilePath, mkdir } from "../utils/file.js";
+import { getOutputStudioFilePath, mkdir, resolveMediaSource } from "../utils/file.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
 import imageGoogleAgent from "../agents/image_google_agent.js";
 import imageOpenaiAgent from "../agents/image_openai_agent.js";
@@ -60,7 +60,10 @@ const imagePreprocessAgent = async (namedInputs: {
   }
 
   const prompt = imagePrompt(beat, imageParams.style);
-  return { path: imagePath, prompt, ...returnValue };
+  const images = (() => {
+    return Object.values(imageParams.images ?? {}).map((image) => resolveMediaSource(image.source, context));
+  })();
+  return { path: imagePath, prompt, ...returnValue, images };
 };
 
 const graph_data: GraphData = {

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -112,6 +112,7 @@ const graph_data: GraphData = {
                 size: ":preprocessor.imageParams.size",
                 moderation: ":preprocessor.imageParams.moderation",
                 aspectRatio: ":preprocessor.aspectRatio",
+                images: ":preprocessor.images",
               },
             },
             defaultValue: {},

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -61,7 +61,9 @@ const imagePreprocessAgent = async (namedInputs: {
 
   const prompt = imagePrompt(beat, imageParams.style);
   const images = (() => {
-    return Object.values(imageParams.images ?? {}).map((image) => resolveMediaSource(image.source, context));
+    const imageNames = beat.imageNames ?? Object.keys(imageParams.images ?? {});
+    const sources = imageNames.map((name) => imageParams.images?.[name]?.source);
+    return sources.filter((source) => source !== undefined).map((source) => resolveMediaSource(source, context));
   })();
   return { path: imagePath, prompt, ...returnValue, images };
 };

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -61,7 +61,7 @@ const imagePreprocessAgent = async (namedInputs: {
 
   const prompt = imagePrompt(beat, imageParams.style);
   const images = (() => {
-    const imageNames = beat.imageNames ?? Object.keys(imageParams.images ?? {});
+    const imageNames = beat.imageNames ?? Object.keys(imageParams.images ?? {}); // use all images if imageNames is not specified
     const sources = imageNames.map((name) => imageParams.images?.[name]?.source);
     return sources.filter((source) => source !== undefined).map((source) => resolveMediaSource(source, context));
   })();

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -41,23 +41,26 @@ export const imageOpenaiAgent: AgentFunction<
   }
 
   console.log("**DEBUG**", (images ?? []).join("\n"));
+  console.log("**DEBUG**", imageOptions.size);
 
   const response = await (async () => {
-    if ((images ?? []).length > 0 && (size === "1536x1024" || size === "1024x1536" || size === "1024x1024")) {
+    const targetSize = imageOptions.size;
+    if ((images ?? []).length > 0 && (targetSize === "1536x1024" || targetSize === "1024x1536" || targetSize === "1024x1024")) {
       const imagelist = await Promise.all(
-        (images ?? []).map(async (file) =>
+        (images ?? []).map(
+          async (file) =>
             await toFile(fs.createReadStream(file), null, {
-                type: "image/png",
-            })
+              type: "image/png", // TODO: Support JPEG as well
+            }),
         ),
       );
-    
-          return await openai.images.edit({ ...imageOptions, size, image: imagelist });
+      console.log("***DEBUG***", imagelist.map((i) => i.name).join("\n"));
+      return await openai.images.edit({ ...imageOptions, size: targetSize, image: imagelist });
     } else {
       return await openai.images.generate(imageOptions);
     }
   })();
-  
+
   if (!response.data) {
     throw new Error(`response.data is undefined: ${response}`);
   }

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -48,8 +48,14 @@ export const imageOpenaiAgent: AgentFunction<
     ),
   );
 
-  const response = (images.length > 0 && imageOptions.size === "1536x1024") ? await openai.images.edit({ ...imageOptions, size: "1536x1024", image: images }) : await openai.images.generate(imageOptions);
-
+  const response = await (async () => {
+    if (images.length > 0 && (size === "1536x1024" || size === "1024x1536" || size === "1024x1024")) {
+      return await openai.images.edit({ ...imageOptions, size, image: images });
+    } else {
+      return await openai.images.generate(imageOptions);
+    }
+  })();
+  
   if (!response.data) {
     throw new Error(`response.data is undefined: ${response}`);
   }

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -40,9 +40,6 @@ export const imageOpenaiAgent: AgentFunction<
     imageOptions.moderation = moderation || "auto";
   }
 
-  console.log("**DEBUG**", (images ?? []).join("\n"));
-  console.log("**DEBUG**", imageOptions.size);
-
   const response = await (async () => {
     const targetSize = imageOptions.size;
     if ((images ?? []).length > 0 && (targetSize === "1536x1024" || targetSize === "1024x1536" || targetSize === "1024x1024")) {
@@ -54,7 +51,6 @@ export const imageOpenaiAgent: AgentFunction<
             }),
         ),
       );
-      console.log("***DEBUG***", imagelist.map((i) => i.name).join("\n"));
       return await openai.images.edit({ ...imageOptions, size: targetSize, image: imagelist });
     } else {
       return await openai.images.generate(imageOptions);

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -206,6 +206,7 @@ export const mulmoBeatSchema = z
     audioParams: beatAudioParamsSchema.optional(), // beat specific parameters
     speechOptions: speechOptionsSchema.optional(),
     textSlideParams: textSlideParamsSchema.optional(),
+    imageNames: z.array(imageIdSchema).optional(), // list of image names to use for the input.
     imagePrompt: z.string().optional(), // specified or inserted by preprocessor
   })
   .strict();

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -206,7 +206,7 @@ export const mulmoBeatSchema = z
     audioParams: beatAudioParamsSchema.optional(), // beat specific parameters
     speechOptions: speechOptionsSchema.optional(),
     textSlideParams: textSlideParamsSchema.optional(),
-    imageNames: z.array(imageIdSchema).optional(), // list of image names to use for the input.
+    imageNames: z.array(imageIdSchema).optional(), // list of image names to use for image generation. The default is all images in the imageParams.images.
     imagePrompt: z.string().optional(), // specified or inserted by preprocessor
   })
   .strict();

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -152,12 +152,15 @@ const mulmoMidiMediaSchema = z
 
 export const mulmoAudioAssetSchema = z.union([mulmoAudioMediaSchema, mulmoMidiMediaSchema]);
 
+const imageIdSchema = z.string();
+
 export const mulmoImageParamsSchema = z
   .object({
     model: z.string().optional(), // default: provider specific
     size: z.string().optional(), // default: provider specific
     style: z.string().optional(), // optional image style
     moderation: z.string().optional(), // optional image style
+    images: z.record(imageIdSchema, mulmoImageMediaSchema).optional(),
   })
   .strict();
 


### PR DESCRIPTION
OpenAIの"image edit"機能を使って、同じキャラクタやものを複数のイメージで使うものです。共有するイメージは、imageParamsに 以下のように追加します。デフォルトでは、すべての画像が渡されますが、beatごとに "imageNames" で選択的に指定することも可能です（オプション）。

```
  "imageParams": {
    "style": "<style>A multi-panel comic strip. Ghibli style.</style>",
    "images": {
      "shota": {
        "type": "image",
        "source": {
          "kind": "path",
          "path": "../tmp/shota_ghibli.png"
        }
      },
      "dogder": {
        "type": "image",
        "source": {
          "kind": "path",
          "path": "../tmp/dodger_ghibli.png"
        }
      }
    }
  },
```