### PR TITLE
Add  POC for deep search

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",
     "latest": "yarn upgrade-interactive  --latest",
     "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
-    "deep_search": "npx tsx ./src/tools/deep_search.ts"
+    "deep_research": "npx tsx ./src/tools/deep_research.ts"
   },
   "repository": "git+ssh://git@github.com/receptron/mulmocast-cli.git",
   "author": "snakajima",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "schema": "npx tsx ./src/cli/bin.ts tool schema",
     "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",
     "latest": "yarn upgrade-interactive  --latest",
-    "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'"
+    "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
+    "deep_search": "npx tsx ./src/tools/create_mulmo_script_deep_search.ts"
   },
   "repository": "git+ssh://git@github.com/receptron/mulmocast-cli.git",
   "author": "snakajima",
@@ -58,6 +59,7 @@
     "@graphai/stream_agent_filter": "^2.0.2",
     "@graphai/vanilla": "^2.0.4",
     "@graphai/vanilla_node_agents": "^2.0.1",
+    "@tavily/core": "^0.5.7",
     "canvas": "^3.1.0",
     "clipboardy": "^4.0.0",
     "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",
     "latest": "yarn upgrade-interactive  --latest",
     "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
-    "deep_search": "npx tsx ./src/tools/create_mulmo_script_deep_search.ts"
+    "deep_search": "npx tsx ./src/tools/deep_search.ts"
   },
   "repository": "git+ssh://git@github.com/receptron/mulmocast-cli.git",
   "author": "snakajima",

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,6 +2,7 @@ import addBGMAgent from "./add_bgm_agent.js";
 import combineAudioFilesAgent from "./combine_audio_files_agent.js";
 import imageGoogleAgent from "./image_google_agent.js";
 import imageOpenaiAgent from "./image_openai_agent.js";
+import tavilySearchAgent from "./tavily_agent.js";
 import ttsElevenlabsAgent from "./tts_elevenlabs_agent.js";
 import ttsNijivoiceAgent from "./tts_nijivoice_agent.js";
 import ttsOpenaiAgent from "./tts_openai_agent.js";
@@ -23,6 +24,7 @@ export {
   combineAudioFilesAgent,
   imageGoogleAgent,
   imageOpenaiAgent,
+  tavilySearchAgent,
   ttsElevenlabsAgent,
   ttsNijivoiceAgent,
   ttsOpenaiAgent,

--- a/src/agents/tavily_agent.ts
+++ b/src/agents/tavily_agent.ts
@@ -23,10 +23,6 @@ const getTavilyApiKey = (params: TavilySearchParams, config?: DefaultConfigData)
   return typeof process !== "undefined" ? process?.env?.TAVILY_API_KEY : null;
 };
 
