### PR TITLE
Fix markdown HTML typo

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -41,7 +41,7 @@ export const renderHTMLToImage = async (
 export const renderMarkdownToImage = async (markdown: string, style: string, outputPath: string, width: number, height: number) => {
   const header = `<head><style>${style}</style></head>`;
   const body = await marked(markdown);
-  const html = `<htlm>${header}<body>${body}</body></html>`;
+  const html = `<html>${header}<body>${body}</body></html>`;
   await renderHTMLToImage(html, outputPath, width, height);
 };
 


### PR DESCRIPTION
（OpenAIのcodexが見つけたtypoです。PRの作成までやってくれました）

## Summary
- fix HTML tag typo in markdown rendering utility

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn ci_test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684f2fc8a95483309d0d16c232b40330