### PR TITLE
update schema: enableLipSync and soundEffectPrompt cannot be active a…

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -368,7 +368,11 @@ export const mulmoBeatSchema = z
     enableLipSync: z.boolean().optional().describe("Enable lip sync generation for this beat"),
     hidden: z.boolean().optional().describe("Hide this beat from the presentation"),
   })
-  .strict();
+  .strict()
+  .refine((data) => !(data.enableLipSync && data.soundEffectPrompt && data.soundEffectPrompt.trim() !== ""), {
+    message: "enableLipSync and soundEffectPrompt cannot be active at the same time.",
+    path: ["enableLipSync"],
+  });
 
 export const mulmoCanvasDimensionSchema = z
   .object({


### PR DESCRIPTION
update schema: enableLipSync and soundEffectPrompt cannot be active at the same time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent simultaneous activation of Lip Sync and Sound Effect Prompt settings. Users will now receive a clear error message if both options are enabled together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->