### PR TITLE
add mulmoImageParamsImagesValueSchema

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -219,7 +219,8 @@ export const mulmoImagePromptMediaSchema = z
   })
   .strict();
 
-export const mulmoImageParamsImagesSchema = z.record(imageIdSchema, z.union([mulmoImageMediaSchema, mulmoImagePromptMediaSchema]));
+export const mulmoImageParamsImagesValueSchema = z.union([mulmoImageMediaSchema, mulmoImagePromptMediaSchema]);
+export const mulmoImageParamsImagesSchema = z.record(imageIdSchema, mulmoImageParamsImagesValueSchema);
 export const mulmoFillOptionSchema = z
   .object({
     style: z.enum(["aspectFit", "aspectFill"]).default("aspectFit"),

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -14,6 +14,7 @@ import {
   mulmoStudioMultiLingualFileSchema,
   speakerDictionarySchema,
   mulmoImageParamsSchema,
+  mulmoImageParamsImagesValueSchema,
   mulmoImageParamsImagesSchema,
   mulmoFillOptionSchema,
   mulmoMovieParamsSchema,
@@ -56,6 +57,7 @@ export type SpeakerDictonary = z.infer<typeof speakerDictionarySchema>;
 export type SpeechOptions = z.infer<typeof speechOptionsSchema>;
 export type SpeakerData = z.infer<typeof speakerDataSchema>;
 export type MulmoImageParams = z.infer<typeof mulmoImageParamsSchema>;
+export type MulmoImageParamsImagesValue = z.infer<typeof mulmoImageParamsImagesValueSchema>;
 export type MulmoImageParamsImages = z.infer<typeof mulmoImageParamsImagesSchema>;
 export type MulmoFillOption = z.infer<typeof mulmoFillOptionSchema>;
 export type TextSlideParams = z.infer<typeof textSlideParamsSchema>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Exposed a new public schema for image parameter values.
  - Added a corresponding TypeScript type alias for easier typing.

- Refactor
  - Updated the existing image parameters schema to reference the new value schema, with no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->