### PR TITLE
Revert "update schema: enableLipSync and soundEffectPrompt cannot be active a…"

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -368,11 +368,7 @@ export const mulmoBeatSchema = z
     enableLipSync: z.boolean().optional().describe("Enable lip sync generation for this beat"),
     hidden: z.boolean().optional().describe("Hide this beat from the presentation"),
   })
-  .strict()
-  .refine((data) => !(data.enableLipSync && data.soundEffectPrompt && data.soundEffectPrompt.trim() !== ""), {
-    message: "enableLipSync and soundEffectPrompt cannot be active at the same time.",
-    path: ["enableLipSync"],
-  });
+  .strict();
 
 export const mulmoCanvasDimensionSchema = z
   .object({


### PR DESCRIPTION
Reverts receptron/mulmocast-cli#982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed overly restrictive validation that prevented enabling lip-sync when sound effect prompts are configured. Users can now use both features together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->