### PR TITLE
documentary template

### DIFF
--- a/assets/templates/documentary.json
+++ b/assets/templates/documentary.json
@@ -1,0 +1,19 @@
+{
+  "title": "Documentary",
+  "description": "Template for documentary, biography, and other long form content.",
+  "systemPrompt": "Generate 30 to 40 beats. Another AI will generate image for each beat based on the text description of that beat. Mention the reference in one of beats, if it exists. Use the JSON below as a template.",
+  "presentationStyle": {
+    "$mulmocast": {
+      "version": "1.1",
+      "credit": "closing"
+    },
+    "imageParams": {
+      "style": "<style>Photo realistic and cinematic. Let the art convey the story and emotions without text. Use the image for the aspect ratio</style>"
+    },
+    "canvasSize": {
+      "width": 1536,
+      "height": 1024
+    }
+  },
+  "scriptName": "text_only_template.json"
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a “Documentary” template for long-form, biography, and documentary-style projects.
  - Generates outlines with 30–40 beats, supporting optional reference mentions.
  - Optimized for photo-realistic, cinematic imagery with no text overlays.
  - Default canvas size set to 1536×1024 for consistent visuals.
  - Includes closing credits configuration.
  - Compatible with text-only scripting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->