### PR TITLE
Save html on htmlPromp

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -100,6 +100,11 @@ export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContex
 
 const htmlImageGeneratorAgent = async (namedInputs: { html: string; file: string; canvasSize: MulmoCanvasDimension }) => {
   const { html, file, canvasSize } = namedInputs;
+
+  // Save HTML file
+  const htmlFile = file.replace(/\.[^/.]+$/, ".html");
+  await fs.promises.writeFile(htmlFile, html, "utf8");
+
   await renderHTMLToImage(html, file, canvasSize.width, canvasSize.height);
 };
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -154,7 +154,7 @@ export const htmlImageSystemPrompt = (canvasSize: MulmoCanvasDimension) => {
   return [
     "Based on the provided information, create a single slide HTML page using Tailwind CSS.",
     `The view port size is ${canvasSize.width}x${canvasSize.height}. Make sure the HTML fits within the view port.`,
-    "If charts are needed, use Chart.js to present them in a clean and visually appealing way.",
+    "If charts are needed, use Chart.js to present them in a clean and visually appealing way (with animation:false to disable animation).",
     "Include a balanced mix of comments, graphs, and illustrations to enhance visual impact.",
     "Output only the HTML code. Do not include any comments, explanations, or additional information outside the HTML.",
     "If data is provided, use it effectively to populate the slide.",


### PR DESCRIPTION
htmlPrompt で生成した html ファイルを images フォルダーにセーブするようにしました（主にデバッグ用）。

そのプロセスで見つけた、chart の animation のために、スナップショットが上手く撮れない問題を解決（プロンプトで）。