### PR TITLE
reference image prompt require prompt

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -215,7 +215,7 @@ const imageIdSchema = z.string();
 export const mulmoImagePromptMediaSchema = z
   .object({
     type: z.literal("imagePrompt"),
-    prompt: z.string(),
+    prompt: z.string().min(1),
   })
   .strict();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image prompt fields now require at least one character. Empty prompts are no longer accepted and will display a validation message before submission, preventing accidental blank requests.
  * This improves input reliability and aligns validation behavior across the app for media prompts, reducing failed actions caused by missing content. Existing non-empty prompts continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->