### PR TITLE
docs: Add comprehensive multilingual FAQ for mulmo movie command and Add compatibility FAQ for v0.0.12 upgrade issues

### DIFF
--- a/docs/faq_en.md
+++ b/docs/faq_en.md
@@ -51,11 +51,11 @@ mulmo movie your_script.json -l ja -c ja
 
 ### Q: What's the difference between `-l ja` and `-c ja` options in `mulmo movie` command?
 
-**A: Both automatically execute translation processing, but each controls different functions.**
+**A: After translating to the specified language, `-l` applies to audio and `-c` applies to subtitles.**
 
-- **`mulmo movie your_script.json -l ja`**: Translation processing + Japanese audio generation
-- **`mulmo movie your_script.json -c ja`**: Translation processing + Japanese subtitle generation
-- **`mulmo movie your_script.json -l ja -c ja`**: Translation processing + both Japanese audio & subtitles
+- **`mulmo movie your_script.json -l ja`**: Translate to Japanese + generate Japanese audio
+- **`mulmo movie your_script.json -c ja`**: Translate to Japanese + generate Japanese subtitles
+- **`mulmo movie your_script.json -l ja -c ja`**: Translate to Japanese + generate both audio & subtitles
 
 ```bash
 # To run translation only
@@ -65,6 +65,8 @@ mulmo translate your_script.json
 ### Q: How can I manually edit translation results?
 
 **A: Edit `multiLingualTexts.ja.text` in `output/your_script_studio.json` file.**
+
+The following example shows Japanese (ja) translation.
 
 ```json
 {

--- a/docs/faq_ja.md
+++ b/docs/faq_ja.md
@@ -51,11 +51,11 @@ mulmo movie your_script.json -l ja -c ja
 
 ### Q: `mulmo movie`コマンドの`-l ja`と`-c ja`オプションの違いは何ですか？
 
-**A: どちらも翻訳処理を自動実行しますが、それぞれ異なる機能を制御します。**
+**A: 指定された言語へ翻訳後、`-l`は音声へ、`-c`は字幕へ反映します。**
 
-- **`mulmo movie your_script.json -l ja`**: 翻訳処理 + 日本語音声の生成
-- **`mulmo movie your_script.json -c ja`**: 翻訳処理 + 日本語字幕の生成
-- **`mulmo movie your_script.json -l ja -c ja`**: 翻訳処理 + 日本語音声・字幕の両方
+- **`mulmo movie your_script.json -l ja`**: 日本語へ翻訳 + 日本語音声の生成
+- **`mulmo movie your_script.json -c ja`**: 日本語へ翻訳 + 日本語字幕の生成
+- **`mulmo movie your_script.json -l ja -c ja`**: 日本語へ翻訳 + 音声・字幕の両方
 
 ```bash
 # 翻訳のみ実行したい場合
@@ -65,6 +65,8 @@ mulmo translate your_script.json
 ### Q: 翻訳結果を手動で修正したい場合はどうすればよいですか？
 
 **A: `output/your_script_studio.json`ファイルの`multiLingualTexts.ja.text`を編集してください。**
+
+以下の例は日本語（ja）の場合です。
 
 ```json
 {


### PR DESCRIPTION
利用者からの質問をFAQ として残します。日英両方作成しました。
まずは、第一弾として、sudio ファイルの扱い、翻訳関係の微修正をどうすれば良いのかについて記述しました。

加えて、0.0.12 のリリースノートに記述した、_studio ファイルの互換性について追加しました

--- 以下、AI 出力のログ ---
## Commit Message

```
docs: Add comprehensive multilingual FAQ for mulmo movie command

- Add faq_ja.md and faq_en.md with multilingual support documentation
- Document -l ja and -c ja options with accurate output filenames
- Explain translation workflow and manual editing procedures
- Include file structure and studio.json editing examples
- Clarify translation caching mechanism and preservation of manual edits
- Add inline comments to highlight editable JSON fields
```

## Summary

多言語対応に関する包括的なFAQドキュメントを作成しました：

### 主要な内容
- **基本的な使用方法**: 英語版から日本語版作成の手順
- **オプションの詳細**: `-l ja`と`-c ja`の違いと正確な出力ファイル名
- **手動修正方法**: studio.jsonの編集手順と翻訳保持メカニズム
- **技術詳細**: 音声・字幕で使用されるテキストフィールド

### ファイル構成
- [`docs/faq_ja.md`](mulmocast-cli/docs/faq_ja.md): 日本語版FAQ
- [`docs/faq_en.md`](mulmocast-cli/docs/faq_en.md): 英語版FAQ

### 特徴
- 論理的な順序で構成（基本→詳細→カスタマイズ）
- 重複を避けた効率的な情報配置
- 実用的なコマンド例とJSON編集例
- 編集箇所を示すインラインコメント