### PR TITLE
-p presentationStyle option

### DIFF
--- a/assets/styles/akira_comic.json
+++ b/assets/styles/akira_comic.json
@@ -1,0 +1,22 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>AKIRA aesthetic.</style>",
+    "images": {
+      "girl": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/akira_presenter.png"
+        }
+      }
+    }
+  }
+}

--- a/assets/styles/children_book.json
+++ b/assets/styles/children_book.json
@@ -1,0 +1,13 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "A hand-drawn style illustration with a warm, nostalgic atmosphere. The background is rich with natural scenery—lush forests, cloudy skies, and traditional Japanese architecture. Characters have expressive eyes, soft facial features, and are portrayed with gentle lighting and subtle shading. The color palette is muted yet vivid, using earthy tones and watercolor-like textures. The overall scene feels magical and peaceful, with a sense of quiet wonder and emotional depth, reminiscent of classic 1980s and 1990s Japanese animation."
+  }
+}

--- a/assets/styles/comic_strips.json
+++ b/assets/styles/comic_strips.json
@@ -1,0 +1,13 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>A multi panel comic strips. 1990s American workplace humor. Clean, minimalist line art with muted colors. One character is a nerdy office worker with glasses</style>"
+  }
+}

--- a/assets/styles/drslump_comic.json
+++ b/assets/styles/drslump_comic.json
@@ -1,0 +1,22 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>Dragon Ball/Dr. Slump aesthetic.</style>",
+    "images": {
+      "girl": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/slump_presenter.png"
+        }
+      }
+    }
+  }
+}

--- a/assets/styles/ghibli_comic.json
+++ b/assets/styles/ghibli_comic.json
@@ -1,0 +1,22 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>Ghibli style</style>",
+    "images": {
+      "presenter": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghibli_presenter.png"
+        }
+      }
+    }
+  }
+}

--- a/assets/styles/ghibli_shorts.json
+++ b/assets/styles/ghibli_shorts.json
@@ -1,0 +1,28 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1024,
+    "height": 1536
+  },
+  "speechParams": {
+    "provider": "nijivoice",
+    "speakers": {
+      "Presenter": { "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62", "speechOptions": { "speed": 1.5 } }
+    }
+  },
+  "imageParams": {
+    "style": "<style>Ghibli style</style>",
+    "images": {
+      "presenter": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghibli_presenter.jpg"
+        }
+      }
+    }
+  }
+}

--- a/assets/styles/ghibli_shorts.json
+++ b/assets/styles/ghibli_shorts.json
@@ -8,9 +8,9 @@
     "height": 1536
   },
   "speechParams": {
-    "provider": "nijivoice",
+    "provider": "openai",
     "speakers": {
-      "Presenter": { "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62", "speechOptions": { "speed": 1.5 } }
+      "Presenter": { "voiceId": "shimmer", "speechOptions": { "instruction": "speak very fast" } }
     }
   },
   "imageParams": {

--- a/assets/styles/ghost_comic.json
+++ b/assets/styles/ghost_comic.json
@@ -1,35 +1,29 @@
 {
-  "title": "Ghost in the shell style",
-  "description": "Template for Ghost in the shell style comic presentation.",
-  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate images for each beat based on the image prompt of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
-  "presentationStyle": {
-    "$mulmocast": {
-      "version": "1.0",
-      "credit": "closing"
-    },
-    "canvasSize": {
-      "width": 1536,
-      "height": 1024
-    },
-    "imageParams": {
-      "style": "<style>Ghost in the shell aesthetic.</style>",
-      "images": {
-        "presenter": {
-          "type": "image",
-          "source": {
-            "kind": "url",
-            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghost_presenter.png"
-          }
-        },
-        "optimus": {
-          "type": "image",
-          "source": {
-            "kind": "url",
-            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/optimus.png"
-          }
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>Ghost in the shell aesthetic.</style>",
+    "images": {
+      "presenter": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghost_presenter.png"
+        }
+      },
+      "optimus": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/optimus.png"
         }
       }
     }
-  },
-  "scriptName": "image_prompts_template.json"
+  }
 }

--- a/assets/styles/ghost_comic.json
+++ b/assets/styles/ghost_comic.json
@@ -1,0 +1,35 @@
+{
+  "title": "Ghost in the shell style",
+  "description": "Template for Ghost in the shell style comic presentation.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate images for each beat based on the image prompt of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "presentationStyle": {
+    "$mulmocast": {
+      "version": "1.0",
+      "credit": "closing"
+    },
+    "canvasSize": {
+      "width": 1536,
+      "height": 1024
+    },
+    "imageParams": {
+      "style": "<style>Ghost in the shell aesthetic.</style>",
+      "images": {
+        "presenter": {
+          "type": "image",
+          "source": {
+            "kind": "url",
+            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/ghost_presenter.png"
+          }
+        },
+        "optimus": {
+          "type": "image",
+          "source": {
+            "kind": "url",
+            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/optimus.png"
+          }
+        }
+      }
+    }
+  },
+  "scriptName": "image_prompts_template.json"
+}

