### PR TITLE
Image concurrency

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -72,7 +72,7 @@ const imagePreprocessAgent = async (namedInputs: {
 
 const graph_data: GraphData = {
   version: 0.5,
-  concurrency: 8,
+  concurrency: 4,
   nodes: {
     context: {},
     imageDirPath: {},
@@ -208,6 +208,12 @@ const generateImages = async (context: MulmoStudioContext) => {
         token,
       },
     };
+  }
+  if (imageAgentInfo.provider === "openai") {
+    // NOTE: Here are the rate limits of OpenAI's text2image API (1token = 32x32 patch).
+    // dall-e-3: 7,500 RPM、15 images per minute (4 images for max resolution)
+    // gpt-image-1：3,000,000 TPM、150 images per minute
+    graph_data.concurrency = imageAgentInfo.imageParams.model === "dall-e-3" ? 4 : 16;
   }
 
   const imageRefs: Record<string, string> = {};

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -72,7 +72,7 @@ const imagePreprocessAgent = async (namedInputs: {
 
 const graph_data: GraphData = {
   version: 0.5,
-  concurrency: 4,
+  concurrency: 8,
   nodes: {
     context: {},
     imageDirPath: {},


### PR DESCRIPTION
image生成のconcurrencyをgpt-image-1（およびそれ以降のもの）に関して、16にまで上げる変更です。古いdall-e-3の場合は、余裕を持って4に設定しています。Googleの方は4のままです。