### PR TITLE
feat: add Azure OpenAI support for translate action

### DIFF
--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -261,6 +261,7 @@ export const provider2LLMAgent = {
     defaultModel: "gpt-5",
     keyName: "OPENAI_API_KEY",
     baseURLKeyName: "OPENAI_BASE_URL",
+    apiVersionKeyName: "OPENAI_API_VERSION",
     max_tokens: 8192,
     models: [
       "gpt-5",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -65,7 +65,9 @@ export const settings2GraphAIConfig = (
     return settings?.[`${prefix}_${key}`] ?? settings?.[key] ?? env?.[`${prefix}_${key}`] ?? env?.[key];
   };
 
-  const addProviderConfigs = <T extends Record<string, { agentName: string; keyName?: string; baseURLKeyName?: string; apiKeyNameOverride?: string }>>(
+  const addProviderConfigs = <
+    T extends Record<string, { agentName: string; keyName?: string; baseURLKeyName?: string; apiVersionKeyName?: string; apiKeyNameOverride?: string }>,
+  >(
     config: ConfigDataDictionary<DefaultConfigData>,
     providers: T,
     prefix: string,
@@ -80,6 +82,9 @@ export const settings2GraphAIConfig = (
 
       if (info.baseURLKeyName) {
         config[info.agentName].baseURL = getKey(prefix, info.baseURLKeyName);
+      }
+      if (info.apiVersionKeyName) {
+        config[info.agentName].apiVersion = getKey(prefix, info.apiVersionKeyName);
       }
     });
   };


### PR DESCRIPTION
## Summary

- Add Azure OpenAI support for the translate action
- Works with the updated `@graphai/openai_agent` that supports Azure (see https://github.com/receptron/graphai/pull/1270)

## Changes

- Add `apiVersionKeyName: "OPENAI_API_VERSION"` to `provider2LLMAgent.openai`
- Update `settings2GraphAIConfig` to pass `apiVersion` to agent config

## Environment Variables

```bash
# For Azure OpenAI translate
LLM_OPENAI_BASE_URL=https://your-resource.openai.azure.com/
LLM_OPENAI_API_KEY=your-api-key
LLM_OPENAI_API_VERSION=2025-04-01-preview  # optional

# Or without prefix
OPENAI_BASE_URL=https://your-resource.openai.azure.com/
OPENAI_API_KEY=your-api-key
OPENAI_API_VERSION=2025-04-01-preview
```

## Test plan

- [x] Test translate with Azure OpenAI endpoint
- [x] Verify "Hello World" → "こんにちは世界" translation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)