### PR TITLE
Nijivoice filter

### DIFF
--- a/scripts/test/test_lang.json
+++ b/scripts/test/test_lang.json
@@ -66,6 +66,16 @@
       }
     },
     {
+      "text": "The yield of TSMC's 3nm process exceeeds 90%.",
+      "duration": 8,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Switching Language (long duration)"
+        }
+      }
+    },
+    {
       "text": "Goodbye",
       "image": {
         "type": "textSlide",

--- a/scripts/test/test_lang.json
+++ b/scripts/test/test_lang.json
@@ -66,12 +66,11 @@
       }
     },
     {
-      "text": "The yield of TSMC's 3nm process exceeeds 90%.",
-      "duration": 8,
+      "text": "The yield of TSMC's 3nm process exceeeds 70%.",
       "image": {
         "type": "textSlide",
         "slide": {
-          "title": "Switching Language (long duration)"
+          "title": "Text replacement test for nijivoice"
         }
       }
     },

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -190,13 +190,13 @@ const graph_data: GraphData = {
 
 const agentFilters = [
   {
-    name: "nijovoiceTextAgentFilter",
-    agent: nijovoiceTextAgentFilter,
+    name: "fileCacheAgentFilter",
+    agent: fileCacheAgentFilter,
     nodeIds: ["tts"],
   },
   {
-    name: "fileCacheAgentFilter",
-    agent: fileCacheAgentFilter,
+    name: "nijovoiceTextAgentFilter",
+    agent: nijovoiceTextAgentFilter,
     nodeIds: ["tts"],
   },
 ];

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -13,7 +13,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 import { MulmoPresentationStyleMethods } from "../methods/index.js";
 
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoStudioMultiLingualData, text2SpeechProviderSchema } from "../types/index.js";
-import { fileCacheAgentFilter } from "../utils/filters.js";
+import { fileCacheAgentFilter, nijovoiceTextAgentFilter } from "../utils/filters.js";
 import { getAudioArtifactFilePath, getAudioFilePath, getOutputStudioFilePath, resolveDirPath, defaultBGMPath, mkdir, writingMessage } from "../utils/file.js";
 import { text2hash, localizedText, settings2GraphAIConfig } from "../utils/utils.js";
 import { provider2TTSAgent } from "../utils/provider2agent.js";
@@ -72,6 +72,8 @@ const preprocessor = (namedInputs: {
     voiceId,
     speechOptions,
     model,
+    provider,
+    lang,
     audioPath,
     studioBeat,
     needsTTS,
@@ -99,6 +101,8 @@ const graph_tts: GraphData = {
       agent: ":preprocessor.ttsAgent",
       inputs: {
         text: ":preprocessor.text",
+        provider: ":preprocessor.provider",
+        lang: ":preprocessor.lang",
         cache: {
           force: [":context.force"],
           file: ":preprocessor.audioPath",
@@ -185,6 +189,11 @@ const graph_data: GraphData = {
 };
 
 const agentFilters = [
+  {
+    name: "nijovoiceTextAgentFilter",
+    agent: nijovoiceTextAgentFilter,
+    nodeIds: ["tts"],
+  },
   {
     name: "fileCacheAgentFilter",
     agent: fileCacheAgentFilter,

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -116,7 +116,7 @@ const translateGraph: GraphData = {
                 },
                 ttsTexts: {
                   agent: (namedInputs: { localizedText: LocalizedText; targetLang: LANG }) => {
-                    const { localizedText, targetLang } = namedInputs;
+                    const { localizedText } = namedInputs;
                     // cache
                     if (localizedText.ttsTexts) {
                       return localizedText;

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -5,7 +5,7 @@ import * as agents from "@graphai/vanilla";
 import { openAIAgent } from "@graphai/openai_agent";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
-import { recursiveSplitJa, replacementsJa, replacePairsJa } from "../utils/string.js";
+import { recursiveSplitJa } from "../utils/string.js";
 import { settings2GraphAIConfig } from "../utils/utils.js";
 import { LANG, LocalizedText, MulmoStudioContext, MulmoBeat, MulmoStudioMultiLingualData, MulmoStudioMultiLingual } from "../types/index.js";
 import { getOutputMultilingualFilePath, mkdir, writingMessage } from "../utils/file.js";
@@ -120,12 +120,6 @@ const translateGraph: GraphData = {
                     // cache
                     if (localizedText.ttsTexts) {
                       return localizedText;
-                    }
-                    if (targetLang === "ja") {
-                      return {
-                        ...localizedText,
-                        ttsTexts: localizedText?.texts?.map(replacePairsJa(replacementsJa)),
-                      };
                     }
                     return {
                       ...localizedText,

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -7,11 +7,12 @@ import { GraphAILogger } from "graphai";
 import { writingMessage } from "./file.js";
 import { text2hash } from "./utils.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
+import { replacementsJa, replacePairsJa } from "../utils/string.js";
 
 export const nijovoiceTextAgentFilter: AgentFilterFunction = async (context, next) => {
   const { text, provider, lang } = context.namedInputs;
   if (provider === "nijivoice" && lang === "ja") {
-    console.log("*** nijovoiceTextAgentFilter ***", text, provider, lang);
+    context.namedInputs.text = replacePairsJa(replacementsJa)(text);
   }
   return next(context);
 };

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -8,6 +8,14 @@ import { writingMessage } from "./file.js";
 import { text2hash } from "./utils.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
+export const nijovoiceTextAgentFilter: AgentFilterFunction = async (context, next) => {
+  const { text, provider, lang } = context.namedInputs;
+  if (provider === "nijivoice" && lang === "ja") {
+    console.log("*** nijovoiceTextAgentFilter ***", text, provider, lang);
+  }
+  return next(context);
+};
+
 export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) => {
   const { force, file, index, mulmoContext, sessionType } = context.namedInputs.cache;
 

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -66,4 +66,5 @@ export const replacementsJa: Replacement[] = [
   { from: "5つ", to: "いつつ" },
   { from: "危険な面", to: "危険なめん" },
   { from: "その通り！", to: "その通り。" },
+  { from: "%", to: "パーセント" },
 ];


### PR DESCRIPTION
translateで呼んでいた文字列のAPIを、filterで呼ぶように変更しました。providerがnijivoiceでlangがjaの時だけにかかります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced text-to-speech processing by supporting provider and language context, enabling more accurate handling for specific providers and languages.
  * Introduced a new filter to improve Japanese text replacement for a particular voice provider.

* **Improvements**
  * Added a replacement rule converting the "%" symbol to "パーセント" in Japanese text processing.
  * Streamlined text transformation logic for Japanese language output in translation features.

* **Tests**
  * Added a new test entry for text replacement functionality in Japanese voice output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->