### PR TITLE
update prompt for translation 

### DIFF
--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -34,9 +34,22 @@ export const interactiveClarificationPrompt = `If there are any unclear points, 
 
 export const prefixPrompt = "Here is the web content that can be used as reference material for the script:";
 
-export const translateSystemPrompt = "Please translate ONLY the text content from ## Original Language to ## Target Language (in locale format, like en, ja, fr, ch). Return ONLY the translated text without any formatting markers, language labels, or additional content.";
+export const translateSystemPrompt =
+  "Please translate ONLY the text content from ## Original Language to ## Target Language (in locale format, like en, ja, fr, ch). Return ONLY the translated text without any formatting markers, language labels, or additional content.";
 
-export const translatePrompts = ["## Original Language", ":lang", "","## Original Text", ":beat.text", "", "## Target Language", ":targetLang", "", "## Target Text", ""];
+export const translatePrompts = [
+  "## Original Language",
+  ":lang",
+  "",
+  "## Original Text",
+  ":beat.text",
+  "",
+  "## Target Language",
+  ":targetLang",
+  "",
+  "## Target Text",
+  "",
+];
 
 export const sceneToBeatsPrompt = ({
   sampleBeats,

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -34,9 +34,9 @@ export const interactiveClarificationPrompt = `If there are any unclear points, 
 
 export const prefixPrompt = "Here is the web content that can be used as reference material for the script:";
 
-export const translateSystemPrompt = "Please translate the given text into the language specified in language (in locale format, like en, ja, fr, ch).";
+export const translateSystemPrompt = "Please translate ONLY the text content from ## Original Language to ## Target Language (in locale format, like en, ja, fr, ch). Return ONLY the translated text without any formatting markers, language labels, or additional content.";
 
-export const translatePrompts = ["## Original Language", ":lang", "", "## Language", ":targetLang", "", "## Target", ":beat.text"];
+export const translatePrompts = ["## Original Language", ":lang", "","## Original Text", ":beat.text", "", "## Target Language", ":targetLang", "", "## Target Text", ""];
 
 export const sceneToBeatsPrompt = ({
   sampleBeats,


### PR DESCRIPTION
翻訳後の文章に prompt の一部（## Target 等）が出力される問題 https://github.com/receptron/mulmocast-app/issues/621 の対応です。
system prompt / user prompt を更新しました。

NG 出力の例
```
      "multiLingualTexts": {
        "ja": {
          "text": "## Target\nMulmocast Tech Insightsへようこそ。ここでは、テクノロジーの最先端とその世界的な影響を探ります。私はあなたのホストであり、今日は物理AIの魅力的な世界、特にヒューマノイドロボットとドローン、そしてこの分野での中国とアメリカの競争の激化についてお話しします。",
          "lang": "ja",
          "texts": [
            "## Target\nMulmocast Tech Insightsへようこそ。",
            "ここでは、テクノロジーの最先端とその世界的な影響を探ります。",
            "私はあなたのホストであり、",
            "今日は物理AIの魅力的な世界、",
            "特にヒューマノイドロボットとドローン、",
            "そしてこの分野での中国とアメリカの競争の激化についてお話しします。"
          ],
```

[scripts/samples/tesla_drone.json](scripts/samples/tesla_drone.json) を翻訳すると 26 beats 中の 2-3 beat は翻訳内容に ## 等が入り込んでいたのが、改善版では解消されたことを確認しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined the translation workflow with a clearer, more explicit input/output format to improve consistency and clarity.
- Bug Fixes
  - Translation results now return only the translated text, eliminating language labels, formatting markers, and extra content for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->