### PR TITLE
docs: Clarify -p option accepts file paths for presentation styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,14 +288,16 @@ Positionals:
   file  Mulmo Script File                                    [string] [required]
 
 Options:
-      --version   Show version number                                  [boolean]
-  -v, --verbose   verbose log              [boolean] [required] [default: false]
-  -h, --help      Show help                                            [boolean]
-  -o, --outdir    output dir                                            [string]
-  -b, --basedir   base dir                                              [string]
-  -l, --lang      target language                 [string] [choices: "en", "ja"]
-  -f, --force     Force regenerate                    [boolean] [default: false]
-  -a, --audiodir  Audio output directory                                [string]
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language        [string] [choices: "en", "ja"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+      --dryRun             Dry run                    [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+  -a, --audiodir           Audio output directory                       [string]
 ```
 
 ```
@@ -307,14 +309,16 @@ Positionals:
   file  Mulmo Script File                                    [string] [required]
 
 Options:
-      --version   Show version number                                  [boolean]
-  -v, --verbose   verbose log              [boolean] [required] [default: false]
-  -h, --help      Show help                                            [boolean]
-  -o, --outdir    output dir                                            [string]
-  -b, --basedir   base dir                                              [string]
-  -l, --lang      target language                 [string] [choices: "en", "ja"]
-  -f, --force     Force regenerate                    [boolean] [default: false]
-  -i, --imagedir  Image output directory                                [string]
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language        [string] [choices: "en", "ja"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+      --dryRun             Dry run                    [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+  -i, --imagedir           Image output directory                       [string]
 ```
 
 ```
@@ -326,16 +330,18 @@ Positionals:
   file  Mulmo Script File                                    [string] [required]
 
 Options:
-      --version   Show version number                                  [boolean]
-  -v, --verbose   verbose log              [boolean] [required] [default: false]
-  -h, --help      Show help                                            [boolean]
-  -o, --outdir    output dir                                            [string]
-  -b, --basedir   base dir                                              [string]
-  -l, --lang      target language                 [string] [choices: "en", "ja"]
-  -f, --force     Force regenerate                    [boolean] [default: false]
-  -a, --audiodir  Audio output directory                                [string]
-  -i, --imagedir  Image output directory                                [string]
-  -c, --caption   Video captions                  [string] [choices: "en", "ja"]
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language        [string] [choices: "en", "ja"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+      --dryRun             Dry run                    [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+  -a, --audiodir           Audio output directory                       [string]
+  -i, --imagedir           Image output directory                       [string]
+  -c, --caption            Video captions         [string] [choices: "en", "ja"]
 ```
 
 ```
@@ -347,17 +353,19 @@ Positionals:
   file  Mulmo Script File                                    [string] [required]
 
 Options:
-      --version   Show version number                                  [boolean]
-  -v, --verbose   verbose log              [boolean] [required] [default: false]
-  -h, --help      Show help                                            [boolean]
-  -o, --outdir    output dir                                            [string]
-  -b, --basedir   base dir                                              [string]
-  -l, --lang      target language                 [string] [choices: "en", "ja"]
-  -f, --force     Force regenerate                    [boolean] [default: false]
-  -i, --imagedir  Image output directory                                [string]
-      --pdf_mode  PDF mode
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language        [string] [choices: "en", "ja"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+      --dryRun             Dry run                    [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+  -i, --imagedir           Image output directory                       [string]
+      --pdf_mode           PDF mode
                [string] [choices: "slide", "talk", "handout"] [default: "slide"]
-      --pdf_size  PDF paper size (default: letter)
+      --pdf_size           PDF paper size (default: letter)
                                    [choices: "letter", "a4"] [default: "letter"]
 ```
 

--- a/docs/faq_en.md
+++ b/docs/faq_en.md
@@ -97,3 +97,27 @@ mulmo movie your_script.json -l ja -c ja
 
 - **Audio generation**: `multiLingualTexts.ja.text`
 - **Subtitle generation**: `multiLingualTexts.ja.text`
+
+## Presentation Styles
+
+### Q: How do I use presentation styles with the `-p` option?
+
+**A: The `-p` option accepts file paths to style JSON files. You can download examples or create your own.**
+
+**Getting style files**:
+- Download example styles from [GitHub](https://github.com/receptron/mulmocast-cli/tree/main/assets/styles)
+- Create your own custom style JSON files
+
+**Usage examples**:
+```bash
+# Downloaded style
+mulmo movie script.json -p ./downloaded-styles/ghibli_style.json
+
+# Project-specific style
+mulmo movie script.json -p ./my-project/custom-style.json
+
+# User-wide style
+mulmo movie script.json -p ~/.mulmocast/styles/my-style.json
+```
+
+**Note**: When installing via `npm install -g mulmocast`, style files are not included. You need to download them separately or create your own.

--- a/docs/faq_ja.md
+++ b/docs/faq_ja.md
@@ -97,3 +97,27 @@ mulmo movie your_script.json -l ja -c ja
 
 - **音声生成**: `multiLingualTexts.ja.text`
 - **字幕生成**: `multiLingualTexts.ja.text`
+
+## プレゼンテーションスタイル
+
+### Q: `-p` オプションでプレゼンテーションスタイルを使うにはどうすればよいですか？
+
+**A: `-p` オプションはスタイルJSONファイルへのファイルパスを受け取ります。サンプルをダウンロードするか、独自のスタイルを作成できます。**
+
+**スタイルファイルの入手方法**:
+- [GitHub](https://github.com/receptron/mulmocast-cli/tree/main/assets/styles)からサンプルスタイルをダウンロード
+- 独自のカスタムスタイルJSONファイルを作成
+
+**使用例**:
+```bash
+# ダウンロードしたスタイル
+mulmo movie script.json -p ./downloaded-styles/ghibli_style.json
+
+# プロジェクト固有のスタイル
+mulmo movie script.json -p ./my-project/custom-style.json
+
+# ユーザー共通スタイル
+mulmo movie script.json -p ~/.mulmocast/styles/my-style.json
+```
+
+**注意**: `npm install -g mulmocast`でインストールした場合、スタイルファイルは含まれません。別途ダウンロードするか、独自に作成する必要があります。

--- a/docs/releasenote/index.md
+++ b/docs/releasenote/index.md
@@ -29,7 +29,11 @@ This release focuses on giving creators more control over audio timing while sig
 **MulmoCast CLI v0.0.16** introduces revolutionary presentation customization and major performance improvements, making content creation more flexible and powerful than ever.
 
 - Revolutionary Presentation Style System
-  - **Independent Style Control**: Use the new `-p` option to apply different visual styles to the same content without editing scripts
+  - **Independent Style Control**: Use the new `-p` option with file paths to apply different visual styles to the same content without editing scripts
+    - Download example styles from [GitHub](https://github.com/receptron/mulmocast-cli/tree/main/assets/styles) or **create your own**
+    - Examples:
+      - `-p ./downloaded-styles/style.json`
+      - `-p ./my-project/custom-style.json`
   - **Built-in Anime Templates**: Choose from professional templates inspired by popular anime (Ghibli, AKIRA, One Piece, Ghost in the Shell)
   - **Mix and Match**: Apply any style to any script - create a Ghibli-style business presentation or an AKIRA-style children's story
   - **Simple Templates**: `text_only` and `text_and_image` options for clean, minimalist presentations


### PR DESCRIPTION
  `-p`オプションがファイルパスを受け取る仕様であることを明確化: 
  - docs/releasenote/index.md: v0.0.16の説明にファイルパス使用例を追加
  - docs/faq_*.md: プレゼンテーションスタイルの使い方をFAQに追加
  - README.md: mulmo movie --helpの出力を更新（-pオプション含む）
  - mulmo コマンド利用者には assets/styles/ からダウンロードしていただく旨追加

関連 Issues - #544 
