### PR TITLE
Overwrap audio

### DIFF
--- a/scripts/test/test_spillover.json
+++ b/scripts/test/test_spillover.json
@@ -5,12 +5,39 @@
   "title": "Spillover Test",
   "beats": [
     {
-      "text": "This is the first beat with a long audio, which exceed the beat duration.",
+      "text": "This beat has a long audio, which exceeds the beat duration.",
       "duration": 2,
       "image": {
         "type": "textSlide",
         "slide": {
-          "title": "This is the first beat."
+          "title": "1. Duration = 2."
+        }
+      }
+    },
+    {
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "2. Default duration = 1. No spillover."
+        }
+      }
+    },
+    {
+      "text": "This beat has a really long audio, which clearly exceeds the beat duration.",
+      "duration": 1,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "3. Duration = 1."
+        }
+      }
+    },
+    {
+      "duration": 2,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "4. Duration = 2."
         }
       }
     },
@@ -19,7 +46,7 @@
       "image": {
         "type": "textSlide",
         "slide": {
-          "title": "This is the second beat."
+          "title": "5. Duration = 1, but no spillover."
         }
       }
     }

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -24,7 +24,6 @@ const getPadding = (context: MulmoStudioContext, beat: MulmoBeat, index: number)
 };
 
 const getTotalPadding = (padding: number, movieDuration: number, audioDuration: number, duration?: number, canSpillover: boolean = false) => {
-  console.log("***DEBUG***", audioDuration, duration, canSpillover);
   if (movieDuration > 0) {
     return padding + (movieDuration - audioDuration);
   } else if (duration && duration > audioDuration) {
@@ -63,11 +62,10 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   const beatDurations: number[] = [];
 
   context.studio.beats.reduce((spillover: number, studioBeat: MulmoStudioBeat, index: number) => {
-    console.log("***DEBUG***", "spillover", index, spillover);
     const beat = context.studio.script.beats[index];
     const { audioDuration, movieDuration } = mediaDurations[index];
     const paddingId = `[padding_${index}]`;
-    const canSpillover = index < context.studio.beats.length - 1 && (mediaDurations[index + 1].movieDuration + mediaDurations[index + 1].audioDuration) === 0;
+    const canSpillover = index < context.studio.beats.length - 1 && mediaDurations[index + 1].movieDuration + mediaDurations[index + 1].audioDuration === 0;
     if (studioBeat.audioFile) {
       const audioId = FfmpegContextInputFormattedAudio(ffmpegContext, studioBeat.audioFile);
       // padding is the amount of audio padding specified in the script.


### PR DESCRIPTION
連続する複数のbeatで音声をシェアすることが可能になりました。
１つ目のbeatでは、textに加えて、durationを指定する必要があります。
２つ目以降のbeatが text を持たなければ、自動的に duration を超えた音声が流れます。
２つ目以降は、durationで指定された時間（defaultは1秒）だけ表示されます。
最後のbeatは、音声が終わるまで表示されます。