### PR TITLE
feat: add Gemini 3 models support

### DIFF
--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -292,7 +292,7 @@ export const provider2LLMAgent = {
     agentName: "geminiAgent",
     defaultModel: "gemini-2.5-flash",
     max_tokens: 8192,
-    models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
+    models: ["gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
     keyName: "GEMINI_API_KEY",
   },
   groq: {


### PR DESCRIPTION
## Summary
- Add `gemini-3-pro-preview` and `gemini-3-flash-preview` to the LLM models list for Gemini provider

## Test plan
- [x] `yarn lint` passes
- [x] `yarn build` passes
- [ ] Tested with `yarn scripting --llm gemini --llm_model gemini-3-pro-preview`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini 3 preview models (Pro and Flash) alongside existing Gemini 2.5 variants, expanding available AI model options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->