### PR TITLE
htmlPrompt: Cache html

### DIFF
--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -96,7 +96,6 @@ export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContex
 
 const htmlImageGeneratorAgent = async (namedInputs: { file: string; canvasSize: MulmoCanvasDimension; htmlText: string }) => {
   const {file, canvasSize, htmlText } = namedInputs;
-  console.log("***DEBUG***", htmlText);
   await renderHTMLToImage(htmlText, file, canvasSize.width, canvasSize.height);
 };
 
@@ -144,7 +143,7 @@ const beat_graph_data = {
         file: ":preprocessor.htmlPath", // only for fileCacheAgentFilter
         mulmoContext: ":context", // for fileCacheAgentFilter
         index: ":__mapIndex", // for fileCacheAgentFilter
-        sessionType: "image", // for fileCacheAgentFilter
+        sessionType: "html", // for fileCacheAgentFilter
       }
     },
     htmlReader: {

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -137,6 +137,10 @@ const beat_graph_data = {
       if: ":preprocessor.htmlPrompt",
       defaultValue: {},
       agent: ":htmlImageAgentInfo.agent",
+      console: {
+        before: true,
+        after: true,
+      },
       inputs: {
         prompt: ":preprocessor.htmlPrompt",
         system: ":preprocessor.htmlImageSystemPrompt",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -145,13 +145,16 @@ const beat_graph_data = {
           max_tokens: ":htmlImageAgentInfo.max_tokens",
         },
       },
+      output: {
+        htmlText: ".text.codeBlockOrRaw()",
+      },
     },
     htmlImageGenerator: {
       if: ":preprocessor.htmlPrompt",
       defaultValue: {},
       agent: htmlImageGeneratorAgent,
       inputs: {
-        html: ":htmlImageAgent.text.codeBlockOrRaw()",
+        html: ":htmlImageAgent.htmlText",
         htmlPath: ":preprocessor.htmlPath",
         canvasSize: ":context.presentationStyle.canvasSize",
         file: ":preprocessor.imagePath", // only for fileCacheAgentFilter

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -94,12 +94,9 @@ export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContex
   }
 };
 
-const htmlImageGeneratorAgent = async (namedInputs: { html: string; file: string; canvasSize: MulmoCanvasDimension; htmlPath: string }) => {
-  const { html, file, canvasSize, htmlPath } = namedInputs;
-
-  // Save HTML file
-  await fs.promises.writeFile(htmlPath, html, "utf8");
-
+const htmlImageGeneratorAgent = async (namedInputs: { file: string; canvasSize: MulmoCanvasDimension; htmlPath: string }) => {
+  const {file, canvasSize, htmlPath } = namedInputs;
+  const html = await fs.promises.readFile(htmlPath, "utf8");
   await renderHTMLToImage(html, file, canvasSize.width, canvasSize.height);
 };
 
@@ -150,7 +147,7 @@ const beat_graph_data = {
         sessionType: "image", // for fileCacheAgentFilter
       },
       output: {
-        htmlText: ".text.codeBlockOrRaw()",
+        foo: ".text.codeBlockOrRaw()",
       },
     },
     htmlImageGenerator: {
@@ -158,7 +155,7 @@ const beat_graph_data = {
       defaultValue: {},
       agent: htmlImageGeneratorAgent,
       inputs: {
-        html: ":htmlImageAgent.htmlText",
+        onComplete: ":htmlImageAgent", // to wait for htmlImageAgent to finish
         htmlPath: ":preprocessor.htmlPath",
         canvasSize: ":context.presentationStyle.canvasSize",
         file: ":preprocessor.imagePath", // only for fileCacheAgentFilter
@@ -324,7 +321,7 @@ const graphOption = async (context: MulmoStudioContext, settings?: Record<string
     {
       name: "fileCacheAgentFilter",
       agent: fileCacheAgentFilter,
-      nodeIds: ["imageGenerator", "movieGenerator", "htmlImageGenerator"],
+      nodeIds: ["imageGenerator", "movieGenerator", "htmlImageGenerator", "htmlImageAgent"],
     },
   ];
 

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -144,6 +144,10 @@ const beat_graph_data = {
           model: ":htmlImageAgentInfo.model",
           max_tokens: ":htmlImageAgentInfo.max_tokens",
         },
+        file: ":preprocessor.htmlPath", // only for fileCacheAgentFilter
+        mulmoContext: ":context", // for fileCacheAgentFilter
+        index: ":__mapIndex", // for fileCacheAgentFilter
+        sessionType: "image", // for fileCacheAgentFilter
       },
       output: {
         htmlText: ".text.codeBlockOrRaw()",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -95,7 +95,7 @@ export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContex
 };
 
 const htmlImageGeneratorAgent = async (namedInputs: { file: string; canvasSize: MulmoCanvasDimension; htmlText: string }) => {
-  const {file, canvasSize, htmlText } = namedInputs;
+  const { file, canvasSize, htmlText } = namedInputs;
   await renderHTMLToImage(htmlText, file, canvasSize.width, canvasSize.height);
 };
 
@@ -144,7 +144,7 @@ const beat_graph_data = {
         mulmoContext: ":context", // for fileCacheAgentFilter
         index: ":__mapIndex", // for fileCacheAgentFilter
         sessionType: "html", // for fileCacheAgentFilter
-      }
+      },
     },
     htmlReader: {
       if: ":preprocessor.htmlPrompt",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -137,10 +137,6 @@ const beat_graph_data = {
       if: ":preprocessor.htmlPrompt",
       defaultValue: {},
       agent: ":htmlImageAgentInfo.agent",
-      console: {
-        before: true,
-        after: true,
-      },
       inputs: {
         prompt: ":preprocessor.htmlPrompt",
         system: ":preprocessor.htmlImageSystemPrompt",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -159,6 +159,7 @@ const beat_graph_data = {
       output: {
         htmlText: ".html.codeBlockOrRaw()",
       },
+      defaultValue: {},
     },
     htmlImageGenerator: {
       if: ":preprocessor.htmlPrompt",

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -435,6 +435,7 @@ export const mulmoSessionStateSchema = z.object({
     movie: z.record(z.number().int(), z.boolean()),
     multiLingual: z.record(z.number().int(), z.boolean()),
     caption: z.record(z.number().int(), z.boolean()),
+    html: z.record(z.number().int(), z.boolean()),
   }),
 });
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -146,7 +146,7 @@ export type BeatMediaType = "movie" | "image";
 export type StoryToScriptGenerateMode = (typeof storyToScriptGenerateMode)[keyof typeof storyToScriptGenerateMode];
 
 export type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "pdf";
-export type BeatSessionType = "audio" | "image" | "multiLingual" | "caption" | "movie";
+export type BeatSessionType = "audio" | "image" | "multiLingual" | "caption" | "movie" | "html";
 
 export type SessionProgressEvent =
   | { kind: "session"; sessionType: SessionType; inSession: boolean }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -64,6 +64,7 @@ const initSessionState = () => {
       movie: {},
       multiLingual: {},
       caption: {},
+      html: {},
     },
   };
 };

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -30,15 +30,15 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   }
   try {
     MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, true);
