### PR TITLE
Add background="opaque" setting for OpenAI image generation

### DIFF
--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -41,6 +41,7 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
     prompt,
     n: 1,
     size,
+    background: "opaque",
   };
   if (model === "gpt-image-1") {
     imageOptions.moderation = moderation || "auto";

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -11,7 +11,7 @@ export type OpenAIImageOptions = {
   size: OpenAIImageSize;
   moderation?: OpenAIImageModeration;
   quality?: OpenAIImageQuality;
-  background?: "opaque" | "transparent";
+  background?: "opaque" | "transparent" | "auto";
 };
 
 export type AgentBufferResult = { buffer?: Buffer; saved?: string; text?: string };

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -11,6 +11,7 @@ export type OpenAIImageOptions = {
   size: OpenAIImageSize;
   moderation?: OpenAIImageModeration;
   quality?: OpenAIImageQuality;
+  background?: "opaque" | "transparent";
 };
 
 export type AgentBufferResult = { buffer?: Buffer; saved?: string; text?: string };


### PR DESCRIPTION
Added background="opaque" as default setting for OpenAI image generation API to prevent transparent background issues.

Changes:
- src/types/agent.ts: Add background parameter to OpenAIImageOptions
- src/agents/image_openai_agent.ts: Set background="opaque" by default

透過画像を動画で使用することには問題があります。
意図しない色味になってしまいます。
具体的にどうなるかはみてもらった方が早いです。


透過された元画像

<img width="1536" height="1024" alt="0p" src="https://github.com/user-attachments/assets/095b135b-dcc0-4919-9905-fdc88a1a37e8" />

透過画像を使用した動画

https://github.com/user-attachments/assets/af6c67bf-2261-4778-a39c-fe187be0b8e8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images generated by the app now have an opaque background by default.

* **Documentation**
  * Updated image generation options to reflect support for specifying background type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->