### PR TITLE
Improve document generation process

### DIFF
--- a/automation/generate_actions_docs/docs_template.md
+++ b/automation/generate_actions_docs/docs_template.md
@@ -4,16 +4,14 @@ generated_at: {{GENERATED_DATE}}
 
 # {{SCRIPT_NAME}}
 
-This file is an auto-generated documentation of the GraphAI graph structure defined in:
+This file is an auto-generated documentation of the GraphAI graph structure defined in: 
 [{{SCRIPT_PATH}}]({{SCRIPT_PATH}})
 
-## Graph Structure
+## Graph Structures
 
-The following Mermaid diagram shows the GraphAI graph structure defined in this script:
+The following Mermaid diagrams show the GraphAI graph structures defined in this script. Each section corresponds to a variable named `*_graph_data`:
 
-```mermaid
-{{MERMAID_DIAGRAM}}
-```
+{{MERMAID_SECTIONS}}
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "format": "prettier --write '{src,scripts,assets/templates,assets/styles,draft,ideason,scripts_mag2,proto,test,batch,graphai,output,docs/scripts}/**/*.{ts,json,yaml}'",
     "deep_research": "npx tsx ./src/tools/deep_research.ts",
     "template": "npx tsx batch/template2tsobject.ts && yarn run format",
-    "mcp_server": "npx tsx ./src/mcp/server.ts"
+    "mcp_server": "npx tsx ./src/mcp/server.ts",
+    "generate_action_docs": "npx tsx ./automation/generate_actions_docs/generate_action_docs.ts"
   },
   "repository": "git+ssh://git@github.com/receptron/mulmocast-cli.git",
   "author": "snakajima",

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -1,0 +1,33 @@
+## Actions Directory
+
+This folder contains action implementations (e.g., `audio.ts`, `images.ts`, `movie.ts`) and their auto‑generated docs (`*.docs.md`).
+
+### How docs are generated
+
+- Script: `automation/generate_actions_docs/generate_action_docs.ts`
+- Dynamically imports action files, detects exports ending with `*_graph_data` (and legacy `graph_data`), converts them to Mermaid, and writes `*.docs.md` alongside each file.
+- If multiple `*_graph_data` exist, it outputs multiple sections (`### <varName>`) in one doc.
+
+#### Template
+
+- `automation/generate_actions_docs/docs_template.md`
+- Inserts diagrams into `{{MERMAID_SECTIONS}}`.
+- Adds `generated_at` and a GitHub link to the source file.
+
+#### Run
+
+From the repo root:
+
+```bash
+yarn generate_action_docs
+# or
+npm run generate_action_docs
+```
+
+This regenerates `*.docs.md` for files under `src/actions/`. If a file has no `*_graph_data` / `graph_data` export, no doc is produced.
+
+### Notes / Best practices
+
+- Export graphs as `GraphData` with names like `xxx_graph_data` (ending in `_graph_data`).
+- Because files are imported at generation time, avoid side effects that require runtime setup.
+

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -5,14 +5,12 @@ This folder contains action implementations (e.g., `audio.ts`, `images.ts`, `mov
 ### How docs are generated
 
 - Script: `automation/generate_actions_docs/generate_action_docs.ts`
-- Dynamically imports action files, detects exports ending with `*_graph_data` (and legacy `graph_data`), converts them to Mermaid, and writes `*.docs.md` alongside each file.
-- If multiple `*_graph_data` exist, it outputs multiple sections (`### <varName>`) in one doc.
+- Dynamically imports action files, detects exports ending with `*_graph_data`, converts them to Mermaid, and writes `*.docs.md` alongside each file.
 
 #### Template
 
 - `automation/generate_actions_docs/docs_template.md`
 - Inserts diagrams into `{{MERMAID_SECTIONS}}`.
-- Adds `generated_at` and a GitHub link to the source file.
 
 #### Run
 
@@ -22,7 +20,7 @@ From the repo root:
 yarn generate_action_docs
 ```
 
-This regenerates `*.docs.md` for files under `src/actions/`. If a file has no `*_graph_data` / `graph_data` export, no doc is produced.
+This regenerates `*.docs.md` for files under `src/actions/`. If a file has no `*_graph_data` export, no doc is produced.
 
 ### Notes / Best practices
 

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -20,8 +20,6 @@ From the repo root:
 
 ```bash
 yarn generate_action_docs
-# or
-npm run generate_action_docs
 ```
 
 This regenerates `*.docs.md` for files under `src/actions/`. If a file has no `*_graph_data` / `graph_data` export, no doc is produced.

--- a/src/actions/audio.docs.md
+++ b/src/actions/audio.docs.md
@@ -1,15 +1,17 @@
 ---
-generated_at: 2025-09-03T23:45:43.812Z
+generated_at: 2025-09-04T12:47:52.499Z
 ---
 
 # audio
 
-This file is an auto-generated documentation of the GraphAI graph structure defined in:
+This file is an auto-generated documentation of the GraphAI graph structure defined in: 
 [https://github.com/receptron/mulmocast-cli/blob/main/src/actions/audio.ts](https://github.com/receptron/mulmocast-cli/blob/main/src/actions/audio.ts)
 
-## Graph Structure
+## Graph Structures
 
-The following Mermaid diagram shows the GraphAI graph structure defined in this script:
+The following Mermaid diagrams show the GraphAI graph structures defined in this script. Each section corresponds to a variable named `*_graph_data`:
+
+### audio_graph_data
 
 ```mermaid
 flowchart TD

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -162,7 +162,7 @@ const graph_tts_map: GraphData = {
     },
   },
 };
