### PR TITLE
Add speed parameter support to OpenAI TTS agent

### DIFF
--- a/src/agents/tts_openai_agent.ts
+++ b/src/agents/tts_openai_agent.ts
@@ -19,7 +19,7 @@ export const ttsOpenaiAgent: AgentFunction<OpenAITTSAgentParams, AgentBufferResu
   config,
 }) => {
   const { text } = namedInputs;
-  const { model, voice, suppressError, instructions } = params;
+  const { model, voice, suppressError, instructions, speed } = params;
   const { apiKey, baseURL } = config ?? {};
   if (!apiKey) {
     throw new Error("OpenAI API key is required (OPENAI_API_KEY)", {
@@ -36,6 +36,9 @@ export const ttsOpenaiAgent: AgentFunction<OpenAITTSAgentParams, AgentBufferResu
     };
     if (instructions) {
       tts_options["instructions"] = instructions;
+    }
+    if (speed) {
+      tts_options["speed"] = speed;
     }
     GraphAILogger.log("ttsOptions", tts_options);
     const response = await openai.audio.speech.create(tts_options);

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -73,6 +73,7 @@ export type TTSAgentParams = {
 export type OpenAITTSAgentParams = TTSAgentParams & {
   instructions: string;
   model: string;
+  speed: number;
 };
 
 export type NijivoiceTTSAgentParams = TTSAgentParams & {


### PR DESCRIPTION
## Summary

- Add `speed` parameter to `OpenAITTSAgentParams` type
- Implement speed parameter handling in `ttsOpenaiAgent`
- OpenAI TTS API supports speed range: 0.25-4.0 (default: 1.0)

This change aligns OpenAI TTS with other providers (Google, ElevenLabs, NijiVoice) that already support speed configuration through `speechOptions`.

## Usage

```json
{
  "speechParams": {
    "speakers": {
      "FastSpeaker": {
        "voiceId": "shimmer",
        "provider": "openai",
        "speechOptions": {
          "speed": 1.5
        }
      }
    }
  }
}
```

## Testing

Tested with three different speeds (0.7x, 1.0x, 1.5x) and verified audio duration changes accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAI text-to-speech now supports a configurable speed parameter for voice synthesis.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->