### PR TITLE
Check if the movie has the audio track

### DIFF
--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -256,7 +256,7 @@ const createVideo = async (audioArtifactFilePath: string, outputVideoPath: strin
     }
 
     // NOTE: We don't support audio if the speed is not 1.0.
-    if (beat.image?.type == "movie" && beat.image.mixAudio > 0.0 && speed === 1.0) {
+    if (studioBeat.hasMovieAudio && beat.image?.type == "movie" && beat.image.mixAudio > 0.0 && speed === 1.0) {
       const { audioId, audioPart } = getAudioPart(inputIndex, duration, timestamp, beat.image.mixAudio);
       audioIdsFromMovieBeats.push(audioId);
       ffmpegContext.filterComplex.push(audioPart);

--- a/src/agents/add_bgm_agent.ts
+++ b/src/agents/add_bgm_agent.ts
@@ -18,7 +18,7 @@ const addBGMAgent: AgentFunction<{ musicFile: string }, string, { voiceFile: str
     throw new Error(`AddBGMAgent musicFile not exist: ${musicFile}`);
   }
 
-  const speechDuration = await ffmpegGetMediaDuration(voiceFile);
+  const { duration: speechDuration } = await ffmpegGetMediaDuration(voiceFile);
   const introPadding = context.presentationStyle.audioParams.introPadding;
   const outroPadding = context.presentationStyle.audioParams.outroPadding;
   const totalDuration = speechDuration + introPadding + outroPadding;

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -5,11 +5,12 @@ import { silent60secPath } from "../utils/file.js";
 import { FfmpegContextInit, FfmpegContextGenerateOutput, FfmpegContextInputFormattedAudio, ffmpegGetMediaDuration } from "../utils/ffmpeg_utils.js";
 import { userAssert } from "../utils/utils.js";
 
-const getMovieDulation = async (beat: MulmoBeat) => {
+const getMovieDuration = async (beat: MulmoBeat) => {
   if (beat.image?.type === "movie" && (beat.image.source.kind === "url" || beat.image.source.kind === "path")) {
     const pathOrUrl = beat.image.source.kind === "url" ? beat.image.source.url : beat.image.source.path;
     const speed = beat.movieParams?.speed ?? 1.0;
-    return (await ffmpegGetMediaDuration(pathOrUrl)) / speed;
+    const { duration } = await ffmpegGetMediaDuration(pathOrUrl);
+    return duration / speed;
   }
   return 0;
 };
@@ -38,8 +39,8 @@ const getMediaDurations = (context: MulmoStudioContext) => {
   return Promise.all(
     context.studio.beats.map(async (studioBeat: MulmoStudioBeat, index: number) => {
       const beat = context.studio.script.beats[index];
-      const movieDuration = await getMovieDulation(beat);
-      const audioDuration = studioBeat.audioFile ? await ffmpegGetMediaDuration(studioBeat.audioFile) : 0;
+      const movieDuration = await getMovieDuration(beat);
+      const audioDuration = studioBeat.audioFile ? (await ffmpegGetMediaDuration(studioBeat.audioFile)).duration : 0;
       return {
         movieDuration,
         audioDuration,

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -9,10 +9,10 @@ const getMovieDuration = async (beat: MulmoBeat) => {
   if (beat.image?.type === "movie" && (beat.image.source.kind === "url" || beat.image.source.kind === "path")) {
     const pathOrUrl = beat.image.source.kind === "url" ? beat.image.source.url : beat.image.source.path;
     const speed = beat.movieParams?.speed ?? 1.0;
-    const { duration } = await ffmpegGetMediaDuration(pathOrUrl);
-    return duration / speed;
+    const { duration, hasAudio } = await ffmpegGetMediaDuration(pathOrUrl);
+    return { duration: duration / speed, hasAudio };
   }
-  return 0;
+  return { duration: 0, hasAudio: false };
 };
 
 const getPadding = (context: MulmoStudioContext, beat: MulmoBeat, index: number) => {
@@ -35,17 +35,18 @@ const getTotalPadding = (padding: number, movieDuration: number, audioDuration: 
   return padding;
 };
 
-const getMediaDurations = (context: MulmoStudioContext) => {
+const getMediaDurationsOfAllBeats = (context: MulmoStudioContext) => {
   return Promise.all(
     context.studio.beats.map(async (studioBeat: MulmoStudioBeat, index: number) => {
       const beat = context.studio.script.beats[index];
-      const movieDuration = await getMovieDuration(beat);
+      const { duration: movieDuration, hasAudio: hasMovieAudio } = await getMovieDuration(beat);
       const audioDuration = studioBeat.audioFile ? (await ffmpegGetMediaDuration(studioBeat.audioFile)).duration : 0;
       return {
         movieDuration,
         audioDuration,
         hasMedia: movieDuration + audioDuration > 0,
         silenceDuration: 0,
+        hasMovieAudio,
       };
     }),
   );
@@ -78,7 +79,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
   const ffmpegContext = FfmpegContextInit();
 
   // First, get the audio durations of all beats, taking advantage of multi-threading capability of ffmpeg.
-  const mediaDurations = await getMediaDurations(context);
+  const mediaDurations = await getMediaDurationsOfAllBeats(context);
 
   const beatDurations: number[] = [];
 
@@ -219,6 +220,7 @@ const combineAudioFilesAgent: AgentFunction<null, { studio: MulmoStudio }, { con
         audioDuration: mediaDurations[index].audioDuration,
         movieDuration: mediaDurations[index].movieDuration,
         silenceDuration: mediaDurations[index].silenceDuration,
+        hasMovieAudio: mediaDurations[index].hasMovieAudio,
       })),
     },
   };

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -416,6 +416,7 @@ export const mulmoStudioBeatSchema = z
     audioDuration: z.number().optional(),
     movieDuration: z.number().optional(),
     silenceDuration: z.number().optional(),
+    hasMovieAudio: z.boolean().optional(),
     audioFile: z.string().optional(),
     imageFile: z.string().optional(), // path to the image
     movieFile: z.string().optional(), // path to the movie file

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -72,13 +72,14 @@ export const FfmpegContextGenerateOutput = (context: FfmpegContext, output: stri
 };
 
 export const ffmpegGetMediaDuration = (filePath: string) => {
-  return new Promise<number>((resolve, reject) => {
+  return new Promise<{ duration: number; hasAudio: boolean }>((resolve, reject) => {
     ffmpeg.ffprobe(filePath, (err, metadata) => {
       if (err) {
         GraphAILogger.info("Error while getting metadata:", err);
         reject(err);
       } else {
-        resolve(metadata.format.duration!);
+        const hasAudio = metadata.streams?.some((stream) => stream.codec_type === "audio") ?? false;
+        resolve({ duration: metadata.format.duration!, hasAudio });
       }
     });
   });


### PR DESCRIPTION
Beatに外部から取り込む映像に音声トラックがあることを確認する変更です。
生成された映像の音声を取り込む変更は別途行いますが、それの準備でもあります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced beat metadata to indicate whether a movie file contains audio.
* **Bug Fixes**
  * Improved accuracy in processing and mixing audio from movie-type beats by only including audio when it is present.
* **Refactor**
  * Updated internal handling of media duration and audio presence for improved reliability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->