### PR TITLE
Fix hailuo 02 with image

### DIFF
--- a/scripts/test/test_replicate.json
+++ b/scripts/test/test_replicate.json
@@ -110,6 +110,16 @@
       "movieParams": {
         "model": "minimax/hailuo-02"
       }
+    },
+    {
+      "id": "hailuo-02-image",
+      "text": "minimax/hailuo-02 with ghibli-styleimage",
+      "duration": 6,
+      "imagePrompt": "a cat is doing an acrobatic dive into a swimming pool at the olympics, from a 10m high diving board, Ghibli style",
+      "moviePrompt": "televised footage of a cat is doing an acrobatic dive into a swimming pool at the olympics, from a 10m high diving board, flips and spins",
+      "movieParams": {
+        "model": "minimax/hailuo-02"
+      }
     }
   ]
 }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -23,6 +23,7 @@ async function generateMovie(
     duration,
     image: undefined as string | undefined,
     start_image: undefined as string | undefined,
+    first_frame_image: undefined as string | undefined,
     aspect_ratio: aspectRatio, // only for bytedance/seedance-1-lite
     // resolution: "720p", // only for bytedance/seedance-1-lite
     // fps: 24, // only for bytedance/seedance-1-lite
@@ -35,8 +36,10 @@ async function generateMovie(
   if (imagePath) {
     const buffer = readFileSync(imagePath);
     const base64Image = `data:image/png;base64,${buffer.toString("base64")}`;
-    if (model === "kwaivgi/kling-v2.1" || model === "kwaivgi/kling-v1.6-pro" || model === "minimax/hailuo-02") {
+    if (model === "kwaivgi/kling-v2.1" || model === "kwaivgi/kling-v1.6-pro") {
       input.start_image = base64Image;
+    } else if (model === "minimax/hailuo-02") {
+      input.first_frame_image = base64Image;
     } else {
       input.image = base64Image;
     }


### PR DESCRIPTION
replicate上でhailuo-02 を使う場合、最初のフレームは、klingのようにstart_frameではなく、first_frame_imageで指定しなければならないことが判明したので、その変更とテストケースです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new test case for generating a movie with a Ghibli-style image prompt, featuring a cat performing an acrobatic dive.
* **Bug Fixes**
  * Improved handling of image input for movie generation, ensuring correct parameter mapping for different models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->