### PR TITLE
update image.md

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -11,7 +11,8 @@
 ### 特殊処理 soundEffectPrompt/enableLipSync/suppressSpeech
 7. 1のtype=movie, 4, 6で動画が生成され、beatに`soundEffectPrompt`があれば、動画に対してsoundEffectPromptで指定されている音声を作成・合成する
 8. 画像が生成され、beatに`enableLipSync`の指定があれば、画像と音声ファイルを使ってリップシンクの処理を行う。生成物は動画になる。
-9. `audioParams.suppressSpeech: true`が指定されている場合、全てのbeatでテキストからの音声読み上げ（TTS）を行わず、音声トラックはBGMのみになる
+   - 注: Replicate 上に動画に対してリップシンク処理が可能なモデルはある、しかし、現時点で MulmoCast 側では動作未確認。なお、将来的にモデル追加する場合は、この生成ロジックの変更は不要。 
+9.  `audioParams.suppressSpeech: true`が指定されている場合、全てのbeatでテキストからの音声読み上げ（TTS）を行わず、音声トラックはBGMのみになる
 
 ## Beat画像・動画生成ルール一覧表
 


### PR DESCRIPTION
こちらの対応です

- enableLipSyncで動画なし -> imageでもlipSyncする(test_mv.jsonはimagePrompt + enableLipSyncなので動画なし） -> 8が間違い
- images.mdは、静止画、動画(moviePrompt or type=movie)までと、その後のsoundEffectPrompt/enableLipSyncsuppressSpeechを分けたほうがわかりやすい。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an expanded image/video generation rules subsection describing image→video generation flow.
  * Introduced a “special processing” section covering sound-effect prompts, lip-sync now tied to image-generated video, and suppress-speech behavior.
  * Replaced prior lip-sync/video guidance to reflect new image-generated-video workflow.
  * Added footnotes and clarified timing and media effects when TTS is suppressed.
  * Reorganized beat/table layout and updated cross-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->