### PR TITLE
fix: add missing return statement in interactive scripting mode

### DIFF
--- a/src/cli/commands/tool/scripting/handler.ts
+++ b/src/cli/commands/tool/scripting/handler.ts
@@ -54,6 +54,7 @@ export const handler = async (
 
   if (interactive) {
     await createMulmoScriptInteractively(context);
+    return;
   }
   if (inputFile) {
     await createMulmoScriptFromFile(inputFile, context);


### PR DESCRIPTION
`mulmo tool scripting -i` コマンドで MulmoScript 生成後、`/bye` で終了しようとしても以下のプロンプトが表示され、終了できない問題を修正しました。

```
🎉 Script file generated successfully! Type /bye to exit.
writing: /[user's]/mulmocast-cli/output/script-1751350215769.json
✔ You: /bye

● Agent: もし他に質問があれば、いつでもお知らせください。さようなら！


? Enter URLs for scripting references (comma separated):
```

## 修正内容
  `src/cli/commands/tool/scripting/handler.ts` の56行目後に `return` 文を追加：
  ```typescript
  if (interactive) {
    await createMulmoScriptInteractively(context);
    return;  // ← 追加
  }
```

##  テスト
  - mulmo tool scripting -i でスクリプト生成後、/bye で正常に終了することを確認
  - 他のモード（-u、--input-file）への影響がないことを確認
