### PR TITLE
fix getAvailablePromptTemplates json file only

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -251,19 +251,21 @@ const getPromptTemplates = <T>(dirPath: string, schema: ZodType | null): T[] => 
   }
 
   const files = fs.readdirSync(templatesDir);
-  return files.map((file) => {
-    try {
-      const promptTemplate = JSON.parse(fs.readFileSync(path.resolve(templatesDir, file), "utf-8"));
-      return {
-        ...(schema ? schema.parse(promptTemplate) : promptTemplate),
-        filename: file.replace(/\.json$/, ""),
-      };
-    } catch (e) {
-      GraphAILogger.info("file: " + file);
-      GraphAILogger.info(e);
-      return {};
-    }
-  });
+  return files
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => {
+      try {
+        const promptTemplate = JSON.parse(fs.readFileSync(path.resolve(templatesDir, file), "utf-8"));
+        return {
+          ...(schema ? schema.parse(promptTemplate) : promptTemplate),
+          filename: file.replace(/\.json$/, ""),
+        };
+      } catch (e) {
+        GraphAILogger.info("file: " + file);
+        GraphAILogger.info(e);
+        return {};
+      }
+    });
 };
 
 export const getAvailablePromptTemplates = (): MulmoPromptTemplateFile[] => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt templates load more reliably by only processing .json files, reducing parsing errors and unexpected empty templates.
* **Performance**
  * Faster and more stable template discovery by skipping non-JSON files.
* **Developer Experience**
  * Cleaner logs with fewer noisy parse errors during template loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->