-export const graph_data: GraphData = {
+export const audio_graph_data: GraphData = {
   version: 0.5,
   concurrency: 8,
   nodes: {
@@ -305,7 +305,7 @@ export const audio = async (context: MulmoStudioContext, args?: PublicAPIArgs) =
 
     const config = settings2GraphAIConfig(settings, process.env);
     const taskManager = new TaskManager(getConcurrency(context));
-    const graph = new GraphAI(graph_data, audioAgents, { agentFilters, taskManager, config });
+    const graph = new GraphAI(audio_graph_data, audioAgents, { agentFilters, taskManager, config });
     graph.injectValue("context", context);
     graph.injectValue("audioArtifactFilePath", audioArtifactFilePath);
     graph.injectValue("audioCombinedFilePath", audioCombinedFilePath);

--- a/src/actions/captions.docs.md
+++ b/src/actions/captions.docs.md
@@ -1,15 +1,17 @@
 ---
-generated_at: 2025-09-03T23:45:43.814Z
+generated_at: 2025-09-04T12:47:52.501Z
 ---
 
 # captions
 
-This file is an auto-generated documentation of the GraphAI graph structure defined in:
+This file is an auto-generated documentation of the GraphAI graph structure defined in: 
 [https://github.com/receptron/mulmocast-cli/blob/main/src/actions/captions.ts](https://github.com/receptron/mulmocast-cli/blob/main/src/actions/captions.ts)
 
-## Graph Structure
+## Graph Structures
 
-The following Mermaid diagram shows the GraphAI graph structure defined in this script:
+The following Mermaid diagrams show the GraphAI graph structures defined in this script. Each section corresponds to a variable named `*_graph_data`:
+
+### caption_graph_data
 
 ```mermaid
 flowchart TD

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -10,7 +10,7 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 
 const vanillaAgents = agents.default ?? agents;
 
-export const graph_data: GraphData = {
+export const caption_graph_data: GraphData = {
   version: 0.5,
   nodes: {
     context: {},
@@ -78,7 +78,7 @@ export const captions = async (context: MulmoStudioContext, args?: PublicAPIArgs
   if (MulmoStudioContextMethods.getCaption(context)) {
     try {
       MulmoStudioContextMethods.setSessionState(context, "caption", true);
-      const graph = new GraphAI(graph_data, { ...vanillaAgents, fileWriteAgent });
+      const graph = new GraphAI(caption_graph_data, { ...vanillaAgents, fileWriteAgent });
       const outDirPath = MulmoStudioContextMethods.getOutDirPath(context);
       const fileName = MulmoStudioContextMethods.getFileName(context);
       const outputStudioFilePath = getOutputStudioFilePath(outDirPath, fileName);

--- a/src/actions/images.docs.md
+++ b/src/actions/images.docs.md
@@ -1,15 +1,153 @@
 ---
-generated_at: 2025-09-03T23:45:43.839Z
+generated_at: 2025-09-04T12:47:52.515Z
 ---
 
 # images
 
-This file is an auto-generated documentation of the GraphAI graph structure defined in:
+This file is an auto-generated documentation of the GraphAI graph structure defined in: 
 [https://github.com/receptron/mulmocast-cli/blob/main/src/actions/images.ts](https://github.com/receptron/mulmocast-cli/blob/main/src/actions/images.ts)
 
-## Graph Structure
+## Graph Structures
 
-The following Mermaid diagram shows the GraphAI graph structure defined in this script:
+The following Mermaid diagrams show the GraphAI graph structures defined in this script. Each section corresponds to a variable named `*_graph_data`:
+
+### beat_graph_data
+
+```mermaid
+flowchart TD
+  n_context(context)
+  n_htmlImageAgentInfo(htmlImageAgentInfo)
+  n_imageRefs(imageRefs)
+  n_beat(beat)
+  n___mapIndex(__mapIndex)
+  n_forceMovie(forceMovie)
+  n_forceImage(forceImage)
+  n_forceLipSync(forceLipSync)
+  n_forceSoundEffect(forceSoundEffect)
+  n_preprocessor(preprocessor<br/>imagePreprocessAgent)
+  n_context --> n_preprocessor
+  n_beat --> n_preprocessor
+  n___mapIndex --> n_preprocessor
+  n_imageRefs --> n_preprocessor
+  n_imagePlugin(imagePlugin<br/>imagePluginAgent)
+  n_context --> n_imagePlugin
+  n_beat --> n_imagePlugin
+  n___mapIndex --> n_imagePlugin
+  n_preprocessor --> n_imagePlugin
+  n_htmlImageAgent(htmlImageAgent<br/>:htmlImageAgentInfo.agent)
+  n_preprocessor -- htmlPrompt --> n_htmlImageAgent
+  n_preprocessor -- htmlImageSystemPrompt --> n_htmlImageAgent
+  n_htmlImageAgentInfo -- model --> n_htmlImageAgent
+  n_htmlImageAgentInfo -- max_tokens --> n_htmlImageAgent
+  n_context -- force --> n_htmlImageAgent
+  n_forceImage --> n_htmlImageAgent
+  n_preprocessor -- htmlPath --> n_htmlImageAgent
+  n___mapIndex --> n_htmlImageAgent
+  n_beat -- id --> n_htmlImageAgent
+  n_context --> n_htmlImageAgent
+  n_htmlReader(htmlReader<br/>agent)
+  n_htmlImageAgent --> n_htmlReader
+  n_preprocessor -- htmlPath --> n_htmlReader
+  n_htmlImageGenerator(htmlImageGenerator<br/>htmlImageGeneratorAgent)
+  n_htmlReader -- htmlText --> n_htmlImageGenerator
+  n_context -- presentationStyle.canvasSize --> n_htmlImageGenerator
+  n_preprocessor -- htmlImageFile --> n_htmlImageGenerator
+  n_imageGenerator(imageGenerator<br/>:preprocessor.imageAgentInfo.agent)
+  n_preprocessor -- prompt --> n_imageGenerator
+  n_preprocessor -- referenceImages --> n_imageGenerator
+  n_context -- force --> n_imageGenerator
+  n_forceImage --> n_imageGenerator
+  n_preprocessor -- imagePath --> n_imageGenerator
+  n___mapIndex --> n_imageGenerator
+  n_beat -- id --> n_imageGenerator
+  n_context --> n_imageGenerator
+  n_preprocessor -- imageParams.model --> n_imageGenerator
+  n_preprocessor -- imageParams.moderation --> n_imageGenerator
+  n_context -- presentationStyle.canvasSize --> n_imageGenerator
+  n_preprocessor -- imageParams.quality --> n_imageGenerator
+  n_movieGenerator(movieGenerator<br/>:preprocessor.movieAgentInfo.agent)
+  n_imageGenerator --> n_movieGenerator
+  n_imagePlugin --> n_movieGenerator
+  n_beat -- moviePrompt --> n_movieGenerator
+  n_preprocessor -- referenceImageForMovie --> n_movieGenerator
+  n_preprocessor -- movieFile --> n_movieGenerator
+  n_context -- force --> n_movieGenerator
+  n_forceMovie --> n_movieGenerator
+  n_preprocessor -- movieFile --> n_movieGenerator
+  n___mapIndex --> n_movieGenerator
+  n_beat -- id --> n_movieGenerator
+  n_context --> n_movieGenerator
+  n_preprocessor -- movieAgentInfo.movieParams.model --> n_movieGenerator
+  n_preprocessor -- beatDuration --> n_movieGenerator
+  n_context -- presentationStyle.canvasSize --> n_movieGenerator
+  n_imageFromMovie(imageFromMovie<br/>agent)
+  n_movieGenerator --> n_imageFromMovie
+  n_preprocessor -- imagePath --> n_imageFromMovie
+  n_preprocessor -- movieFile --> n_imageFromMovie
+  n_audioChecker(audioChecker<br/>agent)
+  n_movieGenerator --> n_audioChecker
+  n_htmlImageGenerator --> n_audioChecker
+  n_soundEffectGenerator --> n_audioChecker
+  n_preprocessor -- movieFile --> n_audioChecker
+  n_preprocessor -- imagePath --> n_audioChecker
+  n_preprocessor -- soundEffectFile --> n_audioChecker
+  n_soundEffectGenerator(soundEffectGenerator<br/>:preprocessor.soundEffectAgentInfo.agentName)
+  n_movieGenerator --> n_soundEffectGenerator
+  n_preprocessor -- soundEffectPrompt --> n_soundEffectGenerator
+  n_preprocessor -- movieFile --> n_soundEffectGenerator
+  n_preprocessor -- soundEffectFile --> n_soundEffectGenerator
+  n_preprocessor -- soundEffectModel --> n_soundEffectGenerator
+  n_preprocessor -- beatDuration --> n_soundEffectGenerator
+  n_context -- force --> n_soundEffectGenerator
+  n_forceSoundEffect --> n_soundEffectGenerator
+  n_preprocessor -- soundEffectFile --> n_soundEffectGenerator
+  n___mapIndex --> n_soundEffectGenerator
+  n_beat -- id --> n_soundEffectGenerator
+  n_context --> n_soundEffectGenerator
+  n_AudioTrimmer(AudioTrimmer<br/>agent)
+  n_imageGenerator --> n_AudioTrimmer
+  n_imagePlugin --> n_AudioTrimmer
+  n_preprocessor -- audioFile --> n_AudioTrimmer
+  n_preprocessor -- bgmFile --> n_AudioTrimmer
+  n_preprocessor -- startAt --> n_AudioTrimmer
+  n_preprocessor -- duration --> n_AudioTrimmer
+  n_context -- force --> n_AudioTrimmer
+  n_preprocessor -- audioFile --> n_AudioTrimmer
+  n___mapIndex --> n_AudioTrimmer
+  n_beat -- id --> n_AudioTrimmer
+  n_context --> n_AudioTrimmer
+  n_lipSyncGenerator(lipSyncGenerator<br/>:preprocessor.lipSyncAgentName)
+  n_soundEffectGenerator --> n_lipSyncGenerator
+  n_AudioTrimmer --> n_lipSyncGenerator
+  n_preprocessor -- movieFile --> n_lipSyncGenerator
+  n_preprocessor -- referenceImageForMovie --> n_lipSyncGenerator
+  n_preprocessor -- audioFile --> n_lipSyncGenerator
+  n_preprocessor -- lipSyncFile --> n_lipSyncGenerator
+  n_preprocessor -- lipSyncModel --> n_lipSyncGenerator
+  n_preprocessor -- beatDuration --> n_lipSyncGenerator
+  n_context -- force --> n_lipSyncGenerator
+  n_forceLipSync --> n_lipSyncGenerator
+  n_preprocessor -- lipSyncFile --> n_lipSyncGenerator
+  n___mapIndex --> n_lipSyncGenerator
+  n_beat -- id --> n_lipSyncGenerator
+  n_context --> n_lipSyncGenerator
+  n_output(output<br/>copyAgent)
+  n_imageFromMovie --> n_output
+  n_htmlImageGenerator --> n_output
+  n_audioChecker --> n_output
+  n_soundEffectGenerator --> n_output
+  n_lipSyncGenerator --> n_output
+  n_preprocessor -- imagePath --> n_output
+  n_preprocessor -- movieFile --> n_output
+  n_preprocessor -- soundEffectFile --> n_output
+  n_preprocessor -- lipSyncFile --> n_output
+  n_audioChecker -- hasMovieAudio --> n_output
+  n_preprocessor -- htmlImageFile --> n_output
+  class n_context,n_htmlImageAgentInfo,n_imageRefs,n_beat,n___mapIndex,n_forceMovie,n_forceImage,n_forceLipSync,n_forceSoundEffect staticNode
+  class n_preprocessor,n_imagePlugin,n_htmlImageAgent,n_htmlReader,n_htmlImageGenerator,n_imageGenerator,n_movieGenerator,n_imageFromMovie,n_audioChecker,n_soundEffectGenerator,n_AudioTrimmer,n_lipSyncGenerator,n_output computedNode
+```
+
+### images_graph_data
 
 ```mermaid
 flowchart TD

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -60,7 +60,7 @@ const defaultAgents = {
 
 dotenv.config();
 
-const beat_graph_data = {
+export const beat_graph_data = {
   version: 0.5,
   concurrency: 4,
   nodes: {
@@ -317,7 +317,7 @@ const beat_graph_data = {
   },
 };
 
-export const graph_data: GraphData = {
+export const images_graph_data: GraphData = {
   version: 0.5,
   concurrency: 4,
   nodes: {
@@ -435,7 +435,7 @@ const generateImages = async (context: MulmoStudioContext, args?: PublicAPIArgs 
     ...defaultAgents,
     ...optionImageAgents,
   };
-  const graph = new GraphAI(graph_data, graphaiAgent, await graphOption(context, settings));
+  const graph = new GraphAI(images_graph_data, graphaiAgent, await graphOption(context, settings));
   Object.keys(injections).forEach((key: string) => {
     graph.injectValue(key, injections[key]);
   });

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,6 +1,6 @@
-export { audio, generateBeatAudio, getBeatAudioPath, listLocalizedAudioPaths } from "./audio.js";
-export { images, generateBeatImage, graphOption } from "./images.js";
-export { captions } from "./captions.js";
+export * from "./audio.js";
+export * from "./images.js";
+export * from "./captions.js";
 export * from "./image_references.js";
 export * from "./image_agents.js";
 export * from "./movie.js";

--- a/src/actions/translate.docs.md
+++ b/src/actions/translate.docs.md
@@ -1,0 +1,84 @@
+---
+generated_at: 2025-09-04T12:47:52.520Z
+---
+
+# translate
+
+This file is an auto-generated documentation of the GraphAI graph structure defined in: 
+[https://github.com/receptron/mulmocast-cli/blob/main/src/actions/translate.ts](https://github.com/receptron/mulmocast-cli/blob/main/src/actions/translate.ts)
+
+## Graph Structures
+
+The following Mermaid diagrams show the GraphAI graph structures defined in this script. Each section corresponds to a variable named `*_graph_data`:
+
+### translate_graph_data
+
+```mermaid
+flowchart TD
+  n_context(context)
+  n_outDirPath(outDirPath)
+  n_outputMultilingualFilePath(outputMultilingualFilePath)
+  n_targetLangs(targetLangs)
+  n_mergeStudioResult(mergeStudioResult<br/>agent)
+  n_context -- multiLingual --> n_mergeStudioResult
+  n_beatsMap -- mergeMultiLingualData --> n_mergeStudioResult
+  n_context -- studio.script.beats --> n_mergeStudioResult
+  subgraph n_beatsMap[beatsMap: mapAgent]
+    n_beatsMap_targetLangs(targetLangs)
+    n_beatsMap_context(context)
+    n_beatsMap_beat(beat)
+    n_beatsMap___mapIndex(__mapIndex)
+    n_beatsMap_multiLingual(multiLingual<br/>agent)
+    n_beatsMap_beat -- text --> n_beatsMap_multiLingual
+    n_beatsMap___mapIndex --> n_beatsMap_multiLingual
+    n_beatsMap_context -- multiLingual --> n_beatsMap_multiLingual
+    subgraph n_beatsMap_preprocessMultiLingual[preprocessMultiLingual: mapAgent]
+      n_beatsMap_preprocessMultiLingual_localizedText(localizedText<br/>openAIAgent)
+      n_beatsMap_preprocessMultiLingual_targetLang --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_beat --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_multiLingual --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_lang --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_beatIndex --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_context --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_lang --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_targetLang --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_beat -- text --> n_beatsMap_preprocessMultiLingual_localizedText
+      n_beatsMap_preprocessMultiLingual_splitText(splitText<br/>splitText)
+      n_beatsMap_preprocessMultiLingual_targetLang --> n_beatsMap_preprocessMultiLingual_splitText
+      n_beatsMap_preprocessMultiLingual_localizedText --> n_beatsMap_preprocessMultiLingual_splitText
+      n_beatsMap_preprocessMultiLingual_textTranslateResult(textTranslateResult<br/>copyAgent)
+      n_beatsMap_preprocessMultiLingual_targetLang --> n_beatsMap_preprocessMultiLingual_textTranslateResult
+      n_beatsMap_preprocessMultiLingual_localizedText -- text --> n_beatsMap_preprocessMultiLingual_textTranslateResult
+      n_beatsMap_preprocessMultiLingual_splitText --> n_beatsMap_preprocessMultiLingual_textTranslateResult
+      n_beatsMap_preprocessMultiLingual_splitText --> n_beatsMap_preprocessMultiLingual_textTranslateResult
+      n_beatsMap_preprocessMultiLingual_multiLingual -- cacheKey --> n_beatsMap_preprocessMultiLingual_textTranslateResult
+    end
+    n_beatsMap_beat --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap_multiLingual --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap_targetLangs --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap_context -- studio.script.lang --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap_context --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap___mapIndex --> n_beatsMap_preprocessMultiLingual
+    n_beatsMap_mergeLocalizedText(mergeLocalizedText<br/>arrayToObjectAgent)
+    n_beatsMap_preprocessMultiLingual -- textTranslateResult --> n_beatsMap_mergeLocalizedText
+    n_beatsMap_multiLingualTexts(multiLingualTexts<br/>mergeObjectAgent)
+    n_beatsMap_multiLingual -- multiLingualTexts --> n_beatsMap_multiLingualTexts
+    n_beatsMap_mergeLocalizedText --> n_beatsMap_multiLingualTexts
+    n_beatsMap_mergeMultiLingualData(mergeMultiLingualData<br/>mergeObjectAgent)
+    n_beatsMap_multiLingual --> n_beatsMap_mergeMultiLingualData
+    n_beatsMap_multiLingualTexts --> n_beatsMap_mergeMultiLingualData
+  end
+  n_targetLangs --> n_beatsMap
+  n_context --> n_beatsMap
+  n_context -- studio.script.beats --> n_beatsMap
+  n_writeOutput(writeOutput<br/>fileWriteAgent)
+  n_outputMultilingualFilePath --> n_writeOutput
+  n_mergeStudioResult -- toJSON() --> n_writeOutput
+  class n_context,n_outDirPath,n_outputMultilingualFilePath,n_targetLangs,n_beatsMap_targetLangs,n_beatsMap_context,n_beatsMap_beat,n_beatsMap___mapIndex staticNode
+  class n_mergeStudioResult,n_beatsMap_multiLingual,n_beatsMap_preprocessMultiLingual_localizedText,n_beatsMap_preprocessMultiLingual_splitText,n_beatsMap_preprocessMultiLingual_textTranslateResult,n_beatsMap_mergeLocalizedText,n_beatsMap_multiLingualTexts,n_beatsMap_mergeMultiLingualData,n_writeOutput computedNode
+  class n_beatsMap_preprocessMultiLingual,n_beatsMap nestedGraph
+```
+
+---
+
+*This document is auto-generated. Please do not edit manually.*

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -149,7 +149,7 @@ const beatGraph = {
   },
 };
 
-const translateGraph: GraphData = {
+export const translate_graph_data: GraphData = {
   version: 0.5,
   nodes: {
     context: {},
@@ -310,7 +310,7 @@ export const translate = async (context: MulmoStudioContext, args?: PublicAPIArg
 
     assert(!!config?.openAIAgent?.apiKey, "The OPENAI_API_KEY environment variable is missing or empty");
 
-    const graph = new GraphAI(translateGraph, { ...vanillaAgents, fileWriteAgent, openAIAgent }, { agentFilters, config });
+    const graph = new GraphAI(translate_graph_data, { ...vanillaAgents, fileWriteAgent, openAIAgent }, { agentFilters, config });
 
     graph.injectValue("context", context);
     graph.injectValue("targetLangs", targetLangs);


### PR DESCRIPTION
actions配下のドキュメントの生成ロジックその他を改良しました。

- xxx_graph_dataという名でexportされた変数を基準にドキュメントを生成するように変更
- 複数のgraph_dataの表示に対応
- src/actionsにdcoument生成等に関するREADME.mdを追加
- src/actions/indexのnamed exportを解除（それぞれでgraphの変数名が変わったため不要になった）
- translateのドキュメントを追加
