### PR TITLE
Text2Image models

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -182,6 +182,23 @@ export const mulmoFillOptionSchema = z
   .describe("How to handle aspect ratio differences between image and canvas");
 
 export const text2ImageProviderSchema = z.union([z.literal("openai"), z.literal("google")]).default("openai");
+
+// NOTE: This is for UI only. (until we figure out how to use it in mulmoImageParamsSchema)
+export const mulmoOpenAIImageModelSchema = z
+  .object({
+    provider: z.literal("openai"),
+    model: z.union([z.literal("dall-e-3"), z.literal("gpt-image-1")]).optional(),
+  })
+  .strict();
+
+// NOTE: This is for UI only. (until we figure out how to use it in mulmoImageParamsSchema)
+export const mulmoGoogleImageModelSchema = z
+  .object({
+    provider: z.literal("google"),
+    model: z.union([z.literal("imagen-3.0-fast-generate-001"), z.literal("imagen-3.0-generate-002"), z.literal("imagen-3.0-capability-001")]).optional(),
+  })
+  .strict();
+
 export const mulmoImageParamsSchema = z
   .object({
     provider: text2ImageProviderSchema, // has default value

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -35,6 +35,8 @@ import {
   mulmoChartMediaSchema,
   mediaSourceSchema,
   mulmoSessionStateSchema,
+  mulmoOpenAIImageModelSchema,
+  mulmoGoogleImageModelSchema,
 } from "./schema.js";
 import { pdf_modes, pdf_sizes, storyToScriptGenerateMode } from "../utils/const.js";
 import { LLM } from "../utils/utils.js";
@@ -70,6 +72,8 @@ export type MulmoStudioMultiLingual = z.infer<typeof mulmoStudioMultiLingualSche
 export type MulmoStudioMultiLingualData = z.infer<typeof mulmoStudioMultiLingualDataSchema>;
 export type MultiLingualTexts = z.infer<typeof multiLingualTextsSchema>;
 export type MulmoMovieParams = z.infer<typeof mulmoMovieParamsSchema>;
+export type MulmoOpenAIImageModel = z.infer<typeof mulmoOpenAIImageModelSchema>;
+export type MulmoGoogleImageModel = z.infer<typeof mulmoGoogleImageModelSchema>;
 
 // images
 export type MulmoTextSlideMedia = z.infer<typeof mulmoTextSlideMediaSchema>;


### PR DESCRIPTION
model名を定義したmulmoOpenAIImageModelSchemaとmulmoGoogleImageModelSchemaをスキーマに追加しました。
本来ならば、この二つのユニオンでmulmoImageParamsSchemaを定義したいところですが、providerがオプションであるため、ビルドエラーだらけになってしまうので、ここで止めています。UIでモデルをプルダウンにするには、これで十分かも。