### PR TITLE
docs: Add API configuration section to FAQ documentation

### DIFF
--- a/docs/faq_en.md
+++ b/docs/faq_en.md
@@ -167,6 +167,48 @@ Speaker-specific settings take priority; if not specified, the global setting is
 **Environment variables setup**:
 When using each provider, set the corresponding API key in your `.env` file. Available providers and details can be found in [Configuration](../README.md#configuration).
 
+## API Configuration
+
+### Q: Can I change the baseURL?
+
+**A: Yes, you can change the baseURL for OpenAI-compatible services. This supports Azure OpenAI and custom endpoints.**
+
+```bash
+# Basic settings (fallback)
+OPENAI_BASE_URL=https://your-azure.openai.azure.com
+
+# Service-specific settings (priority)
+LLM_OPENAI_BASE_URL=https://your-azure.openai.azure.com
+TTS_OPENAI_BASE_URL=https://api.openai.com/v1
+IMAGE_OPENAI_BASE_URL=https://custom-image-endpoint.com/v1
+```
+
+### Q: Can I configure API keys separately for each service?
+
+**A: Yes, you can configure API keys individually for major services.**
+
+```bash
+# Basic settings (fallback)
+OPENAI_API_KEY=sk-general-key
+ANTHROPIC_API_TOKEN=your-claude-key
+REPLICATE_API_TOKEN=your-replicate-key
+
+# Service-specific settings (priority)
+LLM_OPENAI_API_KEY=sk-llm-key
+TTS_OPENAI_API_KEY=sk-tts-key
+IMAGE_OPENAI_API_KEY=sk-image-key
+LLM_ANTHROPIC_API_TOKEN=sk-claude-key
+MOVIE_REPLICATE_API_TOKEN=your-replicate-movie-key
+```
+
+**Prefix explanation**: Used for the following processes
+- **LLM_**: Text processing such as translation and script generation
+- **TTS_**: Audio generation
+- **IMAGE_**: Image generation
+- **MOVIE_**: Video generation
+
+**Priority**: Service-specific settings > General settings
+
 ## Troubleshooting
 
 ### Q: Getting 429 error during image generation

--- a/docs/faq_ja.md
+++ b/docs/faq_ja.md
@@ -167,6 +167,48 @@ mulmo movie script.json -p ~/.mulmocast/styles/my-style.json
 **環境変数の設定**:
 各プロバイダーを使用する場合は、対応するAPIキーを`.env`ファイルに設定してください。利用可能なプロバイダーと詳細は[Configuration](../README.md#configuration)を参照してください。
 
+## API設定
+
+### Q: baseURLは変更できますか？
+
+**A: はい、OpenAI系サービスのbaseURLの変更が可能です。Azure OpenAIやカスタムエンドポイントに対応できます。**
+
+```bash
+# 基本設定（フォールバック）
+OPENAI_BASE_URL=https://your-azure.openai.azure.com
+
+# サービス別設定（優先）
+LLM_OPENAI_BASE_URL=https://your-azure.openai.azure.com
+TTS_OPENAI_BASE_URL=https://api.openai.com/v1
+IMAGE_OPENAI_BASE_URL=https://custom-image-endpoint.com/v1
+```
+
+### Q: APIキーをサービス別に個別設定できますか？
+
+**A: はい、主要なサービスで個別設定が可能です。**
+
+```bash
+# 基本設定（フォールバック）
+OPENAI_API_KEY=sk-general-key
+ANTHROPIC_API_TOKEN=your-claude-key
+REPLICATE_API_TOKEN=your-replicate-key
+
+# サービス別設定（優先）
+LLM_OPENAI_API_KEY=sk-llm-key
+TTS_OPENAI_API_KEY=sk-tts-key
+IMAGE_OPENAI_API_KEY=sk-image-key
+LLM_ANTHROPIC_API_TOKEN=sk-claude-key
+MOVIE_REPLICATE_API_TOKEN=your-replicate-movie-key
+```
+
+**プレフィックス説明**: 以下の処理に利用します
+- **LLM_**: 翻訳、スクリプト生成等のテキスト処理
+- **TTS_**: 音声生成
+- **IMAGE_**: 画像生成
+- **MOVIE_**: 動画生成
+
+**優先順位**: サービス固有設定 > 汎用設定
+
 ## トラブルシューティング
 
 ### Q: 画像生成で429エラーが発生します


### PR DESCRIPTION
PR #635 の変更をドキュメント化しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "API Configuration" section to the FAQ in both English and Japanese, detailing how to customize API endpoints and keys for various services using environment variables.
  * Provided examples and clarified naming conventions and priority rules for service-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->