### PR TITLE
Fix single video transition

### DIFF
--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -160,7 +160,7 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
 
   // Add tranditions if needed
   const mixedVideoId = (() => {
-    if (studio.script.movieParams?.transition && transitionVideoIds.length > 1) {
+    if (studio.script.movieParams?.transition && transitionVideoIds.length > 0) {
       const transition = mulmoTransitionSchema.parse(studio.script.movieParams.transition);
 
       return transitionVideoIds.reduce((acc, transitionVideoId, index) => {


### PR DESCRIPTION
## Summary
- tweak transition handling in movie.ts so fade overlays are applied when there's at least one transition

## Testing
- `yarn run lint` *(fails: package not present in lockfile)*
- `yarn run build` *(fails: package not present in lockfile)*
- `yarn run ci_test` *(fails: package not present in lockfile)*
- `./test/release_test.sh` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684f31f84b748330805e737e41db8d38