### PR TITLE
update nijivoice id

### DIFF
--- a/assets/templates/ghibli_shorts.json
+++ b/assets/templates/ghibli_shorts.json
@@ -14,7 +14,7 @@
     "speechParams": {
       "provider": "nijivoice",
       "speakers": {
-        "Presenter": { "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62", "speechOptions": { "speed": 1.5 } }
+        "Presenter": { "voiceId": "3708ad43-cace-486c-a4ca-8fe41186e20c", "speechOptions": { "speed": 1.5 } }
       }
     },
     "imageParams": {

--- a/assets/templates/sensei_and_taro.json
+++ b/assets/templates/sensei_and_taro.json
@@ -17,7 +17,7 @@
     "speechParams": {
       "provider": "nijivoice",
       "speakers": {
-        "Announcer": { "displayName": { "ja": "アナウンサー" }, "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62" },
+        "Announcer": { "displayName": { "ja": "アナウンサー" }, "voiceId": "3708ad43-cace-486c-a4ca-8fe41186e20c" },
         "Student": { "displayName": { "ja": "太郎" }, "voiceId": "a7619e48-bf6a-4f9f-843f-40485651257f" },
         "Teacher": { "displayName": { "ja": "先生" }, "voiceId": "bc06c63f-fef6-43b6-92f7-67f919bd5dae" }
       }

--- a/docs/scripts/helloworld.json
+++ b/docs/scripts/helloworld.json
@@ -7,7 +7,7 @@
     "provider": "nijivoice",
     "speakers": {
       "Presenter": {
-        "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62"
+        "voiceId": "3708ad43-cace-486c-a4ca-8fe41186e20c"
       }
     }
   },

--- a/docs/scripts/mulmoscript.yaml
+++ b/docs/scripts/mulmoscript.yaml
@@ -211,7 +211,7 @@ beats:
             "provider": "nijivoice",
             "speakers": {
               "Presenter": {
-                "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62"
+                "voiceId": "3708ad43-cace-486c-a4ca-8fe41186e20c"
               }
             }
           },

--- a/prompts/prompt_taro3_json2.md
+++ b/prompts/prompt_taro3_json2.md
@@ -6,7 +6,7 @@
   "description": "韓国で最近発令された戒厳令とその可能性のある影響について、また日本の憲法に関する考慮事項との類似点を含めた洞察に満ちた議論。",
   "tts": "nijivoice",
   "voices": [
-    "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62",
+    "3708ad43-cace-486c-a4ca-8fe41186e20c",
     "a7619e48-bf6a-4f9f-843f-40485651257f",
     "bc06c63f-fef6-43b6-92f7-67f919bd5dae"
   ],

--- a/scripts/test/test2.json
+++ b/scripts/test/test2.json
@@ -21,9 +21,9 @@
     "speakers": {
       "Announcer": {
         "displayName": {
-          "ja": "春玲"
+          "ja": "千草朋香"
         },
-        "voiceId": "afd7df65-0fdc-4d31-ae8b-a29f0f5eed62"
+        "voiceId": "3708ad43-cace-486c-a4ca-8fe41186e20c"
       },
       "Student": {
         "displayName": {


### PR DESCRIPTION
音声（声優）は同じなのですが、キャラクター画像・名前が変更になりました。
その関係で VoideId が変更になっております。

参考画像（キャラクター部分はマスクしました）
![CleanShot 2025-07-02 at 11 24 35](https://github.com/user-attachments/assets/f0ef8deb-c494-462c-863a-cfba08809184)

名前: 千草 朋香
新Id: 3708ad43-cace-486c-a4ca-8fe41186e20c
キャラクター一覧のURL: https://platform.nijivoice.com/characters

にじボイスの案内URLおよび本文
https://platform.nijivoice.com/info/character-renewal

> 【お知らせ】一部キャラクターのリニューアルについて
> 
> 日頃より「にじボイス」をご利用いただき、誠にありがとうございます。
> この度、「にじボイス」にて公開しておりました一部キャラクターにつきまして、元のイラストが二次利用不可の形式であったことから、今後の展開や活用の柔軟性を考慮し、2025年6月14日にイラストおよび設定を新たに、リニューアルキャラクターとして再構築いたしました。
> なお、音声につきましては、従来どおりご利用いただけます。
> リニューアル前後のキャラクターは、以下一覧にてご確認くださいませ。
> 今後とも「にじボイス」をどうぞよろしくお願いいたします。