### PR TITLE
bgm lipSync for Music Video

### DIFF
--- a/scripts/test/test_mv.json
+++ b/scripts/test/test_mv.json
@@ -69,7 +69,8 @@
     {
       "text": "Whispers hide in silver rain. Every shadow calls your name.",
       "duration": 9.32,
-      "imagePrompt": "Singer walking alone at night in neon-lit rainy street, holding a clear umbrella, raindrops sparkling, wearing a black mini dress with thigh-high boots, reflective puddles surrounding her."
+      "imagePrompt": "Singer walking alone at night in neon-lit rainy street, holding a clear umbrella, raindrops sparkling, wearing a black mini dress with thigh-high boots, reflective puddles surrounding her.",
+      "enableLipSync": true
     },
     {
       "text": "I dissolve into the night. Just to echo what you liked.",

--- a/scripts/test/test_mv.json
+++ b/scripts/test/test_mv.json
@@ -1,0 +1,80 @@
+{
+  "$mulmocast": {
+    "version": "1.1",
+    "credit": "closing"
+  },
+  "canvasSize": {
+    "width": 1536,
+    "height": 1024
+  },
+  "speechParams": {
+    "speakers": {
+      "Presenter": {
+        "displayName": {
+          "en": "Presenter"
+        },
+        "voiceId": "shimmer"
+      }
+    }
+  },
+  "imageParams": {
+    "provider": "openai",
+    "style": "<style>Vibrant 3D animation style inspired by K-pop aesthetics, with glossy, stylized characters. The overall visual style combines elements of modern animation, game cinematics, and fashion-forward character design, with sleek outlines, glowing effects, and a polished, cinematic finish.</style>",
+    "images": {
+      "min": {
+        "type": "image",
+        "source": {
+          "kind": "url",
+          "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/characters/min_anime.png"
+        }
+      }
+    }
+  },
+  "movieParams": {
+    "provider": "replicate"
+  },
+  "soundEffectParams": {
+    "provider": "replicate"
+  },
+  "captionParams": {
+    "lang": "en",
+    "styles": ["font-size: 64px", "width: 90%", "padding-left: 5%", "padding-right: 5%"]
+  },
+  "audioParams": {
+    "padding": 0,
+    "introPadding": 0,
+    "closingPadding": 0,
+    "outroPadding": 0,
+    "bgm": {
+      "kind": "url",
+      "url": "https://raw.githubusercontent.com/receptron/mulmocast-media/refs/heads/main/music/finetuning_with_you.mp3"
+    },
+    "bgmVolume": 1,
+    "audioVolume": 0,
+    "suppressSpeech": true
+  },
+  "title": "Music Video",
+  "lang": "en",
+  "beats": [
+    {
+      "text": "Finetuning with you",
+      "duration": 7.0,
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Finetuning with you"
+        }
+      }
+    },
+    {
+      "text": "Whispers hide in silver rain. Every shadow calls your name.",
+      "duration": 9.32,
+      "imagePrompt": "Singer walking alone at night in neon-lit rainy street, holding a clear umbrella, raindrops sparkling, wearing a black mini dress with thigh-high boots, reflective puddles surrounding her."
+    },
+    {
+      "text": "I dissolve into the night. Just to echo what you liked.",
+      "duration": 8.28,
+      "imagePrompt": "Singer standing against a glowing city skyline at night, hair blowing in wind, long white trench coat fluttering, reaching out with one hand as if fading into the background lights."
+    }
+  ]
+}

--- a/scripts/test/test_mv.json
+++ b/scripts/test/test_mv.json
@@ -75,7 +75,8 @@
     {
       "text": "I dissolve into the night. Just to echo what you liked.",
       "duration": 8.28,
-      "imagePrompt": "Singer standing against a glowing city skyline at night, hair blowing in wind, long white trench coat fluttering, reaching out with one hand as if fading into the background lights."
+      "imagePrompt": "Singer standing against a glowing city skyline at night, hair blowing in wind, long white trench coat fluttering, reaching out with one hand as if fading into the background lights.",
+      "enableLipSync": true
     }
   ]
 }

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -1,5 +1,5 @@
 import { MulmoStudioContext, MulmoBeat, MulmoCanvasDimension, MulmoImageParams } from "../types/index.js";
