### PR TITLE
flipped title and description

### DIFF
--- a/assets/templates/ani.json
+++ b/assets/templates/ani.json
@@ -1,6 +1,6 @@
 {
-  "title": "Presentation with Ani in Japanese",
-  "description": "Template for presentation with Ani in Japanese.",
+  "title": "Presentation with Ani",
+  "description": "Template for presentation with Ani.",
   "systemPrompt": "Generate a script for a presentation of the given topic. 言葉づかいは少しツンデレにして。Another AI will generate comic for each beat based on the image prompt of that beat. You don't need to specify the style of the image, just describe the scene. Mention the reference in one of beats, if it exists. Use the JSON below as a template. Create appropriate amount of beats, and make sure the beats are coherent and flow well.",
   "presentationStyle": {
     "$mulmocast": {

--- a/assets/templates/ani_ja.json
+++ b/assets/templates/ani_ja.json
@@ -1,6 +1,6 @@
 {
-  "title": "Presentation with Ani",
-  "description": "Template for presentation with Ani.",
+  "title": "Presentation with Ani in Japanese",
+  "description": "Template for presentation with Ani in Japanese.",
   "systemPrompt": "Generate a Japanese script for a presentation of the given topic. 言葉づかいは少しツンデレにして。Another AI will generate comic for each beat based on the image prompt of that beat. You don't need to specify the style of the image, just describe the scene. Mention the reference in one of beats, if it exists. Use the JSON below as a template. Create appropriate amount of beats, and make sure the beats are coherent and flow well.",
   "presentationStyle": {
     "$mulmocast": {


### PR DESCRIPTION
テンプレートの ani と ani_ja の title/description がひっくり返っていたので修正です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated template titles and descriptions to clarify language usage for presentations with Ani. English templates no longer explicitly mention Japanese, while Japanese templates now clearly indicate the language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->