### PR TITLE
removed beat index from audio file

### DIFF
--- a/scripts/test/test_audio_instructions.json
+++ b/scripts/test/test_audio_instructions.json
@@ -1,0 +1,68 @@
+{
+  "$mulmocast": {
+    "version": "1.0"
+  },
+  "title": "Audio Instructions Test",
+  "speechParams": {
+    "provider": "openai",
+    "speakers": {
+      "Presenter": {
+        "voiceId": "shimmer"
+      },
+      "Presenter2": {
+        "voiceId": "shimmer",
+        "speechOptions": {
+          "instruction": "Speak in a cheerful and positive tone."
+        }
+      }
+    }
+  },
+  "beats": [
+    {
+      "speaker": "Presenter",
+      "text": "Hello, I'm a presenter. I have no instructions.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Presenter"
+        }
+      }
+    },
+    {
+      "speaker": "Presenter2",
+      "text": "Hello, I'm a presenter 2. My instructions are 'Speak in a cheerful and positive tone'.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Presenter 2"
+        }
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "Hello, I'm a presenter. I have a British English instruction.",
+      "speechOptions": {
+        "instruction": "Speak in British English."
+      },
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Presenter with British English instruction"
+        }
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "Hello, I'm a presenter. I have a whisper instruction.",
+      "speechOptions": {
+        "instruction": "Whisper softly, like a pillow talk."
+      },
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Presenter with whisper instruction"
+        }
+      }
+    }
+  ]
+}

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -71,7 +71,7 @@ const preprocessor = (namedInputs: {
   // Use speaker-specific provider if available, otherwise fall back to script-level provider
   const provider = speaker.provider ?? context.studio.script.speechParams.provider;
   const hash_string = `${text}${voiceId}${speechOptions?.instruction ?? ""}${speechOptions?.speed ?? 1.0}${provider}`;
-  const audioFile = `${context.studio.filename}_${index}_${text2hash(hash_string)}` + (lang ? `_${lang}` : "");
+  const audioFile = `${context.studio.filename}_${text2hash(hash_string)}` + (lang ? `_${lang}` : "");
   const audioPath = getAudioPath(context, beat, audioFile, audioDirPath);
   studioBeat.audioFile = audioPath;
   const needsTTS = !beat.audio && audioPath !== undefined;

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -61,7 +61,7 @@ const preprocessor = (namedInputs: {
   context: MulmoStudioContext;
   audioDirPath: string;
 }) => {
-  const { beat, studioBeat, multiLingual, index, context, audioDirPath } = namedInputs;
+  const { beat, studioBeat, multiLingual, context, audioDirPath } = namedInputs;
   const { lang } = context;
   const speaker = context.studio.script.speechParams.speakers[beat.speaker];
   const voiceId = speaker.voiceId;
@@ -95,7 +95,6 @@ const graph_tts: GraphData = {
         beat: ":beat",
         studioBeat: ":studioBeat",
         multiLingual: ":multiLingual",
-        index: ":__mapIndex",
         context: ":context",
         audioDirPath: ":audioDirPath",
       },


### PR DESCRIPTION
beatごとに生成されるオーディオファイル名からindexを省きました。これにより、beatの挿入・削除などがあった場合に同じものを生成する必要がなくなります。
ついでに、instructionのテストを追加しました。スピーカーごと、ビートごとの両方のテストです。