-import { MulmoPresentationStyleMethods, MulmoStudioContextMethods, MulmoBeatMethods } from "../methods/index.js";
+import { MulmoPresentationStyleMethods, MulmoStudioContextMethods, MulmoBeatMethods, MulmoMediaSourceMethods } from "../methods/index.js";
 import { getBeatPngImagePath, getBeatMoviePaths, getAudioFilePath } from "../utils/file.js";
 import { imagePrompt, htmlImageSystemPrompt } from "../utils/prompt.js";
 import { renderHTMLToImage } from "../utils/markdown.js";
@@ -37,7 +37,7 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     lipSyncModel?: string;
     lipSyncAgentName?: string;
     lipSyncTrimAudio?: boolean; // instruction to trim audio from the BGM
-    bgmFile?: string;
+    bgmFile?: string | null;
     startAt?: number;
     duration?: number;
     audioFile?: string;
@@ -68,12 +68,7 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.duration = studioBeat?.duration ?? 0;
     if (context.studio.script.audioParams?.suppressSpeech) {
       returnValue.lipSyncTrimAudio = true;
-      returnValue.bgmFile =
-        context.studio.script.audioParams.bgm?.kind === "url"
-          ? context.studio.script.audioParams.bgm?.url
-          : context.studio.script.audioParams.bgm?.kind === "path"
-            ? context.studio.script.audioParams.bgm?.path
-            : undefined;
+      returnValue.bgmFile = MulmoMediaSourceMethods.resolve(context.studio.script.audioParams.bgm, context);
       const folderName = MulmoStudioContextMethods.getFileName(context);
       const audioDirPath = MulmoStudioContextMethods.getAudioDirPath(context);
       const fileName = `${beatId(beat.id, index)}_trimmed.mp3`;

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -37,6 +37,9 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     lipSyncModel?: string;
     lipSyncAgentName?: string;
     lipSyncTrimAudio?: boolean; // instruction to trim audio from the BGM
+    bgmFile?: string;
+    startAt?: number;
+    duration?: number;
     audioFile?: string;
     beatDuration?: number;
   } = {
@@ -61,8 +64,16 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.lipSyncAgentName = lipSyncAgentInfo.agentName;
     returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
     returnValue.lipSyncFile = moviePaths.lipSyncFile;
+    returnValue.startAt = studioBeat?.startAt ?? 0;
+    returnValue.duration = studioBeat?.duration ?? 0;
     if (context.studio.script.audioParams?.suppressSpeech) {
       returnValue.lipSyncTrimAudio = true;
+      returnValue.bgmFile =
+        context.studio.script.audioParams.bgm?.kind === "url"
+          ? context.studio.script.audioParams.bgm?.url
+          : context.studio.script.audioParams.bgm?.kind === "path"
+            ? context.studio.script.audioParams.bgm?.path
+            : undefined;
       const folderName = MulmoStudioContextMethods.getFileName(context);
       const audioDirPath = MulmoStudioContextMethods.getAudioDirPath(context);
       const fileName = `${beatId(beat.id, index)}_trimmed.mp3`;

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -1,9 +1,10 @@
 import { MulmoStudioContext, MulmoBeat, MulmoCanvasDimension, MulmoImageParams } from "../types/index.js";
 import { MulmoPresentationStyleMethods, MulmoStudioContextMethods, MulmoBeatMethods } from "../methods/index.js";
-import { getBeatPngImagePath, getBeatMoviePaths } from "../utils/file.js";
+import { getBeatPngImagePath, getBeatMoviePaths, getAudioFilePath } from "../utils/file.js";
 import { imagePrompt, htmlImageSystemPrompt } from "../utils/prompt.js";
 import { renderHTMLToImage } from "../utils/markdown.js";
 import { GraphAILogger } from "graphai";
+import { beatId } from "../utils/utils.js";
 
 const htmlStyle = (context: MulmoStudioContext, beat: MulmoBeat) => {
   return {
@@ -35,6 +36,7 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     lipSyncFile?: string;
     lipSyncModel?: string;
     lipSyncAgentName?: string;
+    lipSyncTrimAudio?: boolean; // instruction to trim audio from the BGM
     audioFile?: string;
     beatDuration?: number;
   } = {
@@ -59,10 +61,17 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.lipSyncAgentName = lipSyncAgentInfo.agentName;
     returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
     returnValue.lipSyncFile = moviePaths.lipSyncFile;
-    // Audio file will be set from the beat's audio file when available
-    returnValue.audioFile = studioBeat?.audioFile;
+    if (context.studio.script.audioParams?.suppressSpeech) {
+      returnValue.lipSyncTrimAudio = true;
+      const folderName = MulmoStudioContextMethods.getFileName(context);
+      const audioDirPath = MulmoStudioContextMethods.getAudioDirPath(context);
+      const fileName = `${beatId(beat.id, index)}_trimmed.mp3`;
+      returnValue.audioFile = getAudioFilePath(audioDirPath, folderName, fileName);
+    } else {
+      // Audio file will be set from the beat's audio file when available
+      returnValue.audioFile = studioBeat?.audioFile;
+    }
   }
-
   if (beat.image) {
     const plugin = MulmoBeatMethods.getPlugin(beat);
     const pluginPath = plugin.path({ beat, context, imagePath, ...htmlStyle(context, beat) });

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -64,9 +64,9 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.lipSyncAgentName = lipSyncAgentInfo.agentName;
     returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
     returnValue.lipSyncFile = moviePaths.lipSyncFile;
-    returnValue.startAt = studioBeat?.startAt ?? 0;
-    returnValue.duration = studioBeat?.duration ?? 0;
     if (context.studio.script.audioParams?.suppressSpeech) {
+      returnValue.startAt = studioBeat?.startAt ?? 0;
+      returnValue.duration = studioBeat?.duration ?? 0;
       returnValue.lipSyncTrimAudio = true;
       returnValue.bgmFile = MulmoMediaSourceMethods.resolve(context.studio.script.audioParams.bgm, context);
       const folderName = MulmoStudioContextMethods.getFileName(context);

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -246,10 +246,6 @@ const beat_graph_data = {
     AudioTrimmer: {
       if: ":preprocessor.lipSyncTrimAudio",
       agent: async (namedInputs: { audioFile: string; bgmFile: string; startAt: number; duration: number }) => {
-        console.log(`********1 lipSyncTrimAudio: ${namedInputs.audioFile}`);
-        console.log(`********2 lipSyncTrimAudio: ${namedInputs.bgmFile}`);
-        console.log(`********3 lipSyncTrimAudio: ${namedInputs.startAt}`);
-        console.log(`********4 lipSyncTrimAudio: ${namedInputs.duration}`);
         const buffer = await trimMusic(namedInputs.bgmFile, namedInputs.startAt, namedInputs.duration);
         return { buffer };
       },

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -250,7 +250,7 @@ const beat_graph_data = {
         console.log(`********2 lipSyncTrimAudio: ${namedInputs.bgmFile}`);
         console.log(`********3 lipSyncTrimAudio: ${namedInputs.startAt}`);
         console.log(`********4 lipSyncTrimAudio: ${namedInputs.duration}`);
-        //return await trimMusic(namedInputs.audioFile, 0, 10);
+        return await trimMusic(namedInputs.bgmFile, namedInputs.startAt, namedInputs.duration);
       },
       inputs: {
         audioFile: ":preprocessor.audioFile",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -24,7 +24,7 @@ import { MulmoPresentationStyleMethods, MulmoStudioContextMethods } from "../met
 import { getOutputStudioFilePath, mkdir } from "../utils/file.js";
 import { fileCacheAgentFilter } from "../utils/filters.js";
 import { settings2GraphAIConfig } from "../utils/utils.js";
-import { extractImageFromMovie, ffmpegGetMediaDuration } from "../utils/ffmpeg_utils.js";
+import { extractImageFromMovie, ffmpegGetMediaDuration, trimMusic } from "../utils/ffmpeg_utils.js";
 
 import { getImageRefs } from "./image_references.js";
 import { imagePreprocessAgent, imagePluginAgent, htmlImageGeneratorAgent } from "./image_agents.js";
@@ -240,6 +240,23 @@ const beat_graph_data = {
           sessionType: "soundEffect",
           mulmoContext: ":context",
         },
+      },
+      defaultValue: {},
+    },
+    lipSyncTrimAudio: {
+      if: ":preprocessor.lipSyncTrimAudio",
+      agent: async (namedInputs: { audioFile: string; bgmFile: string; startAt: number; duration: number }) => {
+        console.log(`********1 lipSyncTrimAudio: ${namedInputs.audioFile}`);
+        console.log(`********2 lipSyncTrimAudio: ${namedInputs.bgmFile}`);
+        console.log(`********3 lipSyncTrimAudio: ${namedInputs.startAt}`);
+        console.log(`********4 lipSyncTrimAudio: ${namedInputs.duration}`);
+        //return await trimMusic(namedInputs.audioFile, 0, 10);
+      },
+      inputs: {
+        audioFile: ":preprocessor.audioFile",
+        bgmFile: ":preprocessor.bgmFile",
+        startAt: ":preprocessor.startAt",
+        duration: ":preprocessor.duration",
       },
       defaultValue: {},
     },

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -243,20 +243,29 @@ const beat_graph_data = {
       },
       defaultValue: {},
     },
-    lipSyncTrimAudio: {
+    AudioTrimmer: {
       if: ":preprocessor.lipSyncTrimAudio",
       agent: async (namedInputs: { audioFile: string; bgmFile: string; startAt: number; duration: number }) => {
         console.log(`********1 lipSyncTrimAudio: ${namedInputs.audioFile}`);
         console.log(`********2 lipSyncTrimAudio: ${namedInputs.bgmFile}`);
         console.log(`********3 lipSyncTrimAudio: ${namedInputs.startAt}`);
         console.log(`********4 lipSyncTrimAudio: ${namedInputs.duration}`);
-        return await trimMusic(namedInputs.bgmFile, namedInputs.startAt, namedInputs.duration);
+        const buffer = await trimMusic(namedInputs.bgmFile, namedInputs.startAt, namedInputs.duration);
+        return { buffer };
       },
       inputs: {
         audioFile: ":preprocessor.audioFile",
         bgmFile: ":preprocessor.bgmFile",
         startAt: ":preprocessor.startAt",
         duration: ":preprocessor.duration",
+        cache: {
+          force: [":context.force"],
+          file: ":preprocessor.audioFile",
+          index: ":__mapIndex",
+          id: ":beat.id",
+          sessionType: "audioTrimmer",
+          mulmoContext: ":context",
+        },
       },
       defaultValue: {},
     },
@@ -264,7 +273,7 @@ const beat_graph_data = {
       if: ":beat.enableLipSync",
       agent: ":preprocessor.lipSyncAgentName",
       inputs: {
-        onComplete: [":soundEffectGenerator"], // to wait for soundEffectGenerator to finish
+        onComplete: [":soundEffectGenerator", ":AudioTrimmer"], // to wait for soundEffectGenerator to finish
         movieFile: ":preprocessor.movieFile",
         imageFile: ":preprocessor.referenceImageForMovie",
         audioFile: ":preprocessor.audioFile",
@@ -384,7 +393,7 @@ export const graphOption = async (context: MulmoStudioContext, settings?: Record
       {
         name: "fileCacheAgentFilter",
         agent: fileCacheAgentFilter,
-        nodeIds: ["imageGenerator", "movieGenerator", "htmlImageAgent", "soundEffectGenerator", "lipSyncGenerator"],
+        nodeIds: ["imageGenerator", "movieGenerator", "htmlImageAgent", "soundEffectGenerator", "lipSyncGenerator", "AudioTrimmer"],
       },
     ],
     taskManager: new TaskManager(MulmoPresentationStyleMethods.getConcurrency(context.presentationStyle)),

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -103,6 +103,9 @@ export const extractImageFromMovie = (movieFile: string, imagePath: string): Pro
 };
 
 export const trimMusic = (inputFile: string, startTime: number, duration: number): Promise<Buffer> => {
+  console.log(`********A trimMusic: ${inputFile}`);
+  console.log(`********B trimMusic: ${startTime}`);
+  console.log(`********C trimMusic: ${duration}`);
   return new Promise<Buffer>((resolve, reject) => {
     if (!inputFile.startsWith("http://") && !inputFile.startsWith("https://") && !fs.existsSync(inputFile)) {
       reject(new Error(`File not found: ${inputFile}`));

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -103,9 +103,6 @@ export const extractImageFromMovie = (movieFile: string, imagePath: string): Pro
 };
 
 export const trimMusic = (inputFile: string, startTime: number, duration: number): Promise<Buffer> => {
-  console.log(`********A trimMusic: ${inputFile}`);
-  console.log(`********B trimMusic: ${startTime}`);
-  console.log(`********C trimMusic: ${duration}`);
   return new Promise<Buffer>((resolve, reject) => {
     if (!inputFile.startsWith("http://") && !inputFile.startsWith("https://") && !fs.existsSync(inputFile)) {
       reject(new Error(`File not found: ${inputFile}`));


### PR DESCRIPTION
When suppressSpeech is true and enableLipSync is true, use an corresponding portion of BGM as the audio for lip-sync. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-beat background music trimming for lip-sync scenes, improving timing and synchronization.
  * Improved lip-sync behavior when speech is suppressed.
  * Caching of trimmed audio to speed up repeat renders.

* **Tests**
  * Added a sample "Music Video" config (English captions, presenter voice, BGM, three-beat sequence) for end-to-end validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->