### PR TITLE
Image_Edit: Jpeg support

### DIFF
--- a/assets/templates/ghibli_shorts.json
+++ b/assets/templates/ghibli_shorts.json
@@ -24,7 +24,7 @@
           "type": "image",
           "source": {
             "kind": "url",
-            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghibli_presenter.png"
+            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghibli_presenter.jpg"
           }
         }
       }

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -276,7 +276,25 @@ const generateImages = async (context: MulmoStudioContext, callbacks?: CallbackF
             throw new Error(`Failed to download image: ${image.source.url}`);
           }
           const buffer = Buffer.from(await response.arrayBuffer());
-          const imagePath = `${imageDirPath}/${context.studio.filename}/${key}.png`;
+
+          // Detect file extension from Content-Type header or URL
+          const extension = (() => {
+            const contentType = response.headers.get("content-type");
+            if (contentType?.includes("jpeg") || contentType?.includes("jpg")) {
+              return "jpg";
+            } else if (contentType?.includes("png")) {
+              return "png";
+            } else {
+              // Fall back to URL extension
+              const urlExtension = image.source.url.split(".").pop()?.toLowerCase();
+              if (urlExtension && ["jpg", "jpeg", "png"].includes(urlExtension)) {
+                return urlExtension === "jpeg" ? "jpg" : urlExtension;
+              }
+              return "png"; // default
+            }
+          })();
+
+          const imagePath = `${imageDirPath}/${context.studio.filename}/${key}.${extension}`;
           await fs.promises.writeFile(imagePath, buffer);
           imageRefs[key] = imagePath;
         }

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { AgentFunction, AgentFunctionInfo } from "graphai";
 import OpenAI, { toFile } from "openai";
 
@@ -63,12 +64,11 @@ export const imageOpenaiAgent: AgentFunction<
     const targetSize = imageOptions.size;
     if ((images ?? []).length > 0 && (targetSize === "1536x1024" || targetSize === "1024x1536" || targetSize === "1024x1024")) {
       const imagelist = await Promise.all(
-        (images ?? []).map(
-          async (file) =>
-            await toFile(fs.createReadStream(file), null, {
-              type: "image/png", // TODO: Support JPEG as well
-            }),
-        ),
+        (images ?? []).map(async (file) => {
+          const ext = path.extname(file).toLowerCase();
+          const type = ext === ".jpg" || ext === ".jpeg" ? "image/jpeg" : "image/png";
+          return await toFile(fs.createReadStream(file), null, { type });
+        }),
       );
       return await openai.images.edit({ ...imageOptions, size: targetSize, image: imagelist });
     } else {


### PR DESCRIPTION
OpenAIのイメージ生成の際に渡す画像は、PNGしかサポートしていませんでしたが、JPEGもサポートするように変更しました。