### PR TITLE
Separate multilingual from MulmoStudio

### DIFF
--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -15,7 +15,7 @@ import { MulmoPresentationStyleMethods } from "../methods/index.js";
 
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoStudioMultiLingualData, MulmoPresentationStyle } from "../types/index.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
-import { getAudioArtifactFilePath, getAudioFilePath, getOutputStudioFilePath, resolveDirPath, defaultBGMPath, mkdir, writingMessage } from "../utils/file.js";
+import { getAudioArtifactFilePath, getAudioFilePath, resolveDirPath, defaultBGMPath, mkdir, writingMessage } from "../utils/file.js";
 import { text2hash, localizedText } from "../utils/utils.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
@@ -131,7 +131,6 @@ const graph_data: GraphData = {
     context: {},
     audioArtifactFilePath: {},
     audioCombinedFilePath: {},
-    outputStudioFilePath: {},
     musicFile: {},
     map: {
       agent: "mapAgent",
@@ -155,13 +154,6 @@ const graph_data: GraphData = {
         combinedFileName: ":audioCombinedFilePath",
       },
       isResult: true,
-    },
-    fileWrite: {
-      agent: "fileWriteAgent",
-      inputs: {
-        file: ":outputStudioFilePath",
-        text: ":combineFiles.studio.toJSON()",
-      },
     },
     addBGM: {
       agent: "addBGMAgent",
@@ -238,7 +230,7 @@ export const generateBeatAudio = async (index: number, context: MulmoStudioConte
     graph.injectValue("__mapIndex", index);
     graph.injectValue("beat", context.studio.script.beats[index]);
     graph.injectValue("studioBeat", context.studio.beats[index]);
-    graph.injectValue("multiLingual", context.studio.multiLingual);
+    graph.injectValue("multiLingual", context.multiLingual);
     graph.injectValue("context", context);
 
     if (callbacks) {
@@ -260,7 +252,6 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     const audioArtifactFilePath = audioFilePath(context);
     const audioSegmentDirPath = resolveDirPath(audioDirPath, studio.filename);
     const audioCombinedFilePath = getAudioFilePath(audioDirPath, studio.filename, studio.filename, lang);
-    const outputStudioFilePath = getOutputStudioFilePath(outDirPath, studio.filename);
 
     mkdir(outDirPath);
     mkdir(audioSegmentDirPath);
@@ -270,7 +261,6 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     graph.injectValue("context", context);
     graph.injectValue("audioArtifactFilePath", audioArtifactFilePath);
     graph.injectValue("audioCombinedFilePath", audioCombinedFilePath);
-    graph.injectValue("outputStudioFilePath", outputStudioFilePath);
     graph.injectValue(
       "musicFile",
       MulmoMediaSourceMethods.resolve(context.presentationStyle.audioParams.bgm, context) ?? process.env.PATH_BGM ?? defaultBGMPath(),

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -235,11 +235,14 @@ export const generateBeatAudio = async (index: number, context: MulmoStudioConte
     mkdir(audioSegmentDirPath);
 
     const taskManager = new TaskManager(getConcurrency(context));
+    console.log("***DEBUG001***", context.multiLingual);
     const graph = new GraphAI(graph_tts, audioAgents, { agentFilters, taskManager });
+    console.log("***DEBUG002***", context.multiLingual);
     graph.injectValue("__mapIndex", index);
     graph.injectValue("beat", context.studio.script.beats[index]);
     graph.injectValue("studioBeat", context.studio.beats[index]);
     graph.injectValue("multiLingual", context.multiLingual);
+    console.log("***DEBUG2***", context.multiLingual);
     graph.injectValue("context", context);
 
     if (callbacks) {
@@ -262,6 +265,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     const audioSegmentDirPath = resolveDirPath(audioDirPath, studio.filename);
     const audioCombinedFilePath = getAudioFilePath(audioDirPath, studio.filename, studio.filename, lang);
     const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
+    console.log("***DEBUG1***", outputMultilingualFilePath);
 
     mkdir(outDirPath);
     mkdir(audioSegmentDirPath);
@@ -282,7 +286,9 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
         graph.registerCallback(callback);
       });
     }
+    console.log("***DEBUG3***", outputMultilingualFilePath);
     await graph.run();
+    console.log("***DEBUG4***", outputMultilingualFilePath);
 
     writingMessage(audioCombinedFilePath);
   } finally {

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -137,7 +137,7 @@ const graph_data: GraphData = {
       inputs: {
         rows: ":context.studio.script.beats",
         studioBeat: ":context.studio.beats",
-        multiLingual: ":context.studio.multiLingual",
+        multiLingual: ":context.multiLingual",
         context: ":context",
       },
       params: {

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -138,7 +138,7 @@ const graph_data: GraphData = {
       inputs: {
         rows: ":context.studio.script.beats",
         studioBeat: ":context.studio.beats",
-        multiLingual: ":context.studio.multiLingual",
+        multiLingual: ":context.multiLingual",
         context: ":context",
       },
       params: {
@@ -238,7 +238,7 @@ export const generateBeatAudio = async (index: number, context: MulmoStudioConte
     graph.injectValue("__mapIndex", index);
     graph.injectValue("beat", context.studio.script.beats[index]);
     graph.injectValue("studioBeat", context.studio.beats[index]);
-    graph.injectValue("multiLingual", context.studio.multiLingual);
+    graph.injectValue("multiLingual", context.multiLingual);
     graph.injectValue("context", context);
 
     if (callbacks) {

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -15,7 +15,15 @@ import { MulmoPresentationStyleMethods } from "../methods/index.js";
 
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoStudioMultiLingualData, MulmoPresentationStyle } from "../types/index.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
-import { getAudioArtifactFilePath, getAudioFilePath, resolveDirPath, defaultBGMPath, mkdir, writingMessage } from "../utils/file.js";
+import {
+  getAudioArtifactFilePath,
+  getAudioFilePath,
+  resolveDirPath,
+  defaultBGMPath,
+  mkdir,
+  writingMessage,
+  getOutputMultilingualFilePath,
+} from "../utils/file.js";
 import { text2hash, localizedText } from "../utils/utils.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
@@ -131,6 +139,7 @@ const graph_data: GraphData = {
     context: {},
     audioArtifactFilePath: {},
     audioCombinedFilePath: {},
+    outputMultilingualFilePath: {},
     musicFile: {},
     map: {
       agent: "mapAgent",
@@ -252,6 +261,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     const audioArtifactFilePath = audioFilePath(context);
     const audioSegmentDirPath = resolveDirPath(audioDirPath, studio.filename);
     const audioCombinedFilePath = getAudioFilePath(audioDirPath, studio.filename, studio.filename, lang);
+    const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
 
     mkdir(outDirPath);
     mkdir(audioSegmentDirPath);
@@ -261,6 +271,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     graph.injectValue("context", context);
     graph.injectValue("audioArtifactFilePath", audioArtifactFilePath);
     graph.injectValue("audioCombinedFilePath", audioCombinedFilePath);
+    graph.injectValue("outputMultilingualFilePath", outputMultilingualFilePath);
     graph.injectValue(
       "musicFile",
       MulmoMediaSourceMethods.resolve(context.presentationStyle.audioParams.bgm, context) ?? process.env.PATH_BGM ?? defaultBGMPath(),

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -15,15 +15,7 @@ import { MulmoPresentationStyleMethods } from "../methods/index.js";
 
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoStudioMultiLingualData, MulmoPresentationStyle } from "../types/index.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
-import {
-  getAudioArtifactFilePath,
-  getAudioFilePath,
-  resolveDirPath,
-  defaultBGMPath,
-  mkdir,
-  writingMessage,
-  getOutputMultilingualFilePath,
-} from "../utils/file.js";
+import { getAudioArtifactFilePath, getAudioFilePath, getOutputStudioFilePath, resolveDirPath, defaultBGMPath, mkdir, writingMessage } from "../utils/file.js";
 import { text2hash, localizedText } from "../utils/utils.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
@@ -139,14 +131,14 @@ const graph_data: GraphData = {
     context: {},
     audioArtifactFilePath: {},
     audioCombinedFilePath: {},
-    outputMultilingualFilePath: {},
+    outputStudioFilePath: {},
     musicFile: {},
     map: {
       agent: "mapAgent",
       inputs: {
         rows: ":context.studio.script.beats",
         studioBeat: ":context.studio.beats",
-        multiLingual: ":context.multiLingual",
+        multiLingual: ":context.studio.multiLingual",
         context: ":context",
       },
       params: {
@@ -163,6 +155,13 @@ const graph_data: GraphData = {
         combinedFileName: ":audioCombinedFilePath",
       },
       isResult: true,
+    },
+    fileWrite: {
+      agent: "fileWriteAgent",
+      inputs: {
+        file: ":outputStudioFilePath",
+        text: ":combineFiles.studio.toJSON()",
+      },
     },
     addBGM: {
       agent: "addBGMAgent",
@@ -235,14 +234,11 @@ export const generateBeatAudio = async (index: number, context: MulmoStudioConte
     mkdir(audioSegmentDirPath);
 
     const taskManager = new TaskManager(getConcurrency(context));
-    console.log("***DEBUG001***", context.multiLingual);
     const graph = new GraphAI(graph_tts, audioAgents, { agentFilters, taskManager });
-    console.log("***DEBUG002***", context.multiLingual);
     graph.injectValue("__mapIndex", index);
     graph.injectValue("beat", context.studio.script.beats[index]);
     graph.injectValue("studioBeat", context.studio.beats[index]);
-    graph.injectValue("multiLingual", context.multiLingual);
-    console.log("***DEBUG2***", context.multiLingual);
+    graph.injectValue("multiLingual", context.studio.multiLingual);
     graph.injectValue("context", context);
 
     if (callbacks) {
@@ -264,8 +260,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     const audioArtifactFilePath = audioFilePath(context);
     const audioSegmentDirPath = resolveDirPath(audioDirPath, studio.filename);
     const audioCombinedFilePath = getAudioFilePath(audioDirPath, studio.filename, studio.filename, lang);
-    const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
-    console.log("***DEBUG1***", outputMultilingualFilePath);
+    const outputStudioFilePath = getOutputStudioFilePath(outDirPath, studio.filename);
 
     mkdir(outDirPath);
     mkdir(audioSegmentDirPath);
@@ -275,7 +270,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
     graph.injectValue("context", context);
     graph.injectValue("audioArtifactFilePath", audioArtifactFilePath);
     graph.injectValue("audioCombinedFilePath", audioCombinedFilePath);
-    graph.injectValue("outputMultilingualFilePath", outputMultilingualFilePath);
+    graph.injectValue("outputStudioFilePath", outputStudioFilePath);
     graph.injectValue(
       "musicFile",
       MulmoMediaSourceMethods.resolve(context.presentationStyle.audioParams.bgm, context) ?? process.env.PATH_BGM ?? defaultBGMPath(),
@@ -286,9 +281,7 @@ export const audio = async (context: MulmoStudioContext, callbacks?: CallbackFun
         graph.registerCallback(callback);
       });
     }
-    console.log("***DEBUG3***", outputMultilingualFilePath);
     await graph.run();
-    console.log("***DEBUG4***", outputMultilingualFilePath);
 
     writingMessage(audioCombinedFilePath);
   } finally {

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -34,7 +34,7 @@ const graph_data: GraphData = {
                 const imagePath = `${imageDirPath}/${context.studio.filename}/${index}_caption.png`;
                 const template = getHTMLFile("caption");
                 const text = (() => {
-                  const multiLingual = context.multiLingual;
+                  const multiLingual = context.studio.multiLingual;
                   if (caption && multiLingual) {
                     return multiLingual[index].multiLingualTexts[caption].text;
                   }

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -34,7 +34,7 @@ const graph_data: GraphData = {
                 const imagePath = `${imageDirPath}/${context.studio.filename}/${index}_caption.png`;
                 const template = getHTMLFile("caption");
                 const text = (() => {
-                  const multiLingual = context.studio.multiLingual;
+                  const multiLingual = context.multiLingual;
                   if (caption && multiLingual) {
                     return multiLingual[index].multiLingualTexts[caption].text;
                   }

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -281,7 +281,7 @@ const graphOption = async (context: MulmoStudioContext) => {
 
 const prepareGenerateImages = async (context: MulmoStudioContext) => {
   const { studio, fileDirs } = context;
-  const { outDirPath, imageDirPath } = fileDirs;
+  const { imageDirPath } = fileDirs;
   mkdir(`${imageDirPath}/${studio.filename}`);
 
   const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(context.presentationStyle, context.dryRun);

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -8,7 +8,7 @@ import * as agents from "@graphai/vanilla";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoImageParams, Text2ImageAgentInfo } from "../types/index.js";
-import { getOutputStudioFilePath, mkdir } from "../utils/file.js";
+import { mkdir } from "../utils/file.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
 import { imageGoogleAgent, imageOpenaiAgent, movieGoogleAgent, mediaMockAgent } from "../agents/index.js";
 import { MulmoPresentationStyleMethods, MulmoStudioContextMethods } from "../methods/index.js";
@@ -177,7 +177,6 @@ const graph_data: GraphData = {
     imageDirPath: {},
     imageAgentInfo: {},
     movieAgentInfo: {},
-    outputStudioFilePath: {},
     imageRefs: {},
     map: {
       agent: "mapAgent",
@@ -225,14 +224,6 @@ const graph_data: GraphData = {
       inputs: {
         array: ":map.output",
         context: ":context",
-      },
-    },
-    writeOutput: {
-      // console: { before: true },
-      agent: "fileWriteAgent",
-      inputs: {
-        file: ":outputStudioFilePath",
-        text: ":mergeResult.studio.toJSON()",
       },
     },
   },
@@ -342,7 +333,6 @@ const prepareGenerateImages = async (context: MulmoStudioContext) => {
     movieAgentInfo: {
       agent: context.dryRun ? "mediaMockAgent" : "movieGoogleAgent",
     },
-    outputStudioFilePath: getOutputStudioFilePath(outDirPath, studio.filename),
     imageDirPath,
     imageRefs,
   };
@@ -394,9 +384,7 @@ export const generateBeatImage = async (index: number, context: MulmoStudioConte
     options,
   );
   Object.keys(injections).forEach((key: string) => {
-    if ("outputStudioFilePath" !== key) {
-      graph.injectValue(key, injections[key]);
-    }
+    graph.injectValue(key, injections[key]);
   });
   graph.injectValue("__mapIndex", index);
   graph.injectValue("beat", context.studio.script.beats[index]);

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -127,7 +127,7 @@ const getHandoutTemplateData = (isLandscapeImage: boolean): Record<string, strin
 
 const generatePDFHTML = async (context: MulmoStudioContext, pdfMode: PDFMode, pdfSize: PDFSize): Promise<string> => {
   const { studio, lang = "en" } = context;
-  const { multiLingual } = studio;
+  const { multiLingual } = context;
 
   const { width: imageWidth, height: imageHeight } = MulmoPresentationStyleMethods.getCanvasSize(context.presentationStyle);
   const isLandscapeImage = imageWidth > imageHeight;

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -127,7 +127,7 @@ const getHandoutTemplateData = (isLandscapeImage: boolean): Record<string, strin
 
 const generatePDFHTML = async (context: MulmoStudioContext, pdfMode: PDFMode, pdfSize: PDFSize): Promise<string> => {
   const { studio, lang = "en" } = context;
-  const { multiLingual } = context;
+  const { multiLingual } = studio;
 
   const { width: imageWidth, height: imageHeight } = MulmoPresentationStyleMethods.getCanvasSize(context.presentationStyle);
   const isLandscapeImage = imageWidth > imageHeight;

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -126,8 +126,7 @@ const getHandoutTemplateData = (isLandscapeImage: boolean): Record<string, strin
 });
 
 const generatePDFHTML = async (context: MulmoStudioContext, pdfMode: PDFMode, pdfSize: PDFSize): Promise<string> => {
-  const { studio, lang = "en" } = context;
-  const { multiLingual } = studio;
+  const { studio, multiLingual, lang = "en" } = context;
 
   const { width: imageWidth, height: imageHeight } = MulmoPresentationStyleMethods.getCanvasSize(context.presentationStyle);
   const isLandscapeImage = imageWidth > imageHeight;

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -6,7 +6,7 @@ import { openAIAgent } from "@graphai/openai_agent";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
-import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio } from "../types/index.js";
+import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio, MulmoStudioMultiLingual } from "../types/index.js";
 import { getOutputMultilingualFilePath, getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
 import { translateSystemPrompt, translatePrompts } from "../utils/prompt.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
@@ -32,7 +32,7 @@ const translateGraph: GraphData = {
       isResult: true,
       agent: "mergeObjectAgent",
       inputs: {
-        items: [":context.studio", { multiLingual: ":beatsMap.mergeMultiLingualData" }],
+        items: [{ multiLingual: ":beatsMap.mergeMultiLingualData" }],
       },
     },
     beatsMap: {
@@ -173,7 +173,7 @@ const translateGraph: GraphData = {
       agent: "fileWriteAgent",
       inputs: {
         file: ":outputMultilingualFilePath",
-        text: ":mergeStudioResult.toJSON()",
+        text: ":mergeStudioResult.multiLingual.toJSON()",
       },
     },
   },
@@ -244,10 +244,10 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
         graph.registerCallback(callback);
       });
     }
-    const results = await graph.run<MulmoStudio>();
+    const results = await graph.run<{ multiLingual: MulmoStudioMultiLingual }>();
     writingMessage(outputMultilingualFilePath);
     if (results.mergeStudioResult) {
-      context.studio = results.mergeStudioResult;
+      context.multiLingual = results.mergeStudioResult.multiLingual;
     }
   } finally {
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", false);

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -7,7 +7,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
 import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio } from "../types/index.js";
-import { getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
+import { getOutputMultilingualFilePath, getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
 import { translateSystemPrompt, translatePrompts } from "../utils/prompt.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
@@ -19,7 +19,7 @@ const translateGraph: GraphData = {
     context: {},
     defaultLang: {},
     outDirPath: {},
-    outputStudioFilePath: {},
+    outputMultilingualFilePath: {},
     lang: {
       agent: "stringUpdateTextAgent",
       inputs: {
@@ -172,7 +172,7 @@ const translateGraph: GraphData = {
       // console: { before: true },
       agent: "fileWriteAgent",
       inputs: {
-        file: ":outputStudioFilePath",
+        file: ":outputMultilingualFilePath",
         text: ":mergeStudioResult.toJSON()",
       },
     },
@@ -228,7 +228,7 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", true);
     const { studio, fileDirs } = context;
     const { outDirPath } = fileDirs;
-    const outputStudioFilePath = getOutputStudioFilePath(outDirPath, studio.filename);
+    const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
     mkdir(outDirPath);
 
     assert(!!process.env.OPENAI_API_KEY, "The OPENAI_API_KEY environment variable is missing or empty");
@@ -238,7 +238,7 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     graph.injectValue("defaultLang", defaultLang);
     graph.injectValue("targetLangs", targetLangs);
     graph.injectValue("outDirPath", outDirPath);
-    graph.injectValue("outputStudioFilePath", outputStudioFilePath);
+    graph.injectValue("outputMultilingualFilePath", outputMultilingualFilePath);
     if (callbacks) {
       callbacks.forEach((callback) => {
         graph.registerCallback(callback);

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -6,8 +6,8 @@ import { openAIAgent } from "@graphai/openai_agent";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
-import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio, MulmoStudioMultiLingual } from "../types/index.js";
-import { getOutputMultilingualFilePath, getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
+import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudioMultiLingual } from "../types/index.js";
+import { getOutputMultilingualFilePath, mkdir, writingMessage } from "../utils/file.js";
 import { translateSystemPrompt, translatePrompts } from "../utils/prompt.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -7,7 +7,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
 import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio } from "../types/index.js";
-import { getOutputMultilingualFilePath, mkdir, writingMessage } from "../utils/file.js";
+import { getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
 import { translateSystemPrompt, translatePrompts } from "../utils/prompt.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
@@ -19,7 +19,7 @@ const translateGraph: GraphData = {
     context: {},
     defaultLang: {},
     outDirPath: {},
-    outputMultilingualFilePath: {},
+    outputStudioFilePath: {},
     lang: {
       agent: "stringUpdateTextAgent",
       inputs: {
@@ -57,7 +57,7 @@ const translateGraph: GraphData = {
             },
             inputs: {
               index: ":__mapIndex",
-              rows: ":context.multiLingual",
+              rows: ":context.studio.multiLingual",
             },
           },
           preprocessMultiLingual: {
@@ -172,7 +172,7 @@ const translateGraph: GraphData = {
       // console: { before: true },
       agent: "fileWriteAgent",
       inputs: {
-        file: ":outputMultilingualFilePath",
+        file: ":outputStudioFilePath",
         text: ":mergeStudioResult.toJSON()",
       },
     },
@@ -228,7 +228,7 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", true);
     const { studio, fileDirs } = context;
     const { outDirPath } = fileDirs;
-    const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
+    const outputStudioFilePath = getOutputStudioFilePath(outDirPath, studio.filename);
     mkdir(outDirPath);
 
     assert(!!process.env.OPENAI_API_KEY, "The OPENAI_API_KEY environment variable is missing or empty");
@@ -238,14 +238,14 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     graph.injectValue("defaultLang", defaultLang);
     graph.injectValue("targetLangs", targetLangs);
     graph.injectValue("outDirPath", outDirPath);
-    graph.injectValue("outputMultilingualFilePath", outputMultilingualFilePath);
+    graph.injectValue("outputStudioFilePath", outputStudioFilePath);
     if (callbacks) {
       callbacks.forEach((callback) => {
         graph.registerCallback(callback);
       });
     }
     const results = await graph.run<MulmoStudio>();
-    writingMessage(outputMultilingualFilePath);
+    writingMessage(outputStudioFilePath);
     if (results.mergeStudioResult) {
       context.studio = results.mergeStudioResult;
     }

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -7,7 +7,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
 import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudio } from "../types/index.js";
-import { getOutputStudioFilePath, mkdir, writingMessage } from "../utils/file.js";
+import { getOutputMultilingualFilePath, mkdir, writingMessage } from "../utils/file.js";
 import { translateSystemPrompt, translatePrompts } from "../utils/prompt.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
@@ -19,7 +19,7 @@ const translateGraph: GraphData = {
     context: {},
     defaultLang: {},
     outDirPath: {},
-    outputStudioFilePath: {},
+    outputMultilingualFilePath: {},
     lang: {
       agent: "stringUpdateTextAgent",
       inputs: {
@@ -172,7 +172,7 @@ const translateGraph: GraphData = {
       // console: { before: true },
       agent: "fileWriteAgent",
       inputs: {
-        file: ":outputStudioFilePath",
+        file: ":outputMultilingualFilePath",
         text: ":mergeStudioResult.toJSON()",
       },
     },
@@ -228,7 +228,7 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", true);
     const { studio, fileDirs } = context;
     const { outDirPath } = fileDirs;
-    const outputStudioFilePath = getOutputStudioFilePath(outDirPath, studio.filename);
+    const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, studio.filename);
     mkdir(outDirPath);
 
     assert(!!process.env.OPENAI_API_KEY, "The OPENAI_API_KEY environment variable is missing or empty");
@@ -238,14 +238,14 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
     graph.injectValue("defaultLang", defaultLang);
     graph.injectValue("targetLangs", targetLangs);
     graph.injectValue("outDirPath", outDirPath);
-    graph.injectValue("outputStudioFilePath", outputStudioFilePath);
+    graph.injectValue("outputMultilingualFilePath", outputMultilingualFilePath);
     if (callbacks) {
       callbacks.forEach((callback) => {
         graph.registerCallback(callback);
       });
     }
     const results = await graph.run<MulmoStudio>();
-    writingMessage(outputStudioFilePath);
+    writingMessage(outputMultilingualFilePath);
     if (results.mergeStudioResult) {
       context.studio = results.mergeStudioResult;
     }

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -245,7 +245,7 @@ export const translate = async (context: MulmoStudioContext, callbacks?: Callbac
       });
     }
     const results = await graph.run<MulmoStudio>();
-    writingMessage(outputStudioFilePath);
+    writingMessage(outputMultilingualFilePath);
     if (results.mergeStudioResult) {
       context.studio = results.mergeStudioResult;
     }

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -57,7 +57,7 @@ const translateGraph: GraphData = {
             },
             inputs: {
               index: ":__mapIndex",
-              rows: ":context.studio.multiLingual",
+              rows: ":context.multiLingual",
             },
           },
           preprocessMultiLingual: {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -116,13 +116,13 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
 };
 
-export const getMultiLingual = (multilingualFilePath: string): MulmoStudioMultiLingual => {
+export const getMultiLingual = (multilingualFilePath: string, beatsLength: number): MulmoStudioMultiLingual => {
   if (fs.existsSync(multilingualFilePath)) {
     const jsonData =
       readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
     return mulmoStudioMultiLingualSchema.parse(jsonData);
   }
-  return [{ multiLingualTexts: {} }];
+  return [...Array(beatsLength)].map(() => ({ multiLingualTexts: {} }));
 };
 
 export const getPresentationStyle = (presentationStylePath: string | undefined): MulmoPresentationStyle | null => {
@@ -168,7 +168,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     return null;
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
-  const multiLingual = getMultiLingual(outputMultilingualFilePath);
+  const multiLingual = getMultiLingual(outputMultilingualFilePath, mulmoScript.beats.length);
 
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -2,7 +2,7 @@ import { GraphAILogger } from "graphai";
 import fs from "fs";
 import path from "path";
 import clipboardy from "clipboardy";
-import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile, getOutputStudioFilePath, resolveDirPath, mkdir, getOutputMultilingualFilePath } from "../utils/file.js";
+import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile, resolveDirPath, mkdir, getOutputMultilingualFilePath } from "../utils/file.js";
 import { isHttp } from "../utils/utils.js";
 import { createStudioData } from "../utils/preprocess.js";
 import { outDirName, imageDirName, audioDirName } from "../utils/const.js";

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -2,14 +2,14 @@ import { GraphAILogger } from "graphai";
 import fs from "fs";
 import path from "path";
 import clipboardy from "clipboardy";
-import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile, getOutputStudioFilePath, resolveDirPath, mkdir } from "../utils/file.js";
+import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile, getOutputStudioFilePath, resolveDirPath, mkdir, getOutputMultilingualFilePath } from "../utils/file.js";
 import { isHttp } from "../utils/utils.js";
-import { createOrUpdateStudioData } from "../utils/preprocess.js";
+import { createStudioData } from "../utils/preprocess.js";
 import { outDirName, imageDirName, audioDirName } from "../utils/const.js";
-import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle } from "../types/type.js";
+import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle, MulmoStudioMultiLingual } from "../types/type.js";
 import type { CliArgs } from "../types/cli_types.js";
 import { translate } from "../actions/translate.js";
-import { mulmoPresentationStyleSchema } from "../types/schema.js";
+import { mulmoPresentationStyleSchema, mulmoStudioMultiLingualSchema } from "../types/schema.js";
 
 export const setGraphAILogger = (verbose: boolean | undefined, logValues?: Record<string, unknown>) => {
   if (verbose) {
@@ -34,7 +34,7 @@ export interface FileObject {
   audioDirPath: string;
   isHttpPath: boolean;
   fileOrUrl: string;
-  outputStudioFilePath: string;
+  outputMultilingualFilePath: string;
   presentationStylePath: string | undefined;
   fileName: string;
 }
@@ -71,7 +71,7 @@ export const getFileObject = (args: {
   const mulmoFileDirPath = path.dirname(isHttpPath ? baseDirPath : mulmoFilePath);
   const imageDirPath = getFullPath(outDirPath, imagedir ?? imageDirName);
   const audioDirPath = getFullPath(outDirPath, audiodir ?? audioDirName);
-  const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
+  const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, fileName);
   const presentationStylePath = presentationStyle ? getFullPath(baseDirPath, presentationStyle) : undefined;
   return {
     baseDirPath,
@@ -82,7 +82,7 @@ export const getFileObject = (args: {
     audioDirPath,
     isHttpPath,
     fileOrUrl,
-    outputStudioFilePath,
+    outputMultilingualFilePath,
     presentationStylePath,
     fileName,
   };
@@ -116,6 +116,15 @@ export const getPresentationStyle = (presentationStylePath: string | undefined):
   return null;
 };
 
+export const getMultiLingual = (multilingualFilePath: string): MulmoStudioMultiLingual => {
+    if (fs.existsSync(multilingualFilePath)) {
+      const jsonData =
+      readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
+      return mulmoStudioMultiLingualSchema.parse(jsonData);
+    }
+    return [];
+};
+
 type InitOptions = {
   b?: string;
   o?: string;
@@ -136,7 +145,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     presentationStyle: argv.p,
     file: argv.file ?? "",
   });
-  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath, presentationStylePath } = files;
+  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, presentationStylePath, outputMultilingualFilePath } = files;
 
   setGraphAILogger(argv.v, {
     files,
@@ -147,12 +156,11 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     return null;
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
+  const multiLingual = getMultiLingual(outputMultilingualFilePath);
 
-  // Create or update MulmoStudio file with MulmoScript
-  const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);
   try {
     // validate mulmoStudioSchema. skip if __test_invalid__ is true
-    const studio = createOrUpdateStudioData(mulmoScript, currentStudio?.mulmoData, fileName);
+    const studio = createStudioData(mulmoScript, fileName);
     return {
       studio,
       fileDirs: files,
@@ -178,6 +186,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
         },
       },
       presentationStyle: presentationStyle ?? studio.script,
+      multiLingual
     };
   } catch (error) {
     GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${error}`);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -2,14 +2,23 @@ import { GraphAILogger } from "graphai";
 import fs from "fs";
 import path from "path";
 import clipboardy from "clipboardy";
-import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile, getOutputStudioFilePath, resolveDirPath, mkdir } from "../utils/file.js";
+import {
+  getBaseDirPath,
+  getFullPath,
+  readMulmoScriptFile,
+  fetchMulmoScriptFile,
+  getOutputStudioFilePath,
+  resolveDirPath,
+  mkdir,
+  getOutputMultilingualFilePath,
+} from "../utils/file.js";
 import { isHttp } from "../utils/utils.js";
 import { createOrUpdateStudioData } from "../utils/preprocess.js";
 import { outDirName, imageDirName, audioDirName } from "../utils/const.js";
-import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle } from "../types/type.js";
+import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle, MulmoStudioMultiLingual } from "../types/type.js";
 import type { CliArgs } from "../types/cli_types.js";
 import { translate } from "../actions/translate.js";
-import { mulmoPresentationStyleSchema } from "../types/schema.js";
+import { mulmoPresentationStyleSchema, mulmoStudioMultiLingualSchema } from "../types/schema.js";
 
 export const setGraphAILogger = (verbose: boolean | undefined, logValues?: Record<string, unknown>) => {
   if (verbose) {
@@ -35,6 +44,7 @@ export interface FileObject {
   isHttpPath: boolean;
   fileOrUrl: string;
   outputStudioFilePath: string;
+  outputMultilingualFilePath: string;
   presentationStylePath: string | undefined;
   fileName: string;
 }
@@ -72,6 +82,7 @@ export const getFileObject = (args: {
   const imageDirPath = getFullPath(outDirPath, imagedir ?? imageDirName);
   const audioDirPath = getFullPath(outDirPath, audiodir ?? audioDirName);
   const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
+  const outputMultilingualFilePath = getOutputMultilingualFilePath(outDirPath, fileName);
   const presentationStylePath = presentationStyle ? getFullPath(baseDirPath, presentationStyle) : undefined;
   return {
     baseDirPath,
@@ -83,6 +94,7 @@ export const getFileObject = (args: {
     isHttpPath,
     fileOrUrl,
     outputStudioFilePath,
+    outputMultilingualFilePath,
     presentationStylePath,
     fileName,
   };
@@ -102,6 +114,15 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
     return null;
   }
   return readMulmoScriptFile<MulmoScript>(mulmoFilePath, "ERROR: File does not exist " + mulmoFilePath)?.mulmoData ?? null;
+};
+
+export const getMultiLingual = (multilingualFilePath: string): MulmoStudioMultiLingual => {
+  if (fs.existsSync(multilingualFilePath)) {
+    const jsonData =
+      readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
+    return mulmoStudioMultiLingualSchema.parse(jsonData);
+  }
+  return [{ multiLingualTexts: {} }];
 };
 
 export const getPresentationStyle = (presentationStylePath: string | undefined): MulmoPresentationStyle | null => {
@@ -136,7 +157,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     presentationStyle: argv.p,
     file: argv.file ?? "",
   });
-  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath, presentationStylePath } = files;
+  const { fileName, isHttpPath, fileOrUrl, mulmoFilePath, outputStudioFilePath, presentationStylePath, outputMultilingualFilePath } = files;
 
   setGraphAILogger(argv.v, {
     files,
@@ -147,6 +168,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
     return null;
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
+  const multiLingual = getMultiLingual(outputMultilingualFilePath);
 
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);
@@ -178,6 +200,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
         },
       },
       presentationStyle: presentationStyle ?? studio.script,
+      multiLingual,
     };
   } catch (error) {
     GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${error}`);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -122,7 +122,7 @@ export const getMultiLingual = (multilingualFilePath: string): MulmoStudioMultiL
       readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
     return mulmoStudioMultiLingualSchema.parse(jsonData);
   }
-  return [];
+  return [{ multiLingualTexts: {} }];
 };
 
 type InitOptions = {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -118,10 +118,13 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
 
 export const getMultiLingual = (multilingualFilePath: string, beatsLength: number): MulmoStudioMultiLingual => {
   if (fs.existsSync(multilingualFilePath)) {
+    console.log("***DEBUG1***", multilingualFilePath);
     const jsonData =
       readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
+    console.log("***DEBUG2***", jsonData);
     return mulmoStudioMultiLingualSchema.parse(jsonData);
   }
+  console.log("***DEBUG3***", [...Array(beatsLength)].map(() => ({ multiLingualTexts: {} })));
   return [...Array(beatsLength)].map(() => ({ multiLingualTexts: {} }));
 };
 
@@ -169,6 +172,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
   const multiLingual = getMultiLingual(outputMultilingualFilePath, mulmoScript.beats.length);
+  console.log("***DEBUG4***", multiLingual);
 
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -6,7 +6,7 @@ import { getBaseDirPath, getFullPath, readMulmoScriptFile, fetchMulmoScriptFile,
 import { isHttp } from "../utils/utils.js";
 import { createStudioData } from "../utils/preprocess.js";
 import { outDirName, imageDirName, audioDirName } from "../utils/const.js";
-import type { MulmoStudio, MulmoScript, MulmoStudioContext, MulmoPresentationStyle, MulmoStudioMultiLingual } from "../types/type.js";
+import type { MulmoScript, MulmoStudioContext, MulmoPresentationStyle, MulmoStudioMultiLingual } from "../types/type.js";
 import type { CliArgs } from "../types/cli_types.js";
 import { translate } from "../actions/translate.js";
 import { mulmoPresentationStyleSchema, mulmoStudioMultiLingualSchema } from "../types/schema.js";
@@ -117,12 +117,12 @@ export const getPresentationStyle = (presentationStylePath: string | undefined):
 };
 
 export const getMultiLingual = (multilingualFilePath: string): MulmoStudioMultiLingual => {
-    if (fs.existsSync(multilingualFilePath)) {
-      const jsonData =
+  if (fs.existsSync(multilingualFilePath)) {
+    const jsonData =
       readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
-      return mulmoStudioMultiLingualSchema.parse(jsonData);
-    }
-    return [];
+    return mulmoStudioMultiLingualSchema.parse(jsonData);
+  }
+  return [];
 };
 
 type InitOptions = {
@@ -186,7 +186,7 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
         },
       },
       presentationStyle: presentationStyle ?? studio.script,
-      multiLingual
+      multiLingual,
     };
   } catch (error) {
     GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${error}`);

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -118,13 +118,10 @@ export const fetchScript = async (isHttpPath: boolean, mulmoFilePath: string, fi
 
 export const getMultiLingual = (multilingualFilePath: string, beatsLength: number): MulmoStudioMultiLingual => {
   if (fs.existsSync(multilingualFilePath)) {
-    console.log("***DEBUG1***", multilingualFilePath);
     const jsonData =
       readMulmoScriptFile<MulmoStudioMultiLingual>(multilingualFilePath, "ERROR: File does not exist " + multilingualFilePath)?.mulmoData ?? null;
-    console.log("***DEBUG2***", jsonData);
     return mulmoStudioMultiLingualSchema.parse(jsonData);
   }
-  console.log("***DEBUG3***", [...Array(beatsLength)].map(() => ({ multiLingualTexts: {} })));
   return [...Array(beatsLength)].map(() => ({ multiLingualTexts: {} }));
 };
 
@@ -172,7 +169,6 @@ export const initializeContext = async (argv: CliArgs<InitOptions>): Promise<Mul
   }
   const presentationStyle = getPresentationStyle(presentationStylePath);
   const multiLingual = getMultiLingual(outputMultilingualFilePath, mulmoScript.beats.length);
-  console.log("***DEBUG4***", multiLingual);
 
   // Create or update MulmoStudio file with MulmoScript
   const currentStudio = readMulmoScriptFile<MulmoStudio>(outputStudioFilePath);

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -350,7 +350,6 @@ export const mulmoStudioSchema = z
     script: mulmoScriptSchema,
     filename: z.string(),
     beats: z.array(mulmoStudioBeatSchema).min(1),
-    multiLingual: mulmoStudioMultiLingualSchema,
   })
   .strict();
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -92,6 +92,7 @@ export type MulmoStudioContext = {
   caption?: string;
   sessionState: MulmoSessionState;
   presentationStyle: MulmoPresentationStyle;
+  multiLingual: MulmoStudioMultiLingual;
 };
 
 export type ScriptingParams = {

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -84,8 +84,8 @@ export const fetchMulmoScriptFile = async (url: string): Promise<{ result: boole
   }
 };
 
-export const getOutputStudioFilePath = (outDirPath: string, fileName: string) => {
-  return path.resolve(outDirPath, fileName + "_studio.json");
+export const getOutputMultilingualFilePath = (outDirPath: string, fileName: string) => {
+  return path.resolve(outDirPath, fileName + "_lang.json");
 };
 export const resolveDirPath = (dirPath: string, studioFileName: string) => {
   return path.resolve(dirPath, studioFileName);

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -84,6 +84,9 @@ export const fetchMulmoScriptFile = async (url: string): Promise<{ result: boole
   }
 };
 
+export const getOutputStudioFilePath = (outDirPath: string, fileName: string) => {
+  return path.resolve(outDirPath, fileName + "_studio.json");
+};
 export const getOutputMultilingualFilePath = (outDirPath: string, fileName: string) => {
   return path.resolve(outDirPath, fileName + "_lang.json");
 };

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -1,14 +1,7 @@
 import { GraphAILogger } from "graphai";
 import { MulmoStudio, MulmoBeat, MulmoScript, mulmoScriptSchema, mulmoBeatSchema, mulmoStudioSchema } from "../types/index.js";
 
-const rebuildStudio = (currentStudio: MulmoStudio | undefined, mulmoScript: MulmoScript, fileName: string) => {
-  const parsed = mulmoStudioSchema.safeParse(currentStudio);
-  if (parsed.success) {
-    return parsed.data;
-  }
-  if (currentStudio) {
-    GraphAILogger.info("currentStudio is invalid", parsed.error);
-  }
+const buildStudio = (mulmoScript: MulmoScript, fileName: string) => {
   // We need to parse it to fill default values
   return mulmoStudioSchema.parse({
     script: mulmoScript,
@@ -39,13 +32,11 @@ const mulmoCredit = (speaker: string) => {
   };
 };
 
-export const createOrUpdateStudioData = (_mulmoScript: MulmoScript, currentStudio: MulmoStudio | undefined, fileName: string) => {
+export const createStudioData = (_mulmoScript: MulmoScript, fileName: string) => {
   const mulmoScript = _mulmoScript.__test_invalid__ ? _mulmoScript : mulmoScriptSchema.parse(_mulmoScript); // validate and insert default value
 
-  const studio: MulmoStudio = rebuildStudio(currentStudio, mulmoScript, fileName);
+  const studio: MulmoStudio = buildStudio(mulmoScript, fileName);
 
-  // TODO: Move this code out of this function later
-  // Addition cloing credit
   if (mulmoScript.$mulmocast.credit === "closing") {
     mulmoScript.beats.push(mulmoCredit(mulmoScript.beats[0].speaker)); // First speaker
   }
@@ -55,9 +46,6 @@ export const createOrUpdateStudioData = (_mulmoScript: MulmoScript, currentStudi
   mulmoScript.beats.forEach((beat: MulmoBeat, index: number) => {
     // Filling the default values
     studio.script.beats[index] = mulmoBeatSchema.parse(beat);
-    if (!studio.multiLingual[index]) {
-      studio.multiLingual[index] = { multiLingualTexts: {} };
-    }
   });
   return studio;
 };

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -1,5 +1,5 @@
 import { GraphAILogger } from "graphai";
-import { MulmoStudio, MulmoBeat, MulmoScript, mulmoScriptSchema, mulmoBeatSchema, mulmoStudioSchema } from "../types/index.js";
+import { MulmoStudio, MulmoScript, mulmoScriptSchema, mulmoStudioSchema } from "../types/index.js";
 
 const rebuildStudio = (currentStudio: MulmoStudio | undefined, mulmoScript: MulmoScript, fileName: string) => {
   const parsed = mulmoStudioSchema.safeParse(currentStudio);
@@ -52,12 +52,5 @@ export const createOrUpdateStudioData = (_mulmoScript: MulmoScript, currentStudi
 
   studio.script = mulmoScriptSchema.parse(mulmoScript); // update the script
   studio.beats = studio.script.beats.map((_, index) => studio.beats[index] ?? {});
-  mulmoScript.beats.forEach((beat: MulmoBeat, index: number) => {
-    // Filling the default values
-    studio.script.beats[index] = mulmoBeatSchema.parse(beat);
-    if (!studio.multiLingual[index]) {
-      studio.multiLingual[index] = { multiLingualTexts: {} };
-    }
-  });
   return studio;
 };

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -14,7 +14,6 @@ const rebuildStudio = (currentStudio: MulmoStudio | undefined, mulmoScript: Mulm
     script: mulmoScript,
     filename: fileName,
     beats: [...Array(mulmoScript.beats.length)].map(() => ({})),
-    multiLingual: [...Array(mulmoScript.beats.length)].map(() => ({ multiLingualTexts: {} })),
   });
 };
 

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -6,7 +6,6 @@ const buildStudio = (mulmoScript: MulmoScript, fileName: string) => {
     script: mulmoScript,
     filename: fileName,
     beats: [...Array(mulmoScript.beats.length)].map(() => ({})),
-    multiLingual: [...Array(mulmoScript.beats.length)].map(() => ({ multiLingualTexts: {} })),
   });
 };
 
@@ -34,7 +33,9 @@ const mulmoCredit = (speaker: string) => {
 export const createStudioData = (_mulmoScript: MulmoScript, fileName: string) => {
   const mulmoScript = _mulmoScript.__test_invalid__ ? _mulmoScript : mulmoScriptSchema.parse(_mulmoScript); // validate and insert default value
 
+  console.log("***DEBUG4***", mulmoScript);
   const studio: MulmoStudio = buildStudio(mulmoScript, fileName);
+  console.log("***DEBUG5***", studio);
 
   if (mulmoScript.$mulmocast.credit === "closing") {
     mulmoScript.beats.push(mulmoCredit(mulmoScript.beats[0].speaker)); // First speaker

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -32,10 +32,7 @@ const mulmoCredit = (speaker: string) => {
 
 export const createStudioData = (_mulmoScript: MulmoScript, fileName: string) => {
   const mulmoScript = _mulmoScript.__test_invalid__ ? _mulmoScript : mulmoScriptSchema.parse(_mulmoScript); // validate and insert default value
-
-  console.log("***DEBUG4***", mulmoScript);
   const studio: MulmoStudio = buildStudio(mulmoScript, fileName);
-  console.log("***DEBUG5***", studio);
 
   if (mulmoScript.$mulmocast.credit === "closing") {
     mulmoScript.beats.push(mulmoCredit(mulmoScript.beats[0].speaker)); // First speaker

--- a/src/utils/preprocess.ts
+++ b/src/utils/preprocess.ts
@@ -1,4 +1,3 @@
-import { GraphAILogger } from "graphai";
 import { MulmoStudio, MulmoBeat, MulmoScript, mulmoScriptSchema, mulmoBeatSchema, mulmoStudioSchema } from "../types/index.js";
 
 const buildStudio = (mulmoScript: MulmoScript, fileName: string) => {

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -4,7 +4,6 @@ import test from "node:test";
 import { getFileObject } from "../../src/cli/helpers.js";
 import { createOrUpdateStudioData } from "../../src/utils/preprocess.js";
 import { audio, images, movie } from "../../src/actions/index.js";
-import { mulmoScriptSchema } from "mulmocast/lib/types/schema.js";
 
 import path from "path";
 import { fileURLToPath } from "url";

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import { getFileObject } from "../../src/cli/helpers.js";
 import { createOrUpdateStudioData } from "../../src/utils/preprocess.js";
 import { audio, images, movie } from "../../src/actions/index.js";
+import { mulmoScriptSchema } from "mulmocast/lib/types/schema.js";
 
 import path from "path";
 import { fileURLToPath } from "url";
@@ -117,6 +118,7 @@ test("test images", async () => {
       },
     ],
   };
+
   const studio = createOrUpdateStudioData(mulmoScript, fileDirs, "hello");
   const context = {
     studio,
@@ -140,7 +142,7 @@ test("test images", async () => {
       },
     },
     presentationStyle: studio.script,
-    multiLingual: [...Array(mulmoScript.beats.length)].map(() => ({ multiLingualTexts: {} })),
+    multiLingual: [...Array(studio.script.beats.length)].map(() => ({ multiLingualTexts: {} })),
   };
   await audio(context);
   await images(context);

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -140,6 +140,7 @@ test("test images", async () => {
       },
     },
     presentationStyle: studio.script,
+    multiLingual: [...Array(mulmoScript.beats.length)].map(() => ({ multiLingualTexts: {} })),
   };
   await audio(context);
   await images(context);

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -23,6 +23,7 @@ test("test getFileObject", async () => {
     fileName: "hello",
     fileOrUrl: "hello.yaml",
     presentationStylePath: undefined,
+    outputMultilingualFilePath: path.resolve(__dirname, "../../output/hello_lang.json"),
   });
 });
 
@@ -65,7 +66,6 @@ test("test createOrUpdateStudioData", async () => {
     },
     filename: "",
     beats: [{}, {}],
-    multiLingual: [{ multiLingualTexts: {} }, { multiLingualTexts: {} }],
   };
   assert.deepStrictEqual(studio, expect);
 });


### PR DESCRIPTION
multiLingual を MulmoStudio から切り離し、{filename}_lang.json ファイルとして output フォルダに別途セーブするようにしました。
- studio ファイルのセーブロードは廃止していません（audio, images, movie, pdf 間でデータのやり取りをするため）
- multiLingual は beat の挿入削除に対応できていませんが、そこは修正していません。