### PR TITLE
docs: Add TTS configuration and 429 error troubleshooting to FAQ

### DIFF
--- a/docs/faq_en.md
+++ b/docs/faq_en.md
@@ -121,3 +121,65 @@ mulmo movie script.json -p ~/.mulmocast/styles/my-style.json
 ```
 
 **Note**: When installing via `npm install -g mulmocast`, style files are not included. You need to download them separately or create your own.
+
+## Text-to-Speech (TTS) Configuration
+
+### Q: How do I change the TTS engine?
+
+**A: TTS providers can be specified in two ways.**
+
+**Available providers**:
+- `openai` (default)
+- `nijivoice` 
+- `elevenlabs`
+- `google`
+
+#### Method 1: Specify TTS provider globally
+```json
+{
+  "speechParams": {
+    "provider": "elevenlabs",
+    "speakers": {
+      "narrator": {
+        "voiceId": "your-voice-id"
+      }
+    }
+  }
+}
+```
+
+**Reference**: See [test_voices.json](https://github.com/receptron/mulmocast-cli/blob/main/scripts/test/test_voices.json#L7) for concrete configuration examples.
+
+#### Method 2: Specify TTS provider per speaker
+```json
+{
+  "speechParams": {
+    "provider": "openai",
+    "speakers": {
+      "narrator": {
+        "provider": "elevenlabs",
+        "voiceId": "voice-id-1"
+      },
+      "assistant": {
+        "provider": "nijivoice", 
+        "voiceId": "voice-id-2"
+      }
+    }
+  }
+}
+```
+Speaker-specific settings take priority; if not specified, the global setting is used.
+
+**Environment variables setup**:
+When using each provider, set the corresponding API key in your `.env` file. See [Configuration](../README.md#configuration) for details.
+
+## Troubleshooting
+
+### Q: Getting 429 error during image generation
+```
+An unexpected error occurred: RateLimitError: 429 {"message":null,"type":"image_generation_user_error","param":null,"code":null}
+```
+
+**A: This is caused by OpenAI API rate limits. For optimal experience, we recommend upgrading to Tier 2 or higher.**
+
+Since ChatGPT Plus and OpenAI API are separate services, please consider upgrading to a developer plan for API usage. See [OpenAI Usage Tiers](https://platform.openai.com/docs/guides/rate-limits) for details.

--- a/docs/faq_ja.md
+++ b/docs/faq_ja.md
@@ -121,3 +121,65 @@ mulmo movie script.json -p ~/.mulmocast/styles/my-style.json
 ```
 
 **注意**: `npm install -g mulmocast`でインストールした場合、スタイルファイルは含まれません。別途ダウンロードするか、独自に作成する必要があります。
+
+## 音声（TTS）設定
+
+### Q: TTSエンジンを変更するにはどうすればよいですか？
+
+**A: TTSプロバイダーは2つの方法で指定できます。**
+
+**利用可能なプロバイダー**:
+- `openai` (デフォルト)
+- `nijivoice` 
+- `elevenlabs`
+- `google`
+
+#### 方法1: 全体でTTSプロバイダーを指定
+```json
+{
+  "speechParams": {
+    "provider": "elevenlabs",
+    "speakers": {
+      "narrator": {
+        "voiceId": "your-voice-id"
+      }
+    }
+  }
+}
+```
+
+**参考**: [test_voices.json](https://github.com/receptron/mulmocast-cli/blob/main/scripts/test/test_voices.json#L7) で具体的な設定例を確認できます。
+
+#### 方法2: スピーカーごとにTTSプロバイダーを指定
+```json
+{
+  "speechParams": {
+    "provider": "openai",
+    "speakers": {
+      "narrator": {
+        "provider": "elevenlabs",
+        "voiceId": "voice-id-1"
+      },
+      "assistant": {
+        "provider": "nijivoice", 
+        "voiceId": "voice-id-2"
+      }
+    }
+  }
+}
+```
+スピーカー別の設定が優先され、未指定の場合は全体設定が使用されます。
+
+**環境変数の設定**:
+各プロバイダーを使用する場合は、対応するAPIキーを`.env`ファイルに設定してください。詳細は[Configuration](../README.md#configuration)を参照してください。
+
+## トラブルシューティング
+
+### Q: 画像生成で429エラーが発生します
+```
+An unexpected error occurred: RateLimitError: 429 {"message":null,"type":"image_generation_user_error","param":null,"code":null}
+```
+
+**A: OpenAI APIのレート制限によるエラーです。快適にご利用いただくために、Tier 2以上のプランをおすすめします。**
+
+ChatGPT PlusとOpenAI APIは別サービスのため、APIご利用時は開発者向けプランへのアップグレードをご検討ください。詳細は[OpenAI Usage Tiers](https://platform.openai.com/docs/guides/rate-limits)をご参照ください。


### PR DESCRIPTION
FAQに以下を追加：
## TTS設定
- グローバル・スピーカー別の2つの設定方法
- 環境変数設定（README.mdへのリンク）

## トラブルシューティング
- 429エラー（RateLimitError）の対処法