### PR TITLE
beat specific models

### DIFF
--- a/scripts/test/test_replicate.json
+++ b/scripts/test/test_replicate.json
@@ -21,6 +21,13 @@
       "imagePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
       "moviePrompt": " ",
       "duration": 5
+    },
+    {
+      "text": "movie with minimax/video-01",
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "movieParams": {
+        "model": "minimax/video-01"
+      }
     }
   ]
 }

--- a/scripts/test/test_replicate.json
+++ b/scripts/test/test_replicate.json
@@ -6,18 +6,20 @@
   },
   "beats": [
     {
-      "moviePrompt": "a woman walks in the park",
+      "text": "movie with bytedance seedance-1-lite",
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
       "duration": 5
     },
     {
-      "imagePrompt": "a woman walks in the park",
-      "moviePrompt": "a woman walks in the park",
+      "text": "image gpt4-image and movie with bytedance seedance-1-lite",
+      "imagePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
       "duration": 5
     },
     {
-      "id": "third_beat",
-      "imagePrompt": "a woman walks in the park",
-      "moviePrompt": "a woman walks in the park",
+      "text": "image gpt4-image and movie with bytedance seedance-1-lite, no movie prompt",
+      "imagePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "moviePrompt": " ",
       "duration": 5
     }
   ]

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -3,6 +3,7 @@ import { MulmoPresentationStyleMethods, MulmoStudioContextMethods, MulmoBeatMeth
 import { getBeatPngImagePath, getBeatMoviePath } from "../utils/file.js";
 import { imagePrompt, htmlImageSystemPrompt } from "../utils/prompt.js";
 import { renderHTMLToImage } from "../utils/markdown.js";
+import { GraphAILogger } from "graphai";
 
 const htmlStyle = (context: MulmoStudioContext, beat: MulmoBeat) => {
   return {
@@ -34,15 +35,17 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     return { ...returnValue, imagePath: pluginPath, referenceImageForMovie: pluginPath };
   }
 
+  const movieParams = { ...context.presentationStyle.movieParams, ...beat.movieParams };
+  GraphAILogger.log(`movieParams: ${index}`, movieParams, beat.moviePrompt);
   if (beat.moviePrompt && !beat.imagePrompt) {
-    return { ...returnValue, imagePath, imageFromMovie: true }; // no image prompt, only movie prompt
+    return { ...returnValue, imagePath, imageFromMovie: true, movieParams }; // no image prompt, only movie prompt
   }
 
   // referenceImages for "edit_image", openai agent.
   const referenceImages = MulmoBeatMethods.getImageReferenceForImageGenerator(beat, imageRefs);
 
   const prompt = imagePrompt(beat, imageAgentInfo.imageParams.style);
-  return { ...returnValue, imagePath, referenceImageForMovie: imagePath, imageAgentInfo, prompt, referenceImages };
+  return { ...returnValue, imagePath, referenceImageForMovie: imagePath, imageAgentInfo, prompt, referenceImages, movieParams, moviePrompt: beat.moviePrompt };
 };
 
 export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoBeat; index: number }) => {

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -45,7 +45,7 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
   const referenceImages = MulmoBeatMethods.getImageReferenceForImageGenerator(beat, imageRefs);
 
   const prompt = imagePrompt(beat, imageAgentInfo.imageParams.style);
-  return { ...returnValue, imagePath, referenceImageForMovie: imagePath, imageAgentInfo, prompt, referenceImages, movieParams, moviePrompt: beat.moviePrompt };
+  return { ...returnValue, imagePath, referenceImageForMovie: imagePath, imageAgentInfo, prompt, referenceImages, movieParams };
 };
 
 export const imagePluginAgent = async (namedInputs: { context: MulmoStudioContext; beat: MulmoBeat; index: number }) => {

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -151,7 +151,7 @@ const beat_graph_data = {
           mulmoContext: ":context",
         },
         params: {
-          model: ":context.presentationStyle.movieParams.model",
+          model: ":preprocessor.movieParams.model",
           duration: ":beat.duration",
           canvasSize: ":context.presentationStyle.canvasSize",
         },

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -333,7 +333,7 @@ export const mulmoGoogleMovieModelSchema = z
 export const mulmoReplicateMovieModelSchema = z
   .object({
     provider: z.literal("replicate"),
-    model: z.enum(["bytedance/seedance-1-lite", "kwaivgi/kling-v2.1", "google/veo-3"]).optional(),
+    model: z.enum(["bytedance/seedance-1-lite", "kwaivgi/kling-v2.1", "google/veo-3", "minimax/video-01"]).optional(),
   })
   .strict();
 

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -279,6 +279,7 @@ export const mulmoBeatSchema = z
     audioParams: beatAudioParamsSchema.optional(), // beat specific parameters
     movieParams: z
       .object({
+        model: z.string().optional(),
         fillOption: mulmoFillOptionSchema.optional(),
         speed: z.number().optional().describe("Speed of the video. 1.0 is normal speed. 0.5 is half speed. 2.0 is double speed."),
       })

--- a/test/actions/test_image_preprocess_agent.ts
+++ b/test/actions/test_image_preprocess_agent.ts
@@ -87,6 +87,7 @@ test("imagePreprocessAgent - basic functionality", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -127,6 +128,7 @@ test("imagePreprocessAgent - with movie prompt and text", async () => {
       moderation: "auto",
     },
     movieFile: "/test/images/test_studio/1.mov",
+    movieParams: {},
     imagePath: "/test/images/test_studio/1p.png",
     imageFromMovie: true,
   };
@@ -156,6 +158,7 @@ test("imagePreprocessAgent - movie prompt only (no image prompt)", async () => {
       moderation: "auto",
     },
     movieFile: "/test/images/test_studio/2.mov",
+    movieParams: {},
     imagePath: "/test/images/test_studio/2p.png",
     imageFromMovie: true,
   };
@@ -209,6 +212,7 @@ test("imagePreprocessAgent - with imageNames", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: ["/path/to/image1.png", "/path/to/image2.png"],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -251,6 +255,7 @@ test("imagePreprocessAgent - without imageNames (uses all imageRefs)", async () 
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: ["/path/to/image1.png", "/path/to/image2.png", "/path/to/image3.png"],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -294,6 +299,7 @@ test("imagePreprocessAgent - filters undefined image references", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: ["/path/to/image1.png", "/path/to/image2.png"],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -336,6 +342,7 @@ test("imagePreprocessAgent - merges beat and imageAgentInfo imageParams", async 
       moderation: "auto", // From beat (override)
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -373,6 +380,7 @@ test("imagePreprocessAgent - empty imageRefs", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -417,6 +425,7 @@ test("imagePreprocessAgent - with real sample data", async () => {
         moderation: "auto", // From imageAgentInfo
       },
       movieFile: undefined,
+      movieParams: {},
       referenceImages: [],
       imageAgentInfo: {
         agent: "imageOpenaiAgent",
@@ -459,6 +468,7 @@ test("imagePreprocessAgent - text only", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -500,6 +510,7 @@ test("imagePreprocessAgent - imagePrompt only", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -539,6 +550,7 @@ test("imagePreprocessAgent - moviePrompt only", async () => {
     },
     imagePath: "/test/images/test_studio/15p.png",
     movieFile: "/test/images/test_studio/15.mov",
+    movieParams: {},
     imageFromMovie: true,
   };
 

--- a/test/actions/test_image_preprocess_agent.ts
+++ b/test/actions/test_image_preprocess_agent.ts
@@ -583,6 +583,7 @@ test("imagePreprocessAgent - text + moviePrompt (no imagePrompt)", async () => {
     },
     imagePath: "/test/images/test_studio/16p.png",
     movieFile: "/test/images/test_studio/16.mov",
+    movieParams: {},
     imageFromMovie: true,
   };
 
@@ -615,6 +616,7 @@ test("imagePreprocessAgent - imagePrompt + moviePrompt (no text)", async () => {
       moderation: "auto",
     },
     movieFile: "/test/images/test_studio/17.mov",
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -656,6 +658,7 @@ test("imagePreprocessAgent - text + imagePrompt + moviePrompt (all three)", asyn
       moderation: "auto",
     },
     movieFile: "/test/images/test_studio/18.mov",
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -696,6 +699,7 @@ test("imagePreprocessAgent - no text, no imagePrompt, no moviePrompt", async () 
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -736,6 +740,7 @@ test("imagePreprocessAgent - with both text and imagePrompt", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
     imageAgentInfo: {
       agent: "imageOpenaiAgent",
@@ -789,6 +794,7 @@ test("imagePreprocessAgent - with imageParams override", async () => {
       moderation: "auto",
     },
     movieFile: undefined,
+    movieParams: {},
     referenceImages: [],
   };
 


### PR DESCRIPTION
Beat単位で movie モデルを指定できるようにしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new movie generation model, "minimax/video-01".
  * Enhanced movie prompt handling with more detailed and descriptive prompts in test cases.

* **Improvements**
  * Movie parameters and prompts are now included as metadata throughout the movie generation process, improving traceability and flexibility.
  * Test data updated to cover additional scenarios and provide clearer descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->