### PR TITLE
fix: correct wipe transition offset calculation

### DIFF
--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -239,10 +239,14 @@ const addTransitionEffects = (
         return prevVideoId;
       }
 
-      // Use xfade offset instead of trimming to avoid framerate issues
-      // The static frames are created with proper duration, use offset to start transition at the right time
-      const prevBeatDuration = context.studio.beats[beatIndex - 1].duration ?? 0;
-      const xfadeOffset = prevBeatDuration - duration;
+      // Calculate the actual duration of the static frames
+      // The _last frame was generated with the previous beat's actual duration
+      const prevStudioBeat = context.studio.beats[beatIndex - 1];
+      const prevBeatActualDuration = Math.max(prevStudioBeat.duration! + getExtraPadding(context, beatIndex - 1), prevStudioBeat.movieDuration ?? 0);
+
+      // xfade offset must be non-negative and within the first video's duration
+      // Start the transition at the end of the first video minus the transition duration
+      const xfadeOffset = Math.max(0, prevBeatActualDuration - duration);
 
       // Apply xfade with explicit pixel format
       const xfadeOutputId = `${transitionVideoId}_xfade`;


### PR DESCRIPTION
Fixed issue where wipe transitions would start mid-way through (e.g., 1/3 already wiped) due to incorrect offset calculation.

Problem:
- xfade offset was calculated using simple beat.duration
- Did not account for padding and movieDuration
- Could result in negative or incorrect offset values

Solution:
- Calculate actual beat duration including:
  - getExtraPadding() for audio padding
  - movieDuration for video-based beats
- Use Math.max(0, ...) to ensure non-negative offset
- Start transition at correct time: actualDuration - transitionDuration

Technical changes:
- Calculate prevBeatActualDuration using Math.max of:
  - beat.duration + getExtraPadding()
  - beat.movieDuration
- Ensure xfadeOffset >= 0 with Math.max(0, actualDuration - duration)

Tested with wipetr transition (duration: 2s) on image beats. Log output shows correct offset calculation:
  [wipe] prevBeatActualDuration: 2.356, transition.duration: 2, xfadeOffset: 0.356
  [wipe] prevBeatActualDuration: 3.8, transition.duration: 2, xfadeOffset: 1.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio transition offset calculations to accurately reflect beat timing with padding, ensuring transitions render correctly with non-negative offsets for more reliable crossfades.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->