--- a/assets/styles/onepiece_comic.json
+++ b/assets/styles/onepiece_comic.json
@@ -1,0 +1,28 @@
+{
+  "title": "One Piece style",
+  "description": "Template for One Piece style comic presentation.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate images for each beat based on the image prompt of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "presentationStyle": {
+    "$mulmocast": {
+      "version": "1.0",
+      "credit": "closing"
+    },
+    "canvasSize": {
+      "width": 1536,
+      "height": 1024
+    },
+    "imageParams": {
+      "style": "<style>One Piece aesthetic.</style>",
+      "images": {
+        "presenter": {
+          "type": "image",
+          "source": {
+            "kind": "url",
+            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/onepiece_presenter.png"
+          }
+        }
+      }
+    }
+  },
+  "scriptName": "image_prompts_template.json"
+}

--- a/assets/styles/onepiece_comic.json
+++ b/assets/styles/onepiece_comic.json
@@ -1,28 +1,22 @@
 {
-  "title": "One Piece style",
-  "description": "Template for One Piece style comic presentation.",
-  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate images for each beat based on the image prompt of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
-  "presentationStyle": {
-    "$mulmocast": {
-      "version": "1.0",
-      "credit": "closing"
-    },
-    "canvasSize": {
-      "width": 1536,
-      "height": 1024
-    },
-    "imageParams": {
-      "style": "<style>One Piece aesthetic.</style>",
-      "images": {
-        "presenter": {
-          "type": "image",
-          "source": {
-            "kind": "url",
-            "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/onepiece_presenter.png"
-          }
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "imageParams": {
+    "style": "<style>One Piece aesthetic.</style>",
+    "images": {
+      "presenter": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/onepiece_presenter.png"
         }
       }
     }
-  },
-  "scriptName": "image_prompts_template.json"
+  }
 }

--- a/assets/templates/text_and_image.json
+++ b/assets/templates/text_and_image.json
@@ -1,0 +1,6 @@
+{
+  "title": "Text and Image",
+  "description": "Template for Text and Image Script.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the imagePrompt of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "scriptName": "image_prompts_template.json"
+}

--- a/assets/templates/text_only.json
+++ b/assets/templates/text_only.json
@@ -1,0 +1,6 @@
+{
+  "title": "Text Only",
+  "description": "Template for Text Only Script.",
+  "systemPrompt": "Generate a script for a presentation of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "scriptName": "text_only_template.json"
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "schema": "npx tsx ./src/cli/bin.ts tool schema",
     "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",
     "latest": "yarn upgrade-interactive  --latest",
-    "format": "prettier --write '{src,scripts,assets/templates,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
+    "format": "prettier --write '{src,scripts,assets/templates,assets/styles,draft,ideason,scripts_mag2,proto,test,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
     "deep_research": "npx tsx ./src/tools/deep_research.ts"
   },
   "repository": "git+ssh://git@github.com/receptron/mulmocast-cli.git",

--- a/src/cli/common.ts
+++ b/src/cli/common.ts
@@ -33,6 +33,12 @@ export const commonOptions = (yargs: Argv) => {
       type: "boolean",
       default: false,
     })
+    .option("p", {
+      alias: "presentationStyle",
+      describe: "Presentation Style",
+      demandOption: false,
+      type: "string",
+    })
     .positional("file", {
       describe: "Mulmo Script File",
       type: "string",

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -9,6 +9,7 @@ import { outDirName, imageDirName, audioDirName } from "../utils/const.js";
 import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle } from "../types/type.js";
 import type { CliArgs } from "../types/cli_types.js";
 import { translate } from "../actions/translate.js";
+import { mulmoPresentationStyleSchema } from "../types/schema.js";
 
 export const setGraphAILogger = (verbose: boolean | undefined, logValues?: Record<string, unknown>) => {
   if (verbose) {
@@ -110,7 +111,8 @@ export const getPresentationStyle = (presentationStylePath: string | undefined):
       GraphAILogger.info(`ERROR: File not exists ${presentationStylePath}`);
       return null;
     }
-    return readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;
+    const jsonData = readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;
+    return mulmoPresentationStyleSchema.parse(jsonData);
   }
   return null;
 };

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -104,13 +104,14 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
 };
 
