### PR TITLE
set default speaker provider

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -400,6 +400,7 @@ export const mulmoPresentationStyleSchema = z.object({
     .default({
       speakers: {
         [defaultSpeaker]: {
+          provider: defaultProviders.tts
           voiceId: "shimmer",
           displayName: {
             en: defaultSpeaker,

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -400,7 +400,7 @@ export const mulmoPresentationStyleSchema = z.object({
     .default({
       speakers: {
         [defaultSpeaker]: {
-          provider: defaultProviders.tts
+          provider: defaultProviders.tts,
           voiceId: "shimmer",
           displayName: {
             en: defaultSpeaker,

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -46,7 +46,7 @@ test("test createStudioData", async () => {
       $mulmocast: { version: "1.1", credit: "closing" },
       lang: "en",
       canvasSize: { width: 1280, height: 720 },
-      speechParams: { speakers: { Presenter: { displayName: { en: "Presenter" }, voiceId: "shimmer" } } },
+      speechParams: { speakers: { Presenter: { displayName: { en: "Presenter" }, voiceId: "shimmer", provider: 'openai' } } },
       soundEffectParams: {
         provider: "replicate",
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The default Presenter voice now explicitly uses the app’s default TTS provider, improving consistency out of the box. You may notice subtle changes in timbre/quality for presentations that rely on defaults. Custom speaker configurations and overrides remain unchanged; no configuration changes required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->