### PR TITLE
enable to loop bgm

### DIFF
--- a/src/agents/add_bgm_agent.ts
+++ b/src/agents/add_bgm_agent.ts
@@ -17,7 +17,7 @@ const addBGMAgent: AgentFunction<{ musicFile: string }, string, { voiceFile: str
   GraphAILogger.log("totalDucation:", speechDuration, totalDuration);
 
   const ffmpegContext = FfmpegContextInit();
-  const musicInputIndex = FfmpegContextAddInput(ffmpegContext, musicFile);
+  const musicInputIndex = FfmpegContextAddInput(ffmpegContext, musicFile, ["-stream_loop", "-1"]);
   const voiceInputIndex = FfmpegContextAddInput(ffmpegContext, voiceFile);
   ffmpegContext.filterComplex.push(
     `[${musicInputIndex}:a]aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo, volume=${context.presentationStyle.audioParams.bgmVolume}[music]`,

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -15,8 +15,12 @@ export const FfmpegContextInit = (): FfmpegContext => {
   };
 };
 
-export const FfmpegContextAddInput = (context: FfmpegContext, input: string) => {
-  context.command.input(input);
+export const FfmpegContextAddInput = (context: FfmpegContext, input: string, inputOptions?: string[]) => {
+  if (inputOptions) {
+    context.command.input(input).inputOptions(inputOptions);
+  } else {
+    context.command.input(input);
+  }
   context.inputCount++;
   return context.inputCount - 1; // returned the index of the input
 };


### PR DESCRIPTION
デフォルトの BGM の長さは4分4秒です。
https://github.com/receptron/mulmocast-media/blob/main/bgms/story002.mp3

これを超える長さの動画を作成すると、BGM終了後ナレーションのみになります。
BGM が ループされるように修正しました。