-export const getPresentationStyle = (presentationStylePath: string | undefined):MulmoPresentationStyle | null => {
+export const getPresentationStyle = (presentationStylePath: string | undefined): MulmoPresentationStyle | null => {
   if (presentationStylePath) {
     if (!fs.existsSync(presentationStylePath)) {
       GraphAILogger.info(`ERROR: File not exists ${presentationStylePath}`);
       return null;
     }
-    const jsonData = readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;
+    const jsonData =
+      readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;
     return mulmoPresentationStyleSchema.parse(jsonData);
   }
   return null;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -178,8 +178,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
           caption: {},
         },
       },
-      // TODO: Replace this with optional presentationStyle (--presentationStyle option)
-      presentationStyle: studio.script,
+      presentationStyle: presentationStyle ?? studio.script,
     };
   } catch (error) {
     GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${error}`);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -38,7 +38,14 @@ export interface FileObject {
   fileName: string;
 }
 
-export const getFileObject = (args: { basedir?: string; outdir?: string; imagedir?: string; audiodir?: string; presentationStyle?: string; file: string }): FileObject => {
+export const getFileObject = (args: {
+  basedir?: string;
+  outdir?: string;
+  imagedir?: string;
+  audiodir?: string;
+  presentationStyle?: string;
+  file: string;
+}): FileObject => {
   const { basedir, outdir, imagedir, audiodir, file, presentationStyle } = args;
   const baseDirPath = getBaseDirPath(basedir);
   const outDirPath = getFullPath(baseDirPath, outdir ?? outDirName);
@@ -97,7 +104,7 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
 };
 
-export const getPresentationStyle = async (presentationStylePath: string): Promise<MulmoPresentationStyle | null> => {
+export const getPresentationStyle = (presentationStylePath: string | undefined):MulmoPresentationStyle | null => {
   if (presentationStylePath) {
     if (!fs.existsSync(presentationStylePath)) {
       GraphAILogger.info(`ERROR: File not exists ${presentationStylePath}`);
@@ -139,6 +146,9 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
   if (!mulmoScript) {
     return null;
   }
+  const presentationStyle = getPresentationStyle(presentationStylePath);
+  console.log("***DEBUG***", presentationStyle);
+
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);
   try {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -107,8 +107,7 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
 export const getPresentationStyle = (presentationStylePath: string | undefined): MulmoPresentationStyle | null => {
   if (presentationStylePath) {
     if (!fs.existsSync(presentationStylePath)) {
-      GraphAILogger.info(`ERROR: File not exists ${presentationStylePath}`);
-      return null;
+      throw new Error(`ERROR: File not exists ${presentationStylePath}`);
     }
     const jsonData =
       readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -34,11 +34,12 @@ export interface FileObject {
   isHttpPath: boolean;
   fileOrUrl: string;
   outputStudioFilePath: string;
+  presentationStyle: string | undefined;
   fileName: string;
 }
 
-export const getFileObject = (args: { basedir?: string; outdir?: string; imagedir?: string; audiodir?: string; file: string }): FileObject => {
-  const { basedir, outdir, imagedir, audiodir, file } = args;
+export const getFileObject = (args: { basedir?: string; outdir?: string; imagedir?: string; audiodir?: string; presentationStyle?: string; file: string }): FileObject => {
+  const { basedir, outdir, imagedir, audiodir, file, presentationStyle } = args;
   const baseDirPath = getBaseDirPath(basedir);
   const outDirPath = getFullPath(baseDirPath, outdir ?? outDirName);
   const { fileOrUrl, fileName } = (() => {
@@ -63,6 +64,7 @@ export const getFileObject = (args: { basedir?: string; outdir?: string; imagedi
   const imageDirPath = getFullPath(outDirPath, imagedir ?? imageDirName);
   const audioDirPath = getFullPath(outDirPath, audiodir ?? audioDirName);
   const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
+  console.log("***DEBUG***", presentationStyle);
   return {
     baseDirPath,
     mulmoFilePath,
@@ -73,6 +75,7 @@ export const getFileObject = (args: { basedir?: string; outdir?: string; imagedi
     isHttpPath,
     fileOrUrl,
     outputStudioFilePath,
+    presentationStyle,
     fileName,
   };
 };
@@ -101,14 +104,17 @@ type InitOptions = {
   file?: string;
   l?: string;
   c?: string;
+  p?: string;
 };
 
 export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<MulmoStudioContext | null> => {
+  console.log("***DEBUG***", argv.p);
   const files = getFileObject({
     basedir: argv.b,
     outdir: argv.o,
     imagedir: argv.i,
     audiodir: argv.a,
+    presentationStyle: argv.p,
     file: argv.file ?? "",
   });
   const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath } = files;

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -73,7 +73,6 @@ export const getFileObject = (args: {
   const audioDirPath = getFullPath(outDirPath, audiodir ?? audioDirName);
   const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
   const presentationStylePath = presentationStyle ? getFullPath(baseDirPath, presentationStyle) : undefined;
-  console.log("***DEBUG***", presentationStylePath);
   return {
     baseDirPath,
     mulmoFilePath,
@@ -129,7 +128,6 @@ type InitOptions = {
 };
 
 export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<MulmoStudioContext | null> => {
-  console.log("***DEBUG***", argv.p);
   const files = getFileObject({
     basedir: argv.b,
     outdir: argv.o,
@@ -149,7 +147,6 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     return null;
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
-  console.log("***DEBUG***", presentationStyle);
 
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -34,7 +34,7 @@ export interface FileObject {
   isHttpPath: boolean;
   fileOrUrl: string;
   outputStudioFilePath: string;
-  presentationStyle: string | undefined;
+  presentationStylePath: string | undefined;
   fileName: string;
 }
 
@@ -64,7 +64,8 @@ export const getFileObject = (args: { basedir?: string; outdir?: string; imagedi
   const imageDirPath = getFullPath(outDirPath, imagedir ?? imageDirName);
   const audioDirPath = getFullPath(outDirPath, audiodir ?? audioDirName);
   const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
-  console.log("***DEBUG***", presentationStyle);
+  const presentationStylePath = presentationStyle ? getFullPath(baseDirPath, presentationStyle) : undefined;
+  console.log("***DEBUG***", presentationStylePath);
   return {
     baseDirPath,
     mulmoFilePath,
@@ -75,7 +76,7 @@ export const getFileObject = (args: { basedir?: string; outdir?: string; imagedi
     isHttpPath,
     fileOrUrl,
     outputStudioFilePath,
-    presentationStyle,
+    presentationStylePath,
     fileName,
   };
 };
@@ -94,6 +95,14 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
     return null;
   }
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
+};
+
+export const fetchPresentationStyle = async (presentationStyle: string): Promise<string | null> => {
+  if (presentationStyle) {
+    const res = await fetchMulmoScriptFile(presentationStyle);
+    return res.script;
+  }
+  return null;
 };
 
 type InitOptions = {
@@ -117,7 +126,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     presentationStyle: argv.p,
     file: argv.file ?? "",
   });
-  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath } = files;
+  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath, presentationStylePath } = files;
 
   setGraphAILogger(argv.v, {
     files,

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -6,7 +6,7 @@ import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile,
 import { isHttp } from "../utils/utils.js";
 import { createOrUpdateStudioData } from "../utils/preprocess.js";
 import { outDirName, imageDirName, audioDirName } from "../utils/const.js";
-import type { MulmoStudio, MulmoScript, MulmoStudioContext } from "../types/type.js";
+import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle } from "../types/type.js";
 import type { CliArgs } from "../types/cli_types.js";
 import { translate } from "../actions/translate.js";
 
@@ -97,10 +97,13 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
 };
 
-export const fetchPresentationStyle = async (presentationStyle: string): Promise<string | null> => {
-  if (presentationStyle) {
-    const res = await fetchMulmoScriptFile(presentationStyle);
-    return res.script;
+export const getPresentationStyle = async (presentationStylePath: string): Promise<MulmoPresentationStyle | null> => {
+  if (presentationStylePath) {
+    if (!fs.existsSync(presentationStylePath)) {
+      GraphAILogger.info(`ERROR: File not exists ${presentationStylePath}`);
+      return null;
+    }
+    return readMulmoScriptFile<MulmoPresentationStyle>(presentationStylePath, "ERROR: File does not exist " + presentationStylePath)?.mulmoData ?? null;
   }
   return null;
 };

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -22,6 +22,7 @@ test("test getFileObject", async () => {
     isHttpPath: false,
     fileName: "hello",
     fileOrUrl: "hello.yaml",
+    presentationStylePath: undefined,
   });
 });
 

--- a/test/utils/test_validate_styles.ts
+++ b/test/utils/test_validate_styles.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import test from "node:test";
+
+import { mulmoPresentationStyleSchema } from "../../src/types/schema.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+test("test presentation styles", async () => {
+  // const jsonData = {};
+  const basePath = path.resolve(__dirname, "../../assets/styles/");
+  fs.readdirSync(basePath).map((file) => {
+    try {
+      const content = fs.readFileSync(path.resolve(basePath, file), "utf-8");
+      const jsonData = JSON.parse(content);
+      mulmoPresentationStyleSchema.parse(jsonData);
+    } catch (error) {
+      assert.fail("Invalid style file: " + file + " " + error.message);
+    }
+  });
+});


### PR DESCRIPTION
- -p option で、image/audio などの作成時に、presentationStyle ファイルを指定できるようにしました。
- サンプルのpresentationStyleは、assets/styles に置いてあります。
- assets/templates に、presentationStyle を持たない、text_only と text_and_image の二つのテンプレートを追加しました。App では、この二つ + business, coding を提示してください。