### PR TITLE
feat: add ElevenLabs model selection support

### DIFF
--- a/scripts/test/test_elevenlabs_models.json
+++ b/scripts/test/test_elevenlabs_models.json
@@ -1,0 +1,185 @@
+{
+  "$mulmocast": {
+    "version": "1.0"
+  },
+  "title": "ElevenLabs Model Test",
+  "references": [
+    {
+      "url": "https://elevenlabs.io/docs/models",
+      "title": "Models | ElevenLabs Documentation",
+      "type": "article"
+    }
+  ],
+  "canvasSize": {
+    "width": 1280,
+    "height": 720
+  },
+  "speechParams": {
+    "provider": "elevenlabs",
+    "speakers": {
+      "DefaultModel": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "displayName": {
+          "en": "Default Model"
+        }
+      },
+      "MultilingualV2": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "model": "eleven_multilingual_v2",
+        "displayName": {
+          "en": "Multilingual V2"
+        }
+      },
+      "TurboV2_5": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "model": "eleven_turbo_v2_5",
+        "displayName": {
+          "en": "Turbo V2.5"
+        }
+      },
+      "TurboV2": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "model": "eleven_turbo_v2",
+        "displayName": {
+          "en": "Turbo V2"
+        }
+      },
+      "FlashV2_5": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "model": "eleven_flash_v2_5",
+        "displayName": {
+          "en": "Flash V2.5"
+        }
+      },
+      "FlashV2": {
+        "voiceId": "21m00Tcm4TlvDq8ikWAM",
+        "model": "eleven_flash_v2",
+        "displayName": {
+          "en": "Flash V2"
+        }
+      },
+      "MultilingualJapanese": {
+        "voiceId": "Mv8AjrYZCBkdsmDHNwcB",
+        "model": "eleven_multilingual_v2",
+        "displayName": {
+          "en": "Multilingual Japanese"
+        }
+      },
+      "TurboJapanese": {
+        "voiceId": "Mv8AjrYZCBkdsmDHNwcB",
+        "model": "eleven_turbo_v2_5",
+        "displayName": {
+          "en": "Turbo Japanese"
+        }
+      },
+      "FlashJapanese": {
+        "voiceId": "Mv8AjrYZCBkdsmDHNwcB",
+        "model": "eleven_flash_v2_5",
+        "displayName": {
+          "en": "Flash Japanese"
+        }
+      }
+    }
+  },
+  "beats": [
+    {
+      "speaker": "DefaultModel",
+      "text": "Testing the default model, which should be eleven_multilingual_v2. This model provides lifelike and consistent quality speech synthesis.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Default Model Test",
+          "subtitle": "Uses eleven_multilingual_v2"
+        }
+      }
+    },
+    {
+      "speaker": "MultilingualV2",
+      "text": "Testing Multilingual v2 model. This is a professional quality model supporting 29 languages with rich emotional expression.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Multilingual V2",
+          "subtitle": "Professional quality, 29 languages"
+        }
+      }
+    },
+    {
+      "speaker": "TurboV2_5",
+      "text": "Testing Turbo v2.5, a high quality model with low latency around 250 to 300 milliseconds, supporting 32 languages.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Turbo V2.5",
+          "subtitle": "Balanced quality and speed, 32 languages"
+        }
+      }
+    },
+    {
+      "speaker": "TurboV2",
+      "text": "Testing Turbo v2, an English-only model with balanced quality and performance for low-latency applications.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Turbo V2",
+          "subtitle": "English-only balanced model"
+        }
+      }
+    },
+    {
+      "speaker": "FlashV2_5",
+      "text": "Testing Flash v2.5, an ultra-fast model optimized for real-time use with approximately 75 milliseconds latency, supporting 32 languages.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Flash V2.5",
+          "subtitle": "Ultra-fast (~75ms), 32 languages"
+        }
+      }
+    },
+    {
+      "speaker": "FlashV2",
+      "text": "Testing Flash v2, an English-only ultra-fast model optimized for real-time and conversational AI applications.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Flash V2",
+          "subtitle": "English-only ultra-fast model"
+        }
+      }
+    },
+    {
+      "speaker": "MultilingualJapanese",
+      "text": "こんにちは。これは多言語モデルV2の日本語テストです。29言語に対応し、豊かな感情表現を持つプロフェッショナル品質のモデルです。",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "多言語V2日本語テスト",
+          "subtitle": "プロ品質の音声合成"
+        }
+      }
+    },
+    {
+      "speaker": "TurboJapanese",
+      "text": "おはようございます。Turbo V2.5モデルの日本語テストです。品質と速度のバランスが取れた、32言語対応のモデルです。",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Turbo V2.5日本語テスト",
+          "subtitle": "低レイテンシー（250-300ms）"
+        }
+      }
+    },
+    {
+      "speaker": "FlashJapanese",
+      "text": "Flash V2.5モデルの日本語テストです。約75ミリ秒の超低レイテンシーで、リアルタイム用途に最適化されています。",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Flash V2.5日本語テスト",
+          "subtitle": "超高速（~75ms）"
+        }
+      }
+    }
+  ]
+}

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -9,7 +9,7 @@ export const ttsElevenlabsAgent: AgentFunction = async ({ namedInputs, params, c
   if (!apiKey) {
     throw new Error("ELEVENLABS_API_KEY environment variable is required");
   }
-  
+
   const defaultModel = config?.defaultModel ?? process.env.DEFAULT_ELEVENLABS_MODEL ?? "eleven_multilingual_v2";
 
   if (!voice) {

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -9,6 +9,8 @@ export const ttsElevenlabsAgent: AgentFunction = async ({ namedInputs, params, c
   if (!apiKey) {
     throw new Error("ELEVENLABS_API_KEY environment variable is required");
   }
+  
+  const defaultModel = config?.defaultModel ?? process.env.DEFAULT_ELEVENLABS_MODEL ?? "eleven_multilingual_v2";
 
   if (!voice) {
     throw new Error("Voice ID is required");
@@ -17,7 +19,7 @@ export const ttsElevenlabsAgent: AgentFunction = async ({ namedInputs, params, c
   try {
     const requestBody = {
       text,
-      model_id: model ?? "eleven_monolingual_v1",
+      model_id: model ?? defaultModel,
       voice_settings: {
         stability: stability ?? 0.5,
         similarity_boost: similarityBoost ?? 0.75,

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -70,6 +70,10 @@ export const MulmoPresentationStyleMethods = {
     const speaker = MulmoPresentationStyleMethods.getSpeaker(presentationStyle, beat);
     return speaker.provider ?? presentationStyle.speechParams.provider;
   },
+  getTTSModel(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat): string | undefined {
+    const speaker = MulmoPresentationStyleMethods.getSpeaker(presentationStyle, beat);
+    return speaker.model ?? presentationStyle.speechParams.model;
+  },
   getVoiceId(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat): string {
     const speaker = MulmoPresentationStyleMethods.getSpeaker(presentationStyle, beat);
     return speaker.voiceId;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -35,6 +35,7 @@ export const speakerDataSchema = z
     voiceId: z.string(),
     speechOptions: speechOptionsSchema.optional(),
     provider: text2SpeechProviderSchema.optional(),
+    model: z.string().optional().describe("TTS model to use for this speaker"),
   })
   .strict();
 
@@ -316,6 +317,7 @@ export const mulmoSpeechParamsSchema = z
   .object({
     provider: text2SpeechProviderSchema, // has default value
     speakers: speakerDictionarySchema,
+    model: z.string().optional().describe("Default TTS model to use"),
   })
   .strict();
 

--- a/src/utils/provider2agent.ts
+++ b/src/utils/provider2agent.ts
@@ -25,13 +25,7 @@ export const provider2TTSAgent = {
     defaultModel: "eleven_multilingual_v2",
     // Models | ElevenLabs Documentation
     // https://elevenlabs.io/docs/models
-    models: [
-      "eleven_multilingual_v2",
-      "eleven_turbo_v2_5",
-      "eleven_turbo_v2",
-      "eleven_flash_v2_5",
-      "eleven_flash_v2",
-    ],
+    models: ["eleven_multilingual_v2", "eleven_turbo_v2_5", "eleven_turbo_v2", "eleven_flash_v2_5", "eleven_flash_v2"],
   },
 };
 

--- a/src/utils/provider2agent.ts
+++ b/src/utils/provider2agent.ts
@@ -22,6 +22,16 @@ export const provider2TTSAgent = {
   elevenlabs: {
     agentName: "ttsElevenlabsAgent",
     hasLimitedConcurrency: true,
+    defaultModel: "eleven_multilingual_v2",
+    // Models | ElevenLabs Documentation
+    // https://elevenlabs.io/docs/models
+    models: [
+      "eleven_multilingual_v2",
+      "eleven_turbo_v2_5",
+      "eleven_turbo_v2",
+      "eleven_flash_v2_5",
+      "eleven_flash_v2",
+    ],
   },
 };
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -85,6 +85,7 @@ export const settings2GraphAIConfig = (
     },
     ttsElevenlabsAgent: {
       apiKey: getKey("TTS", "ELEVENLABS_API_KEY"),
+      defaultModel: env?.["DEFAULT_ELEVENLABS_MODEL"],
     },
 
     // TODO


### PR DESCRIPTION
私は現在 openai の tts を使用していますが、日本語読み上げの間違いが多いため、 ElevenLabs を試験的に導入するつもりです。
現在デフォルトとして設定されている `eleven_monolingual_v1` は日本語に対応していません。
環境変数、または MulmoScript における指定によりモデルを自由に選べるようにしました。

なお、[eleven_monolingual_v1 は outdated になっているようである](https://elevenlabs.io/docs/models#models-overview) ため、デフォルトを `eleven_multilingual_v2` にしています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying and selecting different ElevenLabs speech synthesis models for text-to-speech generation.
  * Introduced a new test scenario for validating multiple ElevenLabs TTS models, including multilingual, turbo, and flash variants.
* **Improvements**
  * Enhanced configuration options to allow setting default and per-speaker TTS models.
  * Updated audio generation and caching to consider the selected TTS model.
* **Chores**
  * Expanded documentation and metadata for ElevenLabs TTS model selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->