### PR TITLE
docs: Update ghibli_shorts template title for clarity

### DIFF
--- a/assets/templates/ghibli_shorts.json
+++ b/assets/templates/ghibli_shorts.json
@@ -1,5 +1,5 @@
 {
-  "title": "Ghibli comic style",
+  "title": "Ghibli style for YouTube Shorts",
   "description": "Template for Ghibli-style comic presentation.",
   "systemPrompt": "Generate a Japanese script for a Youtube shorts of the given topic. Another AI will generate comic strips for each beat based on the text description of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
   "presentationStyle": {


### PR DESCRIPTION
assets/templates/ghibli_comic.json

と同じ title のため変更します。

![CleanShot 2025-07-05 at 16 38 44](https://github.com/user-attachments/assets/1a92bab2-7378-44f5-b307-3d5578ba8005)
