### PR TITLE
fix agent filter no context

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -143,6 +143,7 @@ const graph_data: GraphData = {
               imagePath: ":preprocessor.imagePath",
               file: ":preprocessor.movieFile",
               studio: ":context.studio", // for cache
+              mulmoContext: ":context", // for fileCacheAgentFilter
               index: ":__mapIndex", // for cache
               sessionType: "movie", // for cache
               params: {


### PR DESCRIPTION
```
yarn run cli movie scripts/test/test_movie.json
```

cause

```
An unexpected error occurred: TypeError: Cannot read properties of undefined (reading ‘sessionState’)
```