### PR TITLE
Fix translation graph output node name

### DIFF
--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -168,7 +168,7 @@ const translateGraph: GraphData = {
         },
       },
     },
-    writeOutout: {
+    writeOutput: {
       // console: { before: true },
       agent: "fileWriteAgent",
       inputs: {


### PR DESCRIPTION
## Summary
- fix node name typo in `src/actions/translate.ts`

## Testing
- `yarn run lint` *(fails: package isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f344612188330b7063ed142fc4f31