### PR TITLE
Deprecation announcement: The following models will be shut down Marc…

### DIFF
--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -296,7 +296,7 @@ export const provider2LLMAgent = {
     agentName: "geminiAgent",
     defaultModel: "gemini-2.5-flash",
     max_tokens: 8192,
-    models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.0-flash"],
+    models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
     keyName: "GEMINI_API_KEY",
   },
   groq: {


### PR DESCRIPTION
…h 31, 2026:

gemini-2.0-flash
gemini-2.0-flash-001
gemini-2.0-flash-lite
gemini-2.0-flash-lite-001

https://ai.google.dev/gemini-api/docs/changelog.md#2026-01-22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Gemini AI model configuration to exclusively support the latest Gemini 2.5 series models. Older model versions are no longer available for selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->