### PR TITLE
combineAudioFilesAgent refactored

### DIFF
--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -99,12 +99,14 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   ffmpegContext.filterComplex.push(`${inputIds.join("")}concat=n=${inputIds.length}:v=0:a=1[aout]`);
   await FfmpegContextGenerateOutput(ffmpegContext, combinedFileName, ["-map", "[aout]"]);
 
-  return {
+  const result = {
     studio: {
       ...context.studio,
       beats: context.studio.beats.map((studioBeat, index) => ({ ...studioBeat, duration: beatDurations[index] })),
     },
   };
+  context.studio = result.studio; // TODO: removing this breaks test/test_movie.ts
+  return result;
 };
 
 const combineAudioFilesAgentInfo: AgentFunctionInfo = {


### PR DESCRIPTION
combineAudioFilesAgentを扱いやすいようにリファクタリングしました。
1. 非同期処理が必要な処理（audio/movie ファイルの duration の取得）のみ先にPromise.all+mapで並列処理
2. その後の処理はforEachで同期的に行なっています（後に、beatをまたいだ音声をサポートする際に、reduce に変える予定です）
3. studioBeat.duration への代入は途中では行わずに最後にまとめて行なっています。
4. context.studio への update には TODOを付けています。この行がなくても、コマンドラインからの movie は動きますが、context をシェアしている test_movie.ts は失敗します。