### PR TITLE
add defaultProvider.text2image

### DIFF
--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -101,7 +101,8 @@ export const MulmoPresentationStyleMethods = {
     // Notice that we copy imageParams from presentationStyle and update
     // provider and model appropriately.
     const imageParams = { ...presentationStyle.imageParams, ...beat?.imageParams };
-    const provider = MulmoPresentationStyleMethods.getText2ImageProvider(imageParams?.provider) as keyof typeof provider2ImageAgent;
+    const provider =
+      (MulmoPresentationStyleMethods.getText2ImageProvider(imageParams?.provider) as keyof typeof provider2ImageAgent) ?? defaultProviders.text2image;
     const agentInfo = provider2ImageAgent[provider];
 
     // The default text2image model is gpt-image-1 from OpenAI, and to use it you must have an OpenAI account and have verified your identity. If this is not possible, please specify dall-e-3 as the model.


### PR DESCRIPTION
undefined になっているケースがあったので修正です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability in selecting an image provider by ensuring a default provider is used when none is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->