-/**
- * Tavily search agent
- * Performs web search using Tavily API and returns relevant search results
- */
 export const tavilySearchAgent: AgentFunction<TavilySearchParams, TavilySearchResponse, TavilySearchInputs, DefaultConfigData> = async ({
   namedInputs,
   params,

--- a/src/agents/tavily_agent.ts
+++ b/src/agents/tavily_agent.ts
@@ -1,0 +1,155 @@
+import { AgentFunction, AgentFunctionInfo, assert, DefaultConfigData } from "graphai";
+import { tavily, type TavilySearchResponse } from "@tavily/core";
+
+type TavilySearchInputs = {
+  query: string;
+};
+
+type TavilySearchParams = {
+  apiKey?: string;
+  max_results?: number;
+  search_depth?: "basic" | "advanced";
+  include_answer?: boolean;
+  include_raw_content?: boolean | "markdown" | "text";
+};
+
+const getTavilyApiKey = (params: TavilySearchParams, config?: DefaultConfigData) => {
+  if (params?.apiKey) {
+    return params.apiKey;
+  }
+  if (config?.apiKey) {
+    return config.apiKey;
+  }
+  return typeof process !== "undefined" ? process?.env?.TAVILY_API_KEY : null;
+};
+
+/**
+ * Tavily search agent
+ * Performs web search using Tavily API and returns relevant search results
+ */
+export const tavilySearchAgent: AgentFunction<TavilySearchParams, TavilySearchResponse, TavilySearchInputs, DefaultConfigData> = async ({
+  namedInputs,
+  params,
+  config,
+}) => {
+  const { query } = namedInputs;
+
+  assert(!!query, "tavilySearchAgent: query is required! set inputs: { query: 'search terms' }");
+
+  try {
+    const apiKey = getTavilyApiKey(params, config);
+    assert(apiKey, "Tavily API key is required. Please set the TAVILY_API_KEY environment variable or provide it in params/config.");
+
+    const tvly = tavily({ apiKey });
+
+    // Convert params to SDK options format
+    const sdkOptions: Record<string, unknown> = {};
+    if (params?.max_results !== undefined) sdkOptions.maxResults = params.max_results;
+    if (params?.search_depth !== undefined) sdkOptions.searchDepth = params.search_depth;
+    if (params?.include_answer !== undefined) sdkOptions.includeAnswer = params.include_answer;
+    if (params?.include_raw_content !== undefined) sdkOptions.includeRawContent = params.include_raw_content;
+
+    const response = await tvly.search(query, sdkOptions);
+
+    return response;
+  } catch (error) {
+    throw new Error(`Tavily search failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+};
+
+const tavilySearchAgentInfo: AgentFunctionInfo = {
+  name: "tavilySearchAgent",
+  agent: tavilySearchAgent,
+  mock: tavilySearchAgent,
+  params: {
+    type: "object",
+    properties: {
+      apiKey: {
+        type: "string",
+        description: "Tavily API key",
+      },
+      max_results: {
+        type: "number",
+        description: "Maximum number of search results to return (default: 5)",
+      },
+      search_depth: {
+        type: "string",
+        enum: ["basic", "advanced"],
+        description: "Search depth - basic for faster results, advanced for more comprehensive results",
+      },
+      include_answer: {
+        type: "boolean",
+        description: "Include a direct answer to the query when available",
+      },
+      include_raw_content: {
+        type: "string",
+        enum: ["boolean", "markdown", "text"],
+        description: "Include raw content from search results (boolean, markdown, text)",
+      },
+    },
+  },
+  inputs: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "Search query string",
+      },
+    },
+    required: ["query"],
+  },
+  output: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      answer: { type: ["string", "null"] },
+      results: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            title: { type: "string" },
+            url: { type: "string" },
+            content: { type: "string" },
+            rawContent: { type: ["string", "null"] },
+            score: { type: "number" },
+          },
+        },
+      },
+    },
+  },
+  samples: [
+    {
+      inputs: {
+        query: "latest AI developments 2024",
+      },
+      params: {
+        max_results: 3,
+        include_answer: true,
+      },
+      result: {
+        query: "latest AI developments 2024",
+        answer: "Recent AI developments in 2024 include...",
+        results: [
+          {
+            title: "Major AI Breakthroughs in 2024",
+            url: "https://example.com/ai-2024",
+            content: "The year 2024 has seen significant advances in artificial intelligence...",
+            rawContent: null,
+            score: 0.95,
+          },
+        ],
+      },
+    },
+  ],
+  description: "Performs web search using Tavily API and returns relevant search results with optional AI-generated answers",
+  category: ["search", "web"],
+  author: "Receptron Team",
+  repository: "https://github.com/receptron/mulmocast-cli/tree/main/src/agents/tavily_agent.ts",
+  source: "https://github.com/receptron/mulmocast-cli/tree/main/src/agents/tavily_agent.ts",
+  package: "@receptron/mulmocast-cli",
+  license: "MIT",
+  environmentVariables: ["TAVILY_API_KEY"],
+};
+
+export default tavilySearchAgentInfo;

--- a/src/tools/deep_research.ts
+++ b/src/tools/deep_research.ts
@@ -36,7 +36,7 @@ const graphData = {
         userInput: ":userInput.text",
       },
     },
-    deepSearch: {
+    deepResearch: {
       agent: "nestedAgent",
       inputs: {
         userInput: ":userInput.text",
@@ -259,13 +259,13 @@ const graphData = {
     writeResult: {
       agent: "consoleAgent",
       inputs: {
-        text: "\n------Answer------\n\n${:deepSearch.finalAnswer.text}\n",
+        text: "\n------Answer------\n\n${:deepResearch.finalAnswer.text}\n",
       },
     },
   },
 };
 
-export const deepSearch = async () => {
+export const deepResearch = async () => {
   const agentFilters = [
     {
       name: "consoleStreamDataAgentFilter",
@@ -286,4 +286,4 @@ export const deepSearch = async () => {
   await graph.run();
 };
 
-deepSearch();
+deepResearch();

--- a/src/tools/deep_search.ts
+++ b/src/tools/deep_search.ts
@@ -276,16 +276,6 @@ export const deepSearch = async () => {
 
   const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, textInputAgent, tavilySearchAgent }, { agentFilters });
 
-  graph.registerCallback(({ nodeId, state }) => {
-    if (nodeId === "chatAgent") {
-      if (state === "executing") {
-        process.stdout.write(String("\n" + agentHeader + " "));
-      }
-      if (state === "completed") {
-        process.stdout.write("\n\n");
-      }
-    }
-  });
   graph.injectValue("maxRetries", 3);
   graph.registerCallback(cliLoadingPlugin({ nodeId: "searchQueryAgent", message: "Generating search queries..." }));
   graph.registerCallback(cliLoadingPlugin({ nodeId: "reflectionAgent", message: "Analyzing search results..." }));

--- a/src/tools/deep_search.ts
+++ b/src/tools/deep_search.ts
@@ -131,7 +131,6 @@ const graphData = {
                   },
                   params: {
                     max_results: 3,
-                    raw_content: "markdown",
                   },
                 },
                 result: {

--- a/src/tools/deep_search.ts
+++ b/src/tools/deep_search.ts
@@ -1,0 +1,300 @@
+import "dotenv/config";
+import { GraphAILogger, GraphAI } from "graphai";
+import { textInputAgent } from "@graphai/input_agents";
+
+import { consoleStreamDataAgentFilter } from "@graphai/stream_agent_filter/node";
+
+import { openAIAgent } from "@graphai/openai_agent";
+
+import * as agents from "@graphai/vanilla";
+
+import tavilySearchAgent from "../agents/tavily_agent.js";
+import { cliLoadingPlugin } from "../utils/plugins.js";
+import { searchQueryPrompt, reflectionPrompt, finalAnswerPrompt } from "../utils/prompt.js";
+
+const vanillaAgents = agents.default ?? agents;
+
+const agentHeader = "\x1b[34m● \x1b[0m\x1b[1mAgent\x1b[0m:\x1b[0m";
+
+const graphData = {
+  version: 0.5,
+  nodes: {
+    maxRetries: {
+      value: 0,
+    },
+    userInput: {
+      agent: "textInputAgent",
+      params: {
+        message: "You:",
+        required: true,
+      },
+    },
+    startMessage: {
+      agent: "consoleAgent",
+      inputs: {
+        text: `\n${agentHeader} It takes a few minutes to gather resources, analyze data, and create a report.`,
+        userInput: ":userInput.text",
+      },
+    },
+    deepSearch: {
+      agent: "nestedAgent",
+      inputs: {
+        userInput: ":userInput.text",
+        maxRetries: ":maxRetries",
+        startMessage: ":startMessage",
+      },
+      graph: {
+        loop: {
+          while: ":continue",
+        },
+        nodes: {
+          searchResults: {
+            value: [],
+            update: ":reducer.array",
+          },
+          followUpQueries: {
+            value: [],
+            update: ":reflectionAgent.follow_up_queries",
+          },
+          counter: {
+            value: 0,
+            update: ":counter.add(1)",
+          },
+          searchQueryAgent: {
+            agent: "openAIAgent",
+            inputs: {
+              model: "gpt-4o-mini",
+              system: "You are a professional research assistant. Based on the user's inquiry, return the search query to be used for the search engine.",
+              prompt: searchQueryPrompt("${:userInput}", "${:followUpQueries.join(,)}"),
+            },
+            params: {
+              tool_choice: "auto",
+              tools: [
+                {
+                  type: "function",
+                  function: {
+                    name: "search_query",
+                    description: "Return the search queries to be used for the search engine.",
+                    parameters: {
+                      type: "object",
+                      properties: {
+                        queries: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                            description: "A search query to be used for the search engine.",
+                          },
+                          description: "An array of search queries to be used for the search engine.",
+                        },
+                        research_topic: {
+                          type: "string",
+                          description: "The topic of the research. This is used to filter the search results.",
+                        },
+                        analysis_plan: {
+                          type: "string",
+                          description:
+                            "A detailed plan for analyzing the research topic, including main areas to investigate, key factors, and specific aspects that need deeper investigation",
+                        },
+                      },
+                      required: ["queries", "research_topic", "analysis_plan"],
+                    },
+                  },
+                },
+              ],
+            },
+            output: {
+              queries: ".tool.arguments.queries",
+              research_topic: ".tool.arguments.research_topic",
+              analysis_plan: ".tool.arguments.analysis_plan",
+            },
+          },
+          logSearchQuery: {
+            agent: "consoleAgent",
+            inputs: {
+              text: "\n" + agentHeader + " ${:searchQueryAgent.analysis_plan}",
+            },
+          },
+          mapSearchAgent: {
+            agent: "mapAgent",
+            inputs: {
+              rows: ":searchQueryAgent.queries",
+            },
+            params: {
+              compositeResult: true,
+            },
+            graph: {
+              nodes: {
+                tavilySearchAgent: {
+                  agent: "tavilySearchAgent",
+                  inputs: {
+                    query: ":row",
+                  },
+                  params: {
+                    max_results: 3,
+                    raw_content: "markdown",
+                  },
+                },
+                result: {
+                  agent: "copyAgent",
+                  inputs: {
+                    results: ":tavilySearchAgent.results",
+                  },
+                  params: {
+                    namedKey: "results",
+                  },
+                  isResult: true,
+                },
+                logSearchStatus: {
+                  agent: ({ result }: { result: { title: string; url: string }[] }) => {
+                    GraphAILogger.info(result.map((r) => `- [${r.title}](${r.url})`).join("\n"));
+                  },
+                  inputs: {
+                    result: ":result",
+                  },
+                },
+              },
+            },
+          },
+          extractResults: {
+            agent: "copyAgent",
+            inputs: {
+              results: ":mapSearchAgent.result.flat()",
+            },
+            params: {
+              namedKey: "results",
+            },
+          },
+          reflectionAgent: {
+            agent: "openAIAgent",
+            inputs: {
+              model: "gpt-4o-mini",
+              system:
+                "You are a professional research assistant. Based on the user's inquiry and the search results, return the sufficiency of information, knowledge gaps, and follow-up queries as a function call.",
+              prompt: reflectionPrompt("${:searchQueryAgent.research_topic}", "${:reducer.array.toJSON()}"),
+            },
+            params: {
+              tool_choice: "auto",
+              tools: [
+                {
+                  type: "function",
+                  function: {
+                    name: "research_sufficiency",
+                    description: "Return whether the information is sufficient, any knowledge gaps, and follow-up queries for the user's inquiry.",
+                    parameters: {
+                      type: "object",
+                      properties: {
+                        is_sufficient: {
+                          type: "boolean",
+                          description: "Whether the information is sufficient",
+                        },
+                        knowledge_gap: {
+                          type: "string",
+                          description: "Summary of missing knowledge or information",
+                        },
+                        follow_up_queries: {
+                          type: "array",
+                          items: {
+                            type: "string",
+                            description: "Additional questions to investigate (up to 3 maximum)",
+                          },
+                        },
+                      },
+                      required: ["is_sufficient", "knowledge_gap", "follow_up_queries"],
+                    },
+                  },
+                },
+              ],
+            },
+            output: {
+              is_sufficient: ".tool.arguments.is_sufficient",
+              knowledge_gap: ".tool.arguments.knowledge_gap",
+              follow_up_queries: ".tool.arguments.follow_up_queries",
+            },
+          },
+          reducer: {
+            agent: "pushAgent",
+            inputs: {
+              array: ":searchResults",
+              items: ":extractResults",
+            },
+          },
+          continue: {
+            agent: ({
+              is_sufficient,
+              knowledge_gap,
+              counter,
+              maxRetries,
+            }: {
+              is_sufficient: boolean;
+              knowledge_gap: string;
+              counter: number;
+              maxRetries: number;
+            }) => {
+              if (is_sufficient || counter >= maxRetries - 1) {
+                GraphAILogger.info(`\n${agentHeader} All necessary information has been gathered. Preparing comprehensive report.`);
+                return false;
+              }
+              GraphAILogger.info(`\n${agentHeader} ${knowledge_gap}`);
+              return true;
+            },
+            inputs: {
+              is_sufficient: ":reflectionAgent.is_sufficient",
+              knowledge_gap: ":reflectionAgent.knowledge_gap",
+              counter: ":counter",
+              maxRetries: ":maxRetries",
+            },
+          },
+          finalAnswer: {
+            agent: "openAIAgent",
+            unless: ":continue",
+            inputs: {
+              model: "gpt-4o-mini",
+              system: "You are a professional research assistant. Based on the user's inquiry and the search results, return the final answer.",
+              prompt: finalAnswerPrompt("${:userInput}", "${:searchResults.toJSON()}", "${:searchQueryAgent.research_topic}"),
+            },
+            isResult: true,
+          },
+        },
+      },
+    },
+    writeResult: {
+      agent: "consoleAgent",
+      inputs: {
+        text: "\n------Answer------\n\n${:deepSearch.finalAnswer.text}\n",
+      },
+    },
+  },
+};
+
+export const deepSearch = async () => {
+  const agentFilters = [
+    {
+      name: "consoleStreamDataAgentFilter",
+      agent: consoleStreamDataAgentFilter,
+      nodeIds: ["chatAgent"],
+    },
+  ];
+
+  const graph = new GraphAI(graphData, { ...vanillaAgents, openAIAgent, textInputAgent, tavilySearchAgent }, { agentFilters });
+
+  graph.registerCallback(({ nodeId, state }) => {
+    if (nodeId === "chatAgent") {
+      if (state === "executing") {
+        process.stdout.write(String("\n" + agentHeader + " "));
+      }
+      if (state === "completed") {
+        process.stdout.write("\n\n");
+      }
+    }
+  });
+  graph.injectValue("maxRetries", 3);
+  graph.registerCallback(cliLoadingPlugin({ nodeId: "searchQueryAgent", message: "Generating search queries..." }));
+  graph.registerCallback(cliLoadingPlugin({ nodeId: "reflectionAgent", message: "Analyzing search results..." }));
+  graph.registerCallback(cliLoadingPlugin({ nodeId: "tavilySearchAgent", message: "Searching..." }));
+  graph.registerCallback(cliLoadingPlugin({ nodeId: "finalAnswer", message: "Generating final answer..." }));
+
+  GraphAILogger.info(`${agentHeader} What would you like to know?\n`);
+  await graph.run();
+};
+
+deepSearch();

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -94,3 +94,58 @@ Only include keys that exist in the sample script.
 Do not add any keys that are not present in the sample script.
 Please provide your response as valid JSON within \`\`\`json code blocks for clarity.`.trim();
 };
+
+export const searchQueryPrompt = (inquiry: string, followUpQueries: string) => {
+  return `
+  You are a professional research assistant specialized in generating sophisticated and diverse web search queries.
+  Create queries for advanced automated web research tools that can analyze complex results, follow links, and integrate information.
+
+  Instructions:
+  - Ensure collection of the latest information (current date: ${new Date().toLocaleDateString()})
+  - Always prioritize a single search query, add additional ones only when the original question requires multiple aspects
+  - Each query should focus on a specific aspect of the original question
+  - Do not generate more than 3 queries
+  - Generate diverse queries when the topic is broad
+  - Do not generate multiple similar queries, one is sufficient
+  - If follow-up queries exist, prioritize them over the user's inquiry
+
+  User's inquiry: ${inquiry}
+  Follow-up queries: ${followUpQueries}
+  `;
+};
+
+export const reflectionPrompt = (researchTopic: string, searchResults: string) => {
+  return `
+  You are a professional research assistant analyzing summaries related to "${researchTopic}".
+
+  Instructions:
+  - Identify knowledge gaps and areas requiring deeper exploration, then generate follow-up queries
+  - If the provided summary is sufficient to answer the user's question, do not generate follow-up queries
+  - When knowledge gaps exist, generate follow-up queries that help deepen understanding
+  - Focus on technical details, implementation specifications, and emerging trends that are not fully covered
+
+  Requirements:
+  - Follow-up queries should be self-contained and include necessary context for web search
+
+  Search results: ${searchResults}
+  `;
+};
+
+export const finalAnswerPrompt = (userInput: string, searchResults: string, researchTopic: string) => {
+  const currentDate = new Date().toLocaleDateString();
+  return `
+  You are a professional research assistant. Generate a high-quality answer based on the following information.
+
+  Instructions:
+  - Utilize all provided information to create a logical and well-structured response
+  - Include article information (URL and title) as citations in your output when referencing search results
+  - Provide detailed technical specifications and implementation details where possible
+  - Reflect the latest information and trends
+  - Ensure the response is comprehensive and accurate
+
+  User's Question: ${userInput}
+  Search Results: ${searchResults}
+  Research Topic: ${researchTopic}
+  Current Date: ${currentDate}
+  `;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -546,27 +546,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pdf-lib/fontkit@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@pdf-lib/fontkit/-/fontkit-1.1.1.tgz#f18473892b65e3253eb73f4569785abd2c03b1e0"
-  integrity sha512-KjMd7grNapIWS/Dm0gvfHEilSyAmeLvrEGVcqLGi0VYebuqqzTbgF29efCx7tvx+IEbG3zQciRSWl3GkUSvjZg==
-  dependencies:
-    pako "^1.0.6"
-
-"@pdf-lib/standard-fonts@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
-  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
-  dependencies:
-    pako "^1.0.6"
-
-"@pdf-lib/upng@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
-  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
-  dependencies:
-    pako "^1.0.10"
-
 "@pkgr/core@^0.2.4":
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.7.tgz#eb5014dfd0b03e7f3ba2eeeff506eed89b028058"
@@ -644,6 +623,15 @@
   integrity sha512-KKC+vd4I0wnstKh1OhXKjDmSWTH6MDDD/9njxgD8i3hsAukQWUj5Bf8ORe3usHgGDctMbDd9f7crWMbwc1zOOQ==
   dependencies:
     yaml "^2.7.1"
+
+"@tavily/core@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@tavily/core/-/core-0.5.7.tgz#544ab1954c9139f60e51fdd682351298bb2bb60f"
+  integrity sha512-DwIzXCNXkmN3FFsm3OkVZZq3Vabbu4tqlKAgy+2Itx3VAoqVu6R8eAJbdSgkiotwjbbMXAW/2PofUqYcmTBN5Q==
+  dependencies:
+    axios "^1.7.7"
+    https-proxy-agent "^7.0.6"
+    js-tiktoken "^1.0.14"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -968,6 +956,15 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+axios@^1.7.7:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 b4a@^1.6.4:
   version "1.6.7"
   resolved "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz"
@@ -1011,7 +1008,7 @@ bare-stream@^2.6.4:
   dependencies:
     streamx "^2.21.0"
 
-base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1680,6 +1677,11 @@ fluent-ffmpeg@^2.1.3:
     async "^0.2.9"
     which "^1.1.1"
 
+follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 form-data-encoder@1.7.2:
   version "1.7.2"
   resolved "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz"
@@ -2175,6 +2177,13 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+js-tiktoken@^1.0.14:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/js-tiktoken/-/js-tiktoken-1.0.20.tgz#fa2733bf147acaf1bdcf9ab8a878e79c581c95f2"
+  integrity sha512-Xlaqhhs8VfCd6Sh7a1cFkZHQbYTLCwVJJWiHVxBYzLPxW0XsoxBy1hitmjkdIjD3Aon5BXLHFwU5O8WUx6HH+A==
+  dependencies:
+    base64-js "^1.5.1"
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -2552,11 +2561,6 @@ pac-resolver@^7.0.1:
     degenerator "^5.0.0"
     netmask "^2.0.2"
 
-pako@^1.0.10, pako@^1.0.11, pako@^1.0.6:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
@@ -2588,16 +2592,6 @@ path-key@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
   integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
-
-pdf-lib@^1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
-  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
-  dependencies:
-    "@pdf-lib/standard-fonts" "^1.0.0"
-    "@pdf-lib/upng" "^1.0.1"
-    pako "^1.0.11"
-    tslib "^1.11.1"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -3121,11 +3115,6 @@ ts-node@^10.9.2:
     make-error "^1.1.1"
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
-
-tslib@^1.11.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.1, tslib@^2.1.0:
   version "2.8.1"


### PR DESCRIPTION
## 概要

https://github.com/google-gemini/gemini-fullstack-langgraph-quickstart の構造を参考にDeep SearchのPOCを追加しました。

今は単純な検索出力のみですが、scriptingに応用できればと思っています。

## 実行方法
WEB検索のために https://www.tavily.com/ のAPI KEYが必要です。

```
$ export TAVILY_API_KEY=xxxx
$ yarn run deep_search
```

https://github.com/user-attachments/assets/40469d16-259c-4474-99bf-10b7fb8a5dbc

## ロジック

長くて読みづらいグラフ構造ですが、全体的なロジックはこちらです

```mermaid
graph TB
    Start([開始]) --> GenerateQuery[クエリ生成<br/>generate_query]
    GenerateQuery --> Parallel{mapAgent}
    
    Parallel --> WebResearch1[Web検索N<br/>tavilyAgent]
    Parallel --> WebResearch2[Web検索2<br/>tavilyAgent]
    Parallel --> WebResearchN[Web検索1<br/>tavilyAgent]
    
    WebResearch1 --> Reflection[リフレクション<br/>reflectionAgent]
    WebResearch2 --> Reflection
    WebResearchN --> Reflection
    
    Reflection --> Evaluate{評価}
    Evaluate -->|情報不足| FollowUp[追加クエリ生成]
    FollowUp --> GenerateQuery
    
    Evaluate -->|十分な情報 or 指定回数超過| FinalizeAnswer[最終回答生成<br/>finalize_answer]
    FinalizeAnswer --> End([終了])
```


