### PR TITLE
image generation of reference images

### DIFF
--- a/scripts/test/test_image_refs.json
+++ b/scripts/test/test_image_refs.json
@@ -13,14 +13,14 @@
       "cat": {
         "type": "imagePrompt",
         "prompt": "A tiny black cat with a green eyes"
+      },
+      "bloom": {
+        "type": "imagePrompt",
+        "prompt": "A yellow, old broomstick"
       }
     }
   },
   "beats": [
-    {
-      "text": "Hello World with all reference images",
-      "imagePrompt": "Saying hello to the world"
-    },
     {
       "text": "Hello World with a witch",
       "imagePrompt": "Saying hello to the world",
@@ -30,6 +30,15 @@
       "text": "Hello World with a cat",
       "imagePrompt": "Saying hello to the world",
       "imageNames": ["cat"]
+    },
+    {
+      "text": "Hello World with a witch and a cat",
+      "imagePrompt": "Saying hello to the world",
+      "imageNames": ["witch", "cat"]
+    },
+    {
+      "text": "Hello World with all reference images",
+      "imagePrompt": "Saying hello to the world"
     },
     {
       "text": "Hello World with no reference image",

--- a/scripts/test/test_image_refs.json
+++ b/scripts/test/test_image_refs.json
@@ -14,7 +14,7 @@
         "type": "imagePrompt",
         "prompt": "A tiny black cat with a green eyes"
       },
-      "bloom": {
+      "broom": {
         "type": "imagePrompt",
         "prompt": "A yellow, old broomstick"
       }
@@ -22,12 +22,12 @@
   },
   "beats": [
     {
-      "text": "Hello World with a witch",
+      "text": "Hello World with a witch and a broom",
       "imagePrompt": "Saying hello to the world",
-      "imageNames": ["witch"]
+      "imageNames": ["witch", "broom"]
     },
     {
-      "text": "Hello World with a cat",
+      "text": "Hello World with a cat alone",
       "imagePrompt": "Saying hello to the world",
       "imageNames": ["cat"]
     },

--- a/scripts/test/test_image_refs.json
+++ b/scripts/test/test_image_refs.json
@@ -18,7 +18,7 @@
   },
   "beats": [
     {
-      "text": "Hello World",
+      "text": "Hello World with all reference images",
       "imagePrompt": "Saying hello to the world"
     },
     {
@@ -32,7 +32,7 @@
       "imageNames": ["cat"]
     },
     {
-      "text": "Hello World with reference images",
+      "text": "Hello World with no reference image",
       "imagePrompt": "Saying hello to the world",
       "imageNames": []
     }

--- a/scripts/test/test_image_refs.json
+++ b/scripts/test/test_image_refs.json
@@ -6,9 +6,13 @@
   "imageParams": {
     "style": "Ghibli-style",
     "images": {
-      "girl": {
+      "witch": {
         "type": "imagePrompt",
-        "prompt": "A girl with a green hair, wearing a red T-shirt"
+        "prompt": "A witch with a green hair, wearing a black robe"
+      },
+      "cat": {
+        "type": "imagePrompt",
+        "prompt": "A tiny black cat with a green eyes"
       }
     }
   },
@@ -16,6 +20,21 @@
     {
       "text": "Hello World",
       "imagePrompt": "Saying hello to the world"
+    },
+    {
+      "text": "Hello World with a witch",
+      "imagePrompt": "Saying hello to the world",
+      "imageNames": ["witch"]
+    },
+    {
+      "text": "Hello World with a cat",
+      "imagePrompt": "Saying hello to the world",
+      "imageNames": ["cat"]
+    },
+    {
+      "text": "Hello World with reference images",
+      "imagePrompt": "Saying hello to the world",
+      "imageNames": []
     }
   ]
 }

--- a/scripts/test/test_image_refs.json
+++ b/scripts/test/test_image_refs.json
@@ -1,0 +1,21 @@
+{
+  "$mulmocast": {
+    "version": "1.0"
+  },
+  "title": "Test Image References",
+  "imageParams": {
+    "style": "Ghibli-style",
+    "images": {
+      "girl": {
+        "type": "imagePrompt",
+        "prompt": "A girl with a green hair, wearing a red T-shirt"
+      }
+    }
+  },
+  "beats": [
+    {
+      "text": "Hello World",
+      "imagePrompt": "Saying hello to the world"
+    }
+  ]
+}

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -367,8 +367,8 @@ const graphOption = async (context: MulmoStudioContext, settings?: Record<string
 export const generateReferenceImage = async (context: MulmoStudioContext, key: string, image: MulmoImagePromptMedia, force: boolean = false) => {
   const imagePath = getReferenceImagePath(context, key, "png");
   // generate image
-  const prompt = `${image.prompt}\n${context.presentationStyle.imageParams?.style || ""}`;
   const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(context.presentationStyle);
+  const prompt = `${image.prompt}\n${imageAgentInfo.imageParams.style || ""}`;
   const graph_data = {
     version: 0.5,
     nodes: {
@@ -383,6 +383,7 @@ export const generateReferenceImage = async (context: MulmoStudioContext, key: s
           index: -1, // for fileCacheAgentFilter
           sessionType: "image", // for fileCacheAgentFilter
           params: {
+            model: imageAgentInfo.imageParams.model,
             canvasSize: context.presentationStyle.canvasSize,
           },
         },

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -392,15 +392,14 @@ export const generateReferenceImage = async (context: MulmoStudioContext, key: s
     },
   };
 
-  const options: GraphOptions = {
-    agentFilters: [
-      {
-        name: "fileCacheAgentFilter",
-        agent: fileCacheAgentFilter,
-        nodeIds: ["imageGenerator"],
-      },
-    ],
-  };
+  const options = await graphOption(context);
+  options.agentFilters = [
+    {
+      name: "fileCacheAgentFilter",
+      agent: fileCacheAgentFilter,
+      nodeIds: ["imageGenerator"],
+    },
+  ];
 
   const graph = new GraphAI(graph_data, { imageGoogleAgent, imageOpenaiAgent }, options);
   await graph.run<{ output: MulmoStudioBeat[] }>();

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -365,7 +365,6 @@ const graphOption = async (context: MulmoStudioContext, settings?: Record<string
 };
 
 // Application may call this functoin directly to generate reference image.
-// NOTE: index is the index of the image reference sorted by key.
 export const generateReferenceImage = async (context: MulmoStudioContext, key: string, index: number, image: MulmoImagePromptMedia, force: boolean = false) => {
   const imagePath = getReferenceImagePath(context, key, "png");
   // generate image
@@ -382,8 +381,8 @@ export const generateReferenceImage = async (context: MulmoStudioContext, key: s
           file: imagePath, // only for fileCacheAgentFilter
           force, // only for fileCacheAgentFilter
           mulmoContext: context, // for fileCacheAgentFilter
-          index: -(index + 1), // for fileCacheAgentFilter
-          sessionType: "image", // for fileCacheAgentFilter
+          index: index, // for fileCacheAgentFilter
+          sessionType: "imageReference", // for fileCacheAgentFilter
           params: {
             model: imageAgentInfo.imageParams.model,
             canvasSize: context.presentationStyle.canvasSize,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -368,7 +368,6 @@ export const generateReferenceImage = async (context: MulmoStudioContext, key: s
   const imagePath = getReferenceImagePath(context, key, "png");
   // generate image
   const prompt = `${image.prompt}\n${context.presentationStyle.imageParams?.style || ""}`;
-  console.log("***DEBUG***: generating reference image", prompt);
   const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(context.presentationStyle);
   const graph_data = {
     version: 0.5,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -1,7 +1,7 @@
 import dotenv from "dotenv";
 import fs from "fs";
 import { GraphAI, GraphAILogger, TaskManager } from "graphai";
-import type { GraphOptions, GraphData, CallbackFunction, AgentFunctionInfo } from "graphai";
+import type { GraphOptions, GraphData, CallbackFunction } from "graphai";
 import * as agents from "@graphai/vanilla";
 import { openAIAgent } from "@graphai/openai_agent";
 import { anthropicAgent } from "@graphai/anthropic_agent";

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -365,6 +365,7 @@ const graphOption = async (context: MulmoStudioContext, settings?: Record<string
 };
 
 // Application may call this functoin directly to generate reference image.
+// NOTE: index is the index of the image reference sorted by key.
 export const generateReferenceImage = async (context: MulmoStudioContext, key: string, index: number, image: MulmoImagePromptMedia, force: boolean = false) => {
   const imagePath = getReferenceImagePath(context, key, "png");
   // generate image

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -393,14 +393,6 @@ export const generateReferenceImage = async (context: MulmoStudioContext, key: s
   };
 
   const options = await graphOption(context);
-  options.agentFilters = [
-    {
-      name: "fileCacheAgentFilter",
-      agent: fileCacheAgentFilter,
-      nodeIds: ["imageGenerator"],
-    },
-  ];
-
   const graph = new GraphAI(graph_data, { imageGoogleAgent, imageOpenaiAgent }, options);
   await graph.run<{ output: MulmoStudioBeat[] }>();
   return imagePath;

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -386,7 +386,7 @@ export const getImageRefs = async (context: MulmoStudioContext) => {
               throw new Error(`Failed to download image: ${image.source.url}`);
             }
             const buffer = Buffer.from(await response.arrayBuffer());
-  
+
             // Detect file extension from Content-Type header or URL
             const extension = getExtention(response.headers.get("content-type"), image.source.url);
             const imagePath = getReferenceImagePath(context, key, extension);

--- a/src/methods/mulmo_studio_context.ts
+++ b/src/methods/mulmo_studio_context.ts
@@ -58,6 +58,9 @@ export const MulmoStudioContextMethods = {
   },
   setBeatSessionState(context: MulmoStudioContext, sessionType: BeatSessionType, index: number, value: boolean) {
     if (value) {
+      if (!context.sessionState.inBeatSession[sessionType]) {
+        context.sessionState.inBeatSession[sessionType] = {};
+      }
       context.sessionState.inBeatSession[sessionType][index] = true;
     } else {
       // NOTE: Setting to false causes the parse error in rebuildStudio in preprocess.ts

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -189,7 +189,6 @@ export const mulmoImagePromptMediaSchema = z
   })
   .strict();
 
-
 export const mulmoImageParamsImagesSchema = z.record(imageIdSchema, z.union([mulmoImageMediaSchema, mulmoImagePromptMediaSchema]));
 export const mulmoFillOptionSchema = z
   .object({

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -182,7 +182,15 @@ export const mulmoAudioAssetSchema = z.union([mulmoAudioMediaSchema, mulmoMidiMe
 
 const imageIdSchema = z.string();
 
-export const mulmoImageParamsImagesSchema = z.record(imageIdSchema, mulmoImageMediaSchema);
+export const mulmoImagePromptMediaSchema = z
+  .object({
+    type: z.literal("imagePrompt"),
+    prompt: z.string(),
+  })
+  .strict();
+
+
+export const mulmoImageParamsImagesSchema = z.record(imageIdSchema, z.union([mulmoImageMediaSchema, mulmoImagePromptMediaSchema]));
 export const mulmoFillOptionSchema = z
   .object({
     style: z.enum(["aspectFit", "aspectFill"]).default("aspectFit"),

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -443,6 +443,7 @@ export const mulmoSessionStateSchema = z.object({
     multiLingual: z.record(z.number().int(), z.boolean()),
     caption: z.record(z.number().int(), z.boolean()),
     html: z.record(z.number().int(), z.boolean()),
+    imageReference: z.record(z.number().int(), z.boolean()),
   }),
 });
 

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -39,6 +39,7 @@ import {
   mulmoGoogleImageModelSchema,
   mulmoGoogleMovieModelSchema,
   mulmoReplicateMovieModelSchema,
+  mulmoImagePromptMediaSchema,
 } from "./schema.js";
 import { pdf_modes, pdf_sizes, storyToScriptGenerateMode } from "../utils/const.js";
 import { LLM } from "../utils/utils.js";
@@ -78,6 +79,7 @@ export type MulmoOpenAIImageModel = z.infer<typeof mulmoOpenAIImageModelSchema>;
 export type MulmoGoogleImageModel = z.infer<typeof mulmoGoogleImageModelSchema>;
 export type MulmoGoogleMovieModel = z.infer<typeof mulmoGoogleMovieModelSchema>;
 export type MulmoReplicateMovieModel = z.infer<typeof mulmoReplicateMovieModelSchema>;
+export type MulmoImagePromptMedia = z.infer<typeof mulmoImagePromptMediaSchema>;
 
 // images
 export type MulmoTextSlideMedia = z.infer<typeof mulmoTextSlideMediaSchema>;

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -148,7 +148,7 @@ export type BeatMediaType = "movie" | "image";
 export type StoryToScriptGenerateMode = (typeof storyToScriptGenerateMode)[keyof typeof storyToScriptGenerateMode];
 
 export type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "pdf";
-export type BeatSessionType = "audio" | "image" | "multiLingual" | "caption" | "movie" | "html";
+export type BeatSessionType = "audio" | "image" | "multiLingual" | "caption" | "movie" | "html" | "imageReference";
 
 export type SessionProgressEvent =
   | { kind: "session"; sessionType: SessionType; inSession: boolean }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -65,6 +65,7 @@ const initSessionState = () => {
       multiLingual: {},
       caption: {},
       html: {},
+      imageReference: {},
     },
   };
 };


### PR DESCRIPTION
imageParams の リファレンス用（キャラクター統一用の）の images をプロンプトから生成できるようにしました。 
- アプリからも個別生成できるようにgenerateReferenceImageという関数をexportしています。
- inBeatSession へは、-1 ベースのネガティブインデックスを使います（keys を sort した結果の index）
- テストケースを作りました（scripts/test/test_image_refs.json)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating and referencing images directly from text prompts within multimedia or animation scenarios.
  * Enhanced image handling to allow both standard images and prompt-generated images to be used interchangeably.
  * Extended session state tracking to include image reference status per beat.

* **Tests**
  * Introduced a new test scenario covering various combinations of image references, including prompt-generated images, standard images, and cases with no images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->