### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Commands:
   mulmo images <file>     Generate image files
   mulmo movie <file>      Generate movie file
   mulmo pdf <file>        Generate PDF files
+  mulmo markdown <file>   Generate markdown files
+  mulmo html <file>       Generate html files
   mulmo tool <command>    Generate Mulmo script and other tools
 
 Options:
@@ -394,6 +396,50 @@ Options:
                [string] [choices: "slide", "talk", "handout"] [default: "slide"]
       --pdf_size           PDF paper size (default: letter)
                                    [choices: "letter", "a4"] [default: "letter"]
+```
+
+```
+mulmo markdown <file>
+
+Generate markdown files
+
+Positionals:
+  file  Mulmo Script File                                    [string] [required]
+
+Options:
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language
+  [string] [choices: "en", "ja", "fr", "es", "de", "zh-CN", "zh-TW", "ko", "it",
+                                                               "pt", "ar", "hi"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+      --image_width        Image width (e.g., 400px, 50%, auto)         [string]
+```
+
+```
+mulmo html <file>
+
+Generate html files
+
+Positionals:
+  file  Mulmo Script File                                    [string] [required]
+
+Options:
+      --version            Show version number                         [boolean]
+  -v, --verbose            verbose log     [boolean] [required] [default: false]
+  -h, --help               Show help                                   [boolean]
+  -o, --outdir             output dir                                   [string]
+  -b, --basedir            base dir                                     [string]
+  -l, --lang               target language
+  [string] [choices: "en", "ja", "fr", "es", "de", "zh-CN", "zh-TW", "ko", "it",
+                                                               "pt", "ar", "hi"]
+  -f, --force              Force regenerate           [boolean] [default: false]
+  -p, --presentationStyle  Presentation Style                           [string]
+      --image_width        Image width (e.g., 400px, 50%, auto)         [string]
 ```
 
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added README coverage for two CLI commands: mulmo markdown <file> and mulmo html <file>.
  * Included usage examples and a shared set of options: --version, -v/--verbose, -h/--help, -o/--outdir, -b/--basedir, -l/--lang (en, ja, fr, es, de, zh-CN, zh-TW, ko, it, pt, ar, hi), -f/--force, -p/--presentationStyle, and --image_width.
  * Commands now appear in the main Commands list and in dedicated usage sections for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->