### PR TITLE
plain image promp

### DIFF
--- a/assets/templates/image_prompt.json
+++ b/assets/templates/image_prompt.json
@@ -1,0 +1,16 @@
+{
+  "title": "Plain Image Prompt",
+  "description": "Template for image prompt (no style, no images).",
+  "systemPrompt": "Another AI will generate images for each beat based on the image prompt of that beat. Movie prompts must be written in English. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "presentationStyle": {
+    "$mulmocast": {
+      "version": "1.1",
+      "credit": "closing"
+    },
+    "canvasSize": {
+      "width": 1536,
+      "height": 1024
+    }
+  },
+  "scriptName": "image_prompts_template.json"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a plain image prompt template for creating per‑beat image prompts in English. It supports optional reference mentions, provides clear system guidance, and enforces a standardized output structure for consistency.
  * Includes a preset canvas size (1536×1024) and a presentation style compatible with the current player format, ensuring predictable rendering.
  * Available as a selectable template when generating image prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->