### PR TITLE
docs: Add deep research documentation to README and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key
 BROWSERLESS_API_TOKEN=your_browserless_api_token # to access web in mulmo tool
 ```
 
+#### (Optional) for deep search (experimental)
+```bash
+TAVILY_API_KEY=your_tavily_api_key # for AI-powered deep search research
+# Usage: yarn run deep_research
+```
+
 ## Workflow
 
 1. Create a MulmoScript JSON file with `mulmo tool scripting`

--- a/docs/releasenote/index.md
+++ b/docs/releasenote/index.md
@@ -260,6 +260,7 @@ This release focuses on giving creators more control over audio timing while sig
 
 - Deep Search (Experimental)
   - **AI-Powered Research**: Proof-of-concept feature using web search and reflection agents to enhance content research during script generation
+  - **Usage**: `yarn run deep_research` (requires `TAVILY_API_KEY`)
 
 - Others
   - **Translation Bug Fix**: Fixed critical typo that would have broken translation functionality completely


### PR DESCRIPTION
#481 deep research コマンドについて記載を失念していました。

  - README.md: TAVILY_API_KEYの設定方法と`yarn run deep_research`の使用方法を記載
  - docs/releasenote/index.md: v0.0.16のDeep Search機能に使用方法を追加