-    const output = (await next(context)) as { buffer?: Buffer, text?: string } || undefined;
-    const { buffer, text } = output ?? {};
+    const output = (await next(context)) as { buffer?: Buffer, htmlText?: string } || undefined;
+    const { buffer, htmlText } = output ?? {};
     if (buffer) {
       writingMessage(file);
       await fsPromise.writeFile(file, buffer);
       return true;
-    } else if (text) {
+    } else if (htmlText) {
       writingMessage(file);
-      await fsPromise.writeFile(file, text, "utf-8");
+      await fsPromise.writeFile(file, htmlText, "utf-8");
       return true;
     }
     GraphAILogger.log("no cache, no buffer: " + file);

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -30,11 +30,15 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   }
   try {
     MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, true);
-    const output = (await next(context)) as { buffer: Buffer };
-    const buffer = output ? output["buffer"] : undefined;
+    const output = (await next(context)) as { buffer?: Buffer, text?: string } || undefined;
+    const { buffer, text } = output ?? {};
     if (buffer) {
       writingMessage(file);
       await fsPromise.writeFile(file, buffer);
+      return true;
+    } else if (text) {
+      writingMessage(file);
+      await fsPromise.writeFile(file, text, "utf-8");
       return true;
     }
     GraphAILogger.log("no cache, no buffer: " + file);

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -30,7 +30,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   }
   try {
     MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, true);
