### PR TITLE
Calculate startAt in imagePreprocessAgent

### DIFF
--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -65,6 +65,7 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
     returnValue.lipSyncFile = moviePaths.lipSyncFile;
     if (context.studio.script.audioParams?.suppressSpeech) {
+      // studio beat may ot have startAt and duration yet, in case of API call from the app.
       returnValue.startAt = context.studio.beats.filter((_, i) => i < index).reduce((acc, curr) => acc + (curr.duration ?? 0), 0);
       returnValue.duration = beat.duration ?? 0;
       returnValue.lipSyncTrimAudio = true;

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -65,8 +65,8 @@ export const imagePreprocessAgent = async (namedInputs: { context: MulmoStudioCo
     returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
     returnValue.lipSyncFile = moviePaths.lipSyncFile;
     if (context.studio.script.audioParams?.suppressSpeech) {
-      returnValue.startAt = studioBeat?.startAt ?? 0;
-      returnValue.duration = studioBeat?.duration ?? 0;
+      returnValue.startAt = context.studio.beats.filter((_, i) => i < index).reduce((acc, curr) => acc + (curr.duration ?? 0), 0);
+      returnValue.duration = beat.duration ?? 0;
       returnValue.lipSyncTrimAudio = true;
       returnValue.bgmFile = MulmoMediaSourceMethods.resolve(context.studio.script.audioParams.bgm, context);
       const folderName = MulmoStudioContextMethods.getFileName(context);

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -250,6 +250,7 @@ const beat_graph_data = {
         return { buffer };
       },
       inputs: {
+        onComplete: [":imageGenerator", ":imagePlugin"],
         audioFile: ":preprocessor.audioFile",
         bgmFile: ":preprocessor.bgmFile",
         startAt: ":preprocessor.startAt",

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -260,8 +260,8 @@ const beat_graph_data = {
           file: ":preprocessor.audioFile",
           index: ":__mapIndex",
           id: ":beat.id",
-          sessionType: "audioTrimmer",
           mulmoContext: ":context",
+          // sessionType: undefined, // no need to notify state change
         },
       },
       defaultValue: {},

--- a/src/methods/mulmo_studio_context.ts
+++ b/src/methods/mulmo_studio_context.ts
@@ -59,7 +59,10 @@ export const MulmoStudioContextMethods = {
     context.sessionState.inSession[sessionType] = value;
     notifyStateChange(context, sessionType);
   },
-  setBeatSessionState(context: MulmoStudioContext, sessionType: BeatSessionType, index: number, id: string | undefined, value: boolean) {
+  setBeatSessionState(context: MulmoStudioContext, sessionType: BeatSessionType | undefined, index: number, id: string | undefined, value: boolean) {
+    if (!sessionType) {
+      return;
+    }
     const key = beatId(id, index);
     if (value) {
       if (!context.sessionState.inBeatSession[sessionType]) {

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -37,7 +37,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     return true;
   }
   try {
-    MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, true);
+    sessionType && MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, true);
     const output = ((await next(context)) as { buffer?: Buffer; text?: string; saved?: boolean }) || undefined;
     const { buffer, text, saved } = output ?? {};
     if (saved) {
@@ -57,7 +57,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     GraphAILogger.log("no cache, no buffer: " + file);
     return false;
   } finally {
-    MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, false);
+    sessionType && MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, false);
   }
 };
 

--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -37,7 +37,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     return true;
   }
   try {
-    sessionType && MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, true);
+    MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, true);
     const output = ((await next(context)) as { buffer?: Buffer; text?: string; saved?: boolean }) || undefined;
     const { buffer, text, saved } = output ?? {};
     if (saved) {
@@ -57,7 +57,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     GraphAILogger.log("no cache, no buffer: " + file);
     return false;
   } finally {
-    sessionType && MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, false);
+    MulmoStudioContextMethods.setBeatSessionState(mulmoContext, sessionType, index, id, false);
   }
 };
 


### PR DESCRIPTION
- So that the app can generate lipSync without the audio
- Eliminated the unnecessary "trimMusic" notification
- MusicTrimmer waits for image generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected audio timing across beats using cumulative offsets, reducing misalignment.
  - Prevented rare crashes by safely handling missing session information.
- Refactor
  - Synchronized audio trimming completion with image generation, ensuring steps finish in the correct order for more reliable outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->