### PR TITLE
Voice over

### DIFF
--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -17,7 +17,7 @@
     },
     {
       "speaker": "Presenter",
-      "text": "This is a reference beat.",
+      "text": "This code processes the image.",
       "duration": 0.5,
       "image": {
         "type": "voice_over",

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -29,7 +29,7 @@
       "text": "This code processes the image.",
       "image": {
         "type": "voice_over",
-        "timestamp": 4.0
+        "startAt": 4.0
       }
     },
     {

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -5,6 +5,15 @@
   "title": "Voice Over Test",
   "beats": [
     {
+      "text": "This is the first slide.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "First slide"
+        }
+      }
+    },
+    {
       "speaker": "Presenter",
       "text": "This code processes the audio.",
       "image": {
@@ -25,7 +34,6 @@
     },
     {
       "text": "This is the last slide.",
-      "duration": 0.5,
       "image": {
         "type": "textSlide",
         "slide": {

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -26,10 +26,42 @@
     },
     {
       "speaker": "Presenter",
-      "text": "This code processes the image.",
+      "text": "This code processes the captions.",
       "image": {
         "type": "voice_over",
-        "startAt": 4.0
+        "startAt": 8.0
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This code processes the images.",
+      "image": {
+        "type": "voice_over",
+        "startAt": 14.5
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This code processes the movie.",
+      "image": {
+        "type": "voice_over",
+        "startAt": 21.0
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This code processes the pdf.",
+      "image": {
+        "type": "voice_over",
+        "startAt": 25.0
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This code processes the translation.",
+      "image": {
+        "type": "voice_over",
+        "startAt": 30.0
       }
     },
     {

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -3,6 +3,9 @@
     "version": "1.0"
   },
   "title": "Voice Over Test",
+  "captionParams": {
+    "lang": "en"
+  },
   "beats": [
     {
       "text": "This is the first slide.",

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -20,7 +20,8 @@
       "text": "This is a reference beat.",
       "duration": 0.5,
       "image": {
-        "type": "beat"
+        "type": "voice_over",
+        "timestamp": 4.0
       }
     }
   ]

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -17,7 +17,6 @@
       }
     },
     {
-      "speaker": "Presenter",
       "text": "This code processes the audio.",
       "image": {
         "type": "movie",
@@ -28,7 +27,11 @@
       }
     },
     {
-      "speaker": "Presenter",
+      "image": {
+        "type": "voice_over"
+      }
+    },
+    {
       "text": "This code processes the captions.",
       "image": {
         "type": "voice_over",
@@ -36,7 +39,11 @@
       }
     },
     {
-      "speaker": "Presenter",
+      "image": {
+        "type": "voice_over"
+      }
+    },
+    {
       "text": "This code processes the images.",
       "image": {
         "type": "voice_over",
@@ -44,7 +51,11 @@
       }
     },
     {
-      "speaker": "Presenter",
+      "image": {
+        "type": "voice_over"
+      }
+    },
+    {
       "text": "This code processes the movie.",
       "image": {
         "type": "voice_over",
@@ -52,7 +63,11 @@
       }
     },
     {
-      "speaker": "Presenter",
+      "image": {
+        "type": "voice_over"
+      }
+    },
+    {
       "text": "This code processes the pdf.",
       "image": {
         "type": "voice_over",
@@ -60,11 +75,20 @@
       }
     },
     {
-      "speaker": "Presenter",
+      "image": {
+        "type": "voice_over"
+      }
+    },
+    {
       "text": "This code processes the translation.",
       "image": {
         "type": "voice_over",
         "startAt": 30.0
+      }
+    },
+    {
+      "image": {
+        "type": "voice_over"
       }
     },
     {

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -18,10 +18,19 @@
     {
       "speaker": "Presenter",
       "text": "This code processes the image.",
-      "duration": 0.5,
       "image": {
         "type": "voice_over",
         "timestamp": 4.0
+      }
+    },
+    {
+      "text": "This is the last slide.",
+      "duration": 0.5,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Last slide"
+        }
       }
     }
   ]

--- a/scripts/test/test_voice_over.json
+++ b/scripts/test/test_voice_over.json
@@ -1,0 +1,27 @@
+{
+  "$mulmocast": {
+    "version": "1.0"
+  },
+  "title": "Voice Over Test",
+  "beats": [
+    {
+      "speaker": "Presenter",
+      "text": "This code processes the audio.",
+      "image": {
+        "type": "movie",
+        "source": {
+          "kind": "url",
+          "url": "https://github.com/receptron/mulmocast-media/raw/refs/heads/main/movies/actions.mp4"
+        }
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This is a reference beat.",
+      "duration": 0.5,
+      "image": {
+        "type": "beat"
+      }
+    }
+  ]
+}

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -2,9 +2,10 @@ import { MulmoStudioContext, MulmoBeat, mulmoCaptionParamsSchema } from "../type
 import { GraphAI, GraphAILogger } from "graphai";
 import type { GraphData, CallbackFunction } from "graphai";
 import * as agents from "@graphai/vanilla";
-import { getHTMLFile, getCaptionImagePath } from "../utils/file.js";
+import { getHTMLFile, getCaptionImagePath, getOutputStudioFilePath } from "../utils/file.js";
 import { renderHTMLToImage, interpolate } from "../utils/markdown.js";
 import { MulmoStudioContextMethods, MulmoPresentationStyleMethods } from "../methods/index.js";
+import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 const vanillaAgents = agents.default ?? agents;
 
@@ -12,6 +13,7 @@ const graph_data: GraphData = {
   version: 0.5,
   nodes: {
     context: {},
+    outputStudioFilePath: {},
     map: {
       agent: "mapAgent",
       inputs: { rows: ":context.studio.script.beats", context: ":context" },
@@ -62,6 +64,14 @@ const graph_data: GraphData = {
         },
       },
     },
+    fileWrite: {
+      agent: "fileWriteAgent",
+      inputs: {
+        onComplete: ":map.generateCaption",
+        file: ":outputStudioFilePath",
+        text: ":context.studio.toJSON()",
+      },
+    },
   },
 };
 
@@ -69,14 +79,19 @@ export const captions = async (context: MulmoStudioContext, callbacks?: Callback
   if (MulmoStudioContextMethods.getCaption(context)) {
     try {
       MulmoStudioContextMethods.setSessionState(context, "caption", true);
-      const graph = new GraphAI(graph_data, { ...vanillaAgents });
+      const graph = new GraphAI(graph_data, { ...vanillaAgents, fileWriteAgent });
+      const outDirPath = MulmoStudioContextMethods.getOutDirPath(context);
+      const fileName = MulmoStudioContextMethods.getFileName(context);
+      const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);
       graph.injectValue("context", context);
+      graph.injectValue("outputStudioFilePath", outputStudioFilePath);
       if (callbacks) {
         callbacks.forEach((callback) => {
           graph.registerCallback(callback);
         });
       }
       await graph.run();
+
     } finally {
       MulmoStudioContextMethods.setSessionState(context, "caption", false);
     }

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -91,7 +91,6 @@ export const captions = async (context: MulmoStudioContext, callbacks?: Callback
         });
       }
       await graph.run();
-
     } finally {
       MulmoStudioContextMethods.setSessionState(context, "caption", false);
     }

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -164,6 +164,7 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
     const { videoId, videoPart } = getVideoPart(inputIndex, mediaType, duration, canvasInfo, fillOption, speed);
     ffmpegContext.filterComplex.push(videoPart);
     if (caption && studioBeat.captionFile) {
+      // NOTE: This works for normal beats, but not for voice-over beats.
       const captionInputIndex = FfmpegContextAddInput(ffmpegContext, studioBeat.captionFile);
       const compositeVideoId = `c${index}`;
       ffmpegContext.filterComplex.push(`[${videoId}][${captionInputIndex}:v]overlay=format=auto[${compositeVideoId}]`);

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -163,6 +163,7 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
     const speed = beat.movieParams?.speed ?? 1.0;
     const { videoId, videoPart } = getVideoPart(inputIndex, mediaType, duration, canvasInfo, fillOption, speed);
     ffmpegContext.filterComplex.push(videoPart);
+    /*
     if (caption && studioBeat.captionFile) {
       // NOTE: This works for normal beats, but not for voice-over beats.
       const captionInputIndex = FfmpegContextAddInput(ffmpegContext, studioBeat.captionFile);
@@ -170,8 +171,10 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
       ffmpegContext.filterComplex.push(`[${videoId}][${captionInputIndex}:v]overlay=format=auto[${compositeVideoId}]`);
       filterComplexVideoIds.push(compositeVideoId);
     } else {
-      filterComplexVideoIds.push(videoId);
     }
+    */
+    filterComplexVideoIds.push(videoId);
+
     if (context.presentationStyle.movieParams?.transition && index < context.studio.beats.length - 1) {
       const sourceId = filterComplexVideoIds.pop();
       ffmpegContext.filterComplex.push(`[${sourceId}]split=2[${sourceId}_0][${sourceId}_1]`);
@@ -210,11 +213,10 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
   // Overlay voice-over captions
   const captionedVideoId = (() => {
     const overlays = context.studio.beats.map((studioBeat, index) => {
-      const beat = context.studio.script.beats[index];
       return { index, 
-        captionFile: beat.image?.type === "voice_over" && studioBeat.captionFile,
-        startTime: beatTimestamps[index],
-        duration: studioBeat.duration ?? 0, // HACK: ?? 0 for the TypeSceript compiler
+        captionFile: studioBeat.captionFile,
+        startTime: studioBeat.startAt as number,
+        duration: studioBeat.duration as number,
       };
     }).filter(({ captionFile }) => captionFile);
     if (caption && overlays.length > 0) {

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -207,6 +207,18 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
   const videoIds = filterComplexVideoIds.filter((id) => id !== undefined); // filter out voice-over beats
   ffmpegContext.filterComplex.push(`${videoIds.map((id) => `[${id}]`).join("")}concat=n=${videoIds.length}:v=1:a=0[${concatVideoId}]`);
 
+  // Overlay voice-over captions
+  const captionedVideoId = (() => {
+    const indeces = context.studio.beats.map((studioBeat, index) => {
+      const beat = context.studio.script.beats[index];
+      return { index, hasCaption: !!(beat.image?.type === "voice_over" && studioBeat.captionFile) };
+    }).filter(({ hasCaption }) => hasCaption);
+    if (caption && indeces.length > 0) {
+      console.log("*** indeces", indeces);
+    }
+    return concatVideoId;
+  })();
+
   // Add tranditions if needed
   const mixedVideoId = (() => {
     if (context.presentationStyle.movieParams?.transition && transitionVideoIds.length > 0) {

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -212,19 +212,24 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
 
   // Overlay voice-over captions
   const captionedVideoId = (() => {
-    const overlays = context.studio.beats.map((studioBeat, index) => {
-      return { index, 
-        captionFile: studioBeat.captionFile,
-        startTime: studioBeat.startAt as number,
-        duration: studioBeat.duration as number,
-      };
-    }).filter(({ captionFile }) => captionFile);
+    const overlays = context.studio.beats
+      .map((studioBeat, index) => {
+        return {
+          index,
+          captionFile: studioBeat.captionFile,
+          startTime: (studioBeat.startAt as number) + context.presentationStyle.audioParams.introPadding,
+          duration: studioBeat.duration as number,
+        };
+      })
+      .filter(({ captionFile }) => captionFile);
     if (caption && overlays.length > 0) {
       console.log("*** overlays", overlays);
       return overlays.reduce((acc, overlay) => {
         const captionInputIndex = FfmpegContextAddInput(ffmpegContext, overlay.captionFile as string);
         const compositeVideoId = `oc${overlay.index}`;
-        ffmpegContext.filterComplex.push(`[${acc}][${captionInputIndex}:v]overlay=format=auto:enable='between(t,${overlay.startTime},${overlay.startTime + overlay.duration})'[${compositeVideoId}]`);
+        ffmpegContext.filterComplex.push(
+          `[${acc}][${captionInputIndex}:v]overlay=format=auto:enable='between(t,${overlay.startTime},${overlay.startTime + overlay.duration})'[${compositeVideoId}]`,
+        );
         return compositeVideoId;
       }, concatVideoId);
     }

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -215,13 +215,14 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
     const beatsWithCaptions = context.studio.beats
       .filter(({ captionFile }) => captionFile);
     if (caption && beatsWithCaptions.length > 0) {
+      const introPadding = context.presentationStyle.audioParams.introPadding;
       return beatsWithCaptions.reduce((acc, beat, index) => {
         const { startAt, duration, captionFile } = beat;
         if (startAt !== undefined && duration !== undefined && captionFile !== undefined) {
           const captionInputIndex = FfmpegContextAddInput(ffmpegContext, captionFile);
           const compositeVideoId = `oc${index}`;
           ffmpegContext.filterComplex.push(
-            `[${acc}][${captionInputIndex}:v]overlay=format=auto:enable='between(t,${startAt},${startAt + duration})'[${compositeVideoId}]`,
+            `[${acc}][${captionInputIndex}:v]overlay=format=auto:enable='between(t,${startAt + introPadding},${startAt + duration + introPadding})'[${compositeVideoId}]`,
           );
           return compositeVideoId;
         }

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -223,7 +223,6 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
       })
       .filter(({ captionFile }) => captionFile);
     if (caption && overlays.length > 0) {
-      console.log("*** overlays", overlays);
       return overlays.reduce((acc, overlay) => {
         const captionInputIndex = FfmpegContextAddInput(ffmpegContext, overlay.captionFile as string);
         const compositeVideoId = `oc${overlay.index}`;

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -150,7 +150,9 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
       }
       return 0;
     })();
-    const duration = studioBeat.duration + extraPadding;
+
+    // The movie duration is bigger in case of voice-over.
+    const duration = Math.max(studioBeat.duration + extraPadding, studioBeat.movieDuration ?? 0);
 
     // Get fillOption from merged imageParams (global + beat-specific)
     const globalFillOption = context.presentationStyle.movieParams?.fillOption;

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -212,8 +212,7 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
 
   // Overlay voice-over captions
   const captionedVideoId = (() => {
-    const beatsWithCaptions = context.studio.beats
-      .filter(({ captionFile }) => captionFile);
+    const beatsWithCaptions = context.studio.beats.filter(({ captionFile }) => captionFile);
     if (caption && beatsWithCaptions.length > 0) {
       const introPadding = context.presentationStyle.audioParams.introPadding;
       return beatsWithCaptions.reduce((acc, beat, index) => {

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -220,7 +220,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   };
   result.studio.beats.reduce((acc, beat, index) => {
     beat.startAt = acc;
-    return acc + beat.duration;
+    return acc + beat.duration + beat.silenceDuration;
   }, 0);
   // context.studio = result.studio; // TODO: removing this breaks test/test_movie.ts
   return {

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -218,6 +218,10 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
       })),
     },
   };
+  result.studio.beats.reduce((acc, beat, index) => {
+    beat.startAt = acc;
+    return acc + beat.duration;
+  }, 0);
   // context.studio = result.studio; // TODO: removing this breaks test/test_movie.ts
   return {
     ...context,

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -198,7 +198,13 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   const result = {
     studio: {
       ...context.studio,
-      beats: context.studio.beats.map((studioBeat, index) => ({ ...studioBeat, duration: beatDurations[index] })),
+      beats: context.studio.beats.map((studioBeat, index) => ({
+        ...studioBeat,
+        duration: beatDurations[index],
+        audioDuration: mediaDurations[index].audioDuration,
+        movieDuration: mediaDurations[index].movieDuration,
+        silenceDuration: mediaDurations[index].silenceDuration,
+      })),
     },
   };
   // context.studio = result.studio; // TODO: removing this breaks test/test_movie.ts

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -98,7 +98,10 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
         group.reduce((remaining, idx, iGroup) => {
           const subBeat = context.studio.script.beats[idx];
           const subBeatDurations = mediaDurations[idx];
-          userAssert(subBeatDurations.audioDuration <= remaining, `subBeatDurations.audioDuration(${subBeatDurations.audioDuration}) > remaining(${remaining})`);
+          userAssert(
+            subBeatDurations.audioDuration <= remaining,
+            `subBeatDurations.audioDuration(${subBeatDurations.audioDuration}) > remaining(${remaining})`,
+          );
           if (iGroup === group.length - 1) {
             beatDurations.push(subBeatDurations.audioDuration);
             subBeatDurations.silenceDuration = remaining - subBeatDurations.audioDuration;

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -96,7 +96,6 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
       }
       if (group.length > 1) {
         group.reduce((remaining, idx, iGroup) => {
-          const subBeat = context.studio.script.beats[idx];
           const subBeatDurations = mediaDurations[idx];
           userAssert(
             subBeatDurations.audioDuration <= remaining,

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -218,7 +218,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
       })),
     },
   };
-  result.studio.beats.reduce((acc, beat, index) => {
+  result.studio.beats.reduce((acc, beat) => {
     beat.startAt = acc;
     return acc + beat.duration + beat.silenceDuration;
   }, 0);

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -108,6 +108,15 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
             return 0;
           }
           beatDurations.push(subBeatDurations.audioDuration);
+          const nextBeat = context.studio.script.beats[idx + 1];
+          assert(nextBeat.image?.type === "voice_over", "nextBeat.image.type !== voice_over");
+          const voiceStartAt = nextBeat.image?.startAt;
+          if (voiceStartAt) {
+            const remainingDuration = movieDuration - voiceStartAt;
+            userAssert(remainingDuration <= remaining, `remainingDuration(${remainingDuration}) > remaining(${remaining})`);
+            subBeatDurations.silenceDuration = remaining - remainingDuration;
+            return remainingDuration;
+          }
           return remaining - subBeatDurations.audioDuration;
         }, movieDuration);
         return;

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -81,7 +81,13 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   const beatDurations: number[] = [];
 
   context.studio.script.beats.forEach((beat: MulmoBeat, index: number) => {
+    if (beatDurations.length > index) {
+      // The current beat has already been processed.
+      return;
+    }
+    assert(beatDurations.length === index, "beatDurations.length !== index");
     const { audioDuration, movieDuration } = mediaDurations[index];
+    
     // Check if the current beat has media and the next beat does not have media.
     if (audioDuration > 0) {
       // Check if the current beat has spilled over audio.
@@ -124,16 +130,14 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
       }
     } else if (movieDuration > 0) {
       // This beat has only a movie, not audio.
-      assert(beatDurations.length === index, "beatDurations.length !== index");
       beatDurations.push(movieDuration);
       mediaDurations[index].silenceDuration = movieDuration;
-    } else if (beatDurations.length === index) {
+    } else {
       // The current beat has no audio, nor no spilled over audio
       const beatDuration = beat.duration ?? (movieDuration > 0 ? movieDuration : 1.0);
       beatDurations.push(beatDuration);
       mediaDurations[index].silenceDuration = beatDuration;
     }
-    // else { Skip this beat if the duration has been already added as a group }
   });
   assert(beatDurations.length === context.studio.beats.length, "beatDurations.length !== studio.beats.length");
 

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -87,7 +87,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
     }
     assert(beatDurations.length === index, "beatDurations.length !== index");
     const { audioDuration, movieDuration } = mediaDurations[index];
-    
+
     // Check if the current beat has media and the next beat does not have media.
     if (audioDuration > 0) {
       // Check if the current beat has spilled over audio.

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -101,7 +101,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
           userAssert(subBeatDurations.audioDuration <= remaining, `subBeatDurations.audioDuration(${subBeatDurations.audioDuration}) > remaining(${remaining})`);
           if (iGroup === group.length - 1) {
             beatDurations.push(subBeatDurations.audioDuration);
-            subBeatDurations.silenceDuration = remaining;
+            subBeatDurations.silenceDuration = remaining - subBeatDurations.audioDuration;
             return 0;
           }
           beatDurations.push(subBeatDurations.audioDuration);

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -113,8 +113,8 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
           const voiceStartAt = nextBeat.image?.startAt;
           if (voiceStartAt) {
             const remainingDuration = movieDuration - voiceStartAt;
-            userAssert(remainingDuration <= remaining, `remainingDuration(${remainingDuration}) > remaining(${remaining})`);
-            subBeatDurations.silenceDuration = remaining - remainingDuration;
+            subBeatDurations.silenceDuration = remaining - remainingDuration - subBeatDurations.audioDuration;
+            userAssert(subBeatDurations.silenceDuration >= 0, `subBeatDurations.silenceDuration(${subBeatDurations.silenceDuration}) < 0`);
             return remainingDuration;
           }
           return remaining - subBeatDurations.audioDuration;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -387,6 +387,7 @@ export const mulmoStudioBeatSchema = z
   .object({
     hash: z.string().optional(),
     duration: z.number().optional(),
+    startAt: z.number().optional(),
     audioDuration: z.number().optional(),
     movieDuration: z.number().optional(),
     silenceDuration: z.number().optional(),

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -143,7 +143,7 @@ export const mulmoBeatReferenceMediaSchema = z
 export const mulmoVoiceOverMediaSchema = z
   .object({
     type: z.literal("voice_over"),
-    timestamp: z.number().describe("The timestamp of the voice over in seconds."),
+    startAt: z.number().describe("The time to start the voice over the video in seconds."),
   })
   .strict();
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -143,7 +143,7 @@ export const mulmoBeatReferenceMediaSchema = z
 export const mulmoVoiceOverMediaSchema = z
   .object({
     type: z.literal("voice_over"),
-    startAt: z.number().describe("The time to start the voice over the video in seconds."),
+    startAt: z.number().optional().describe("The time to start the voice over the video in seconds."),
   })
   .strict();
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -140,6 +140,13 @@ export const mulmoBeatReferenceMediaSchema = z
   })
   .strict();
 
+export const mulmoVoiceOverMediaSchema = z
+  .object({
+    type: z.literal("voice_over"),
+    timestamp: z.number().describe("The timestamp of the voice over in seconds."),
+  })
+  .strict();
+
 export const mulmoImageAssetSchema = z.union([
   mulmoMarkdownMediaSchema,
   mulmoWebMediaSchema,
@@ -154,6 +161,7 @@ export const mulmoImageAssetSchema = z.union([
   mulmoMermaidMediaSchema,
   mulmoHtmlTailwindMediaSchema,
   mulmoBeatReferenceMediaSchema,
+  mulmoVoiceOverMediaSchema,
 ]);
 
 const mulmoAudioMediaSchema = z

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -387,6 +387,9 @@ export const mulmoStudioBeatSchema = z
   .object({
     hash: z.string().optional(),
     duration: z.number().optional(),
+    audioDuration: z.number().optional(),
+    movieDuration: z.number().optional(),
+    silenceDuration: z.number().optional(),
     audioFile: z.string().optional(),
     imageFile: z.string().optional(), // path to the image
     movieFile: z.string().optional(), // path to the movie file

--- a/src/utils/image_plugins/index.ts
+++ b/src/utils/image_plugins/index.ts
@@ -6,8 +6,9 @@ import * as pluginHtmlTailwind from "./html_tailwind.js";
 import * as pluginImage from "./image.js";
 import * as pluginMovie from "./movie.js";
 import * as pluginBeat from "./beat.js";
+import * as pluginVoiceOver from "./voice_over.js";
 
-const imagePlugins = [pluginTextSlide, pluginMarkdown, pluginImage, pluginChart, pluginMermaid, pluginMovie, pluginHtmlTailwind, pluginBeat];
+const imagePlugins = [pluginTextSlide, pluginMarkdown, pluginImage, pluginChart, pluginMermaid, pluginMovie, pluginHtmlTailwind, pluginBeat, pluginVoiceOver];
 
 export const findImagePlugin = (imageType?: string) => {
   return imagePlugins.find((plugin) => plugin.imageType === imageType);

--- a/src/utils/image_plugins/voice_over.ts
+++ b/src/utils/image_plugins/voice_over.ts
@@ -1,0 +1,13 @@
+import { ImageProcessorParams } from "../../types/index.js";
+
+export const imageType = "voice_over";
+
+export const processBeatReference = async (__: ImageProcessorParams) => {
+  // For voice-over, return undefined to indicate no image should be generated
+  return undefined;
+};
+
+export const process = processBeatReference;
+export const path = (__: ImageProcessorParams) => {
+  return undefined;
+};


### PR DESCRIPTION
既存のビデオにボイス・オーバー（ナレーションを重ねること）を可能にする変更です。
- beat image に type="voice_over" を追加しました。これを使うと、一つのbeatに紐づいた映像に複数のbeatの音声・キャプション重ねることが可能になります。
- オプションで startAt で映像のどの時点に重ねるかを指定出来ます。
- これを可能にするために、captionの表示の仕方を変更しました。
- デバッグ用に caption 処理後の studio もセーブするようにしました。
- studio beat にタイミング関連のプロパティを複数追加しました（audioDuration, movieDuration, startAt など）。