-    const output = (await next(context)) as { buffer?: Buffer, text?: string } || undefined;
+    const output = ((await next(context)) as { buffer?: Buffer; text?: string }) || undefined;
     const { buffer, text } = output ?? {};
     if (buffer) {
       writingMessage(file);

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -30,15 +30,15 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   }
   try {
     MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, true);
-    const output = (await next(context)) as { buffer?: Buffer, htmlText?: string } || undefined;
-    const { buffer, htmlText } = output ?? {};
+    const output = (await next(context)) as { buffer?: Buffer, text?: string } || undefined;
+    const { buffer, text } = output ?? {};
     if (buffer) {
       writingMessage(file);
       await fsPromise.writeFile(file, buffer);
       return true;
-    } else if (htmlText) {
+    } else if (text) {
       writingMessage(file);
-      await fsPromise.writeFile(file, htmlText, "utf-8");
+      await fsPromise.writeFile(file, text, "utf-8");
       return true;
     }
     GraphAILogger.log("no cache, no buffer: " + file);

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -25,7 +25,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
   };
 
   if (await shouldUseCache()) {
-    GraphAILogger.debug("cache");
+    GraphAILogger.debug(`cache: ${path.basename(file)}`);
     return true;
   }
   try {

--- a/test/actions/run_audio.ts
+++ b/test/actions/run_audio.ts
@@ -123,6 +123,7 @@ const getContext = () => {
         movie: {},
         multiLingual: {},
         caption: {},
+        html: {},
       },
     },
     presentationStyle: studio.script,

--- a/test/actions/test_image_preprocess_agent.ts
+++ b/test/actions/test_image_preprocess_agent.ts
@@ -56,6 +56,7 @@ const createMockContext = (): MulmoStudioContext => ({
       movie: {},
       multiLingual: {},
       caption: {},
+      html: {},
     },
   },
 });

--- a/test/actions/test_images.ts
+++ b/test/actions/test_images.ts
@@ -125,6 +125,7 @@ const getContext = () => {
         movie: {},
         multiLingual: {},
         caption: {},
+        html: {},
       },
     },
     presentationStyle: studio.script,

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-test("test images", async () => {
+test("test images and movie", async () => {
   // const fileDirs = getFileObject({ file: "hello.yaml", basedir: __dirname });
   const fileDirs = getFileObject({ file: "hello.yaml" });
 
@@ -138,6 +138,7 @@ test("test images", async () => {
         movie: {},
         multiLingual: {},
         caption: {},
+        html: {},
       },
     },
     presentationStyle: studio.script,


### PR DESCRIPTION
htmlPrompt の際に、imageが既に生成されているのに、htmlの生成が毎回されている問題があったので、解決しました。
- filterCacheAgentFilter は、imageに加えてtext もキャッシュするように変更しました。
- htmlImageGenerator に上のフィルターをつけて、textをキャッシュするようにしました。
- codeBlockOrRaw をキャッシュ後にかけるために、htmlReader ノードを付け加えました。
- inBeatSession に "html" (htmlの生成中）を追加しました。