### PR TITLE
fix: preserve buffered text when wrapping lines at max width

### DIFF
--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -49,12 +49,12 @@ export const wrapText = (text: string, font: PDFFont, fontSize: number, maxWidth
 
       const isBreakable = currentIsFull || (!currentIsFull && (char === " " || nextChar === " " || nextIsFull));
 
-      if (width > maxWidth && buffer) {
+      if (width > maxWidth && line) {
         lines.push(line);
-        line = "";
-        buffer = char;
-      }
-
+        line = buffer;
+        buffer = "";
+      } 
+      
       if (isBreakable || i === rawLine.length - 1) {
         line += buffer;
         buffer = "";

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -53,8 +53,8 @@ export const wrapText = (text: string, font: PDFFont, fontSize: number, maxWidth
         lines.push(line);
         line = buffer;
         buffer = "";
-      } 
-      
+      }
+
       if (isBreakable || i === rawLine.length - 1) {
         line += buffer;
         buffer = "";


### PR DESCRIPTION
テキストが最大幅を超えた際に、バッファの内容を新しい行に引き継ぐように修正。


![CleanShot 2025-06-02 at 16 03 06](https://github.com/user-attachments/assets/b92856d0-bc48-407c-bbd2-259e6f439743)
