### PR TITLE
fix: add --version option to CLI

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -14,6 +14,7 @@ import { GraphAILogger } from "graphai";
 export const main = async () => {
   const cli = yargs(hideBin(process.argv))
     .scriptName("mulmo")
+    .version()
     .usage("$0 <command> [options]")
     .option("v", {
       alias: "verbose",

--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -3,6 +3,9 @@
 import "dotenv/config";
 import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 import * as translateCmd from "./commands/translate/index.js";
 import * as audioCmd from "./commands/audio/index.js";
 import * as imagesCmd from "./commands/image/index.js";
@@ -11,10 +14,14 @@ import * as pdfCmd from "./commands/pdf/index.js";
 import * as toolCmd from "./commands/tool/index.js";
 import { GraphAILogger } from "graphai";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf8"));
+
 export const main = async () => {
   const cli = yargs(hideBin(process.argv))
     .scriptName("mulmo")
-    .version()
+    .version(packageJson.version)
     .usage("$0 <command> [options]")
     .option("v", {
       alias: "verbose",


### PR DESCRIPTION
fix(cli): implement --version option

- Load version from package.json using fileURLToPath and readFileSync
- Configure yargs with .version(packageJson.version)
- Resolves issue where mulmo --version returned "unknown"

---
mulmocast-cli 以外のフォルダで mulmo --version を実行すると unknown と表示される。
当該フォルダに version を追加した

  const cli = yargs(hideBin(process.argv))
    .scriptName("mulmo")
    .version(packageJson.version) <--- 今回追加
    .usage("$0 <command> [options]")