### PR TITLE
feat: add tool complete command for MulmoScript completion

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -65,6 +65,7 @@ jobs:
     - run: yarn run cli bundle scripts/test/test_no_audio.json
     - run: yarn run cli markdown scripts/test/test_no_audio.json
     - run: yarn run cli html scripts/test/test_no_audio.json
+    - run: yarn run cli tool complete test/json/minimum_beats.json
     - name: Upload generated media
       uses: actions/upload-artifact@v4
       with:

--- a/src/cli/commands/tool/complete/builder.ts
+++ b/src/cli/commands/tool/complete/builder.ts
@@ -1,0 +1,26 @@
+import { Argv } from "yargs";
+import { getAvailablePromptTemplates } from "../../../../utils/file.js";
+
+const availableTemplateNames = getAvailablePromptTemplates().map((template) => template.filename);
+
+export const builder = (yargs: Argv) => {
+  return yargs
+    .option("o", {
+      alias: "output",
+      description: "Output file path (default: <file>_completed.json)",
+      demandOption: false,
+      type: "string",
+    })
+    .option("t", {
+      alias: "template",
+      description: "Template/style name to apply",
+      demandOption: false,
+      choices: availableTemplateNames,
+      type: "string",
+    })
+    .positional("file", {
+      description: "Input beats file path (JSON)",
+      type: "string",
+      demandOption: true,
+    });
+};

--- a/src/cli/commands/tool/complete/handler.ts
+++ b/src/cli/commands/tool/complete/handler.ts
@@ -1,0 +1,57 @@
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
+import { GraphAILogger } from "graphai";
+import { completeScript, templateExists } from "../../../../tools/complete_script.js";
+
+type CompleteHandlerArgs = {
+  file: string;
+  o?: string;
+  t?: string;
+  v?: boolean;
+};
+
+export const handler = async (argv: CompleteHandlerArgs) => {
+  const { file, o: outputPath, t: templateName, v: verbose } = argv;
+
+  if (!file) {
+    GraphAILogger.error("Error: Input file is required");
+    process.exit(1);
+  }
+
+  const inputPath = path.resolve(file);
+
+  const inputData = (() => {
+    try {
+      const content = readFileSync(inputPath, "utf-8");
+      return JSON.parse(content);
+    } catch (error) {
+      GraphAILogger.error(`Error reading file: ${inputPath}`);
+      GraphAILogger.error((error as Error).message);
+      process.exit(1);
+    }
+  })();
+
+  if (templateName && !templateExists(templateName)) {
+    GraphAILogger.warn(`Warning: Template '${templateName}' not found`);
+  }
+
+  const result = completeScript(inputData, templateName);
+
+  if (!result.success) {
+    GraphAILogger.error("Validation errors:");
+    result.error.issues.forEach((issue) => {
+      GraphAILogger.error(`  - ${issue.path.join(".")}: ${issue.message}`);
+    });
+    process.exit(1);
+  }
+
+  if (verbose && templateName) {
+    GraphAILogger.info(`Applied template: ${templateName}`);
+  }
+
+  const outputFilePath = outputPath ? path.resolve(outputPath) : inputPath.replace(/\.json$/, "_completed.json");
+
+  writeFileSync(outputFilePath, JSON.stringify(result.data, null, 2));
+
+  GraphAILogger.info(`Completed script written to: ${outputFilePath}`);
+};

--- a/src/cli/commands/tool/complete/index.ts
+++ b/src/cli/commands/tool/complete/index.ts
@@ -1,0 +1,4 @@
+export const command = "complete <file>";
+export const desc = "Complete MulmoScript with schema defaults and optional style";
+export { builder } from "./builder.js";
+export { handler } from "./handler.js";

--- a/src/cli/commands/tool/index.ts
+++ b/src/cli/commands/tool/index.ts
@@ -4,12 +4,13 @@ import * as promptCmd from "./prompt/index.js";
 import * as schemaCmd from "./schema/index.js";
 import * as storyToScriptCmd from "./story_to_script/index.js";
 import * as whisperCmd from "./whisper/index.js";
+import * as completeCmd from "./complete/index.js";
 import { Argv } from "yargs";
 
 export const command = "tool <command>";
 export const desc = "Generate Mulmo script and other tools";
 
 export const builder = (y: Argv) =>
-  y.command(scriptingCmd).command(promptCmd).command(schemaCmd).command(storyToScriptCmd).command(whisperCmd).demandCommand().strict();
+  y.command(scriptingCmd).command(promptCmd).command(schemaCmd).command(storyToScriptCmd).command(whisperCmd).command(completeCmd).demandCommand().strict();
 
 export const handler = (__argv: ToolCliArgs) => {};

--- a/src/tools/complete_script.ts
+++ b/src/tools/complete_script.ts
@@ -1,0 +1,62 @@
+import { type ZodSafeParseResult } from "zod";
+import { mulmoScriptSchema } from "../types/schema.js";
+import { getScriptFromPromptTemplate } from "../utils/file.js";
+import { currentMulmoScriptVersion } from "../types/const.js";
+import type { MulmoScript } from "../types/type.js";
+
+type PartialMulmoScript = Record<string, unknown>;
+
+/**
+ * Add $mulmocast version if not present
+ */
+export const addMulmocastVersion = (data: PartialMulmoScript): PartialMulmoScript => {
+  if (data.$mulmocast) {
+    return data;
+  }
+  return {
+    ...data,
+    $mulmocast: { version: currentMulmoScriptVersion },
+  };
+};
+
+const deepMergeKeys = ["speechParams", "imageParams", "movieParams", "audioParams"] as const;
+
+/**
+ * Merge input data with template (input takes precedence)
+ */
+export const mergeWithTemplate = (data: PartialMulmoScript, template: MulmoScript): PartialMulmoScript => {
+  const merged: PartialMulmoScript = { ...template, ...data };
+
+  deepMergeKeys.forEach((key) => {
+    if (template[key] && data[key]) {
+      merged[key] = { ...template[key], ...(data[key] as object) };
+    }
+  });
+
+  return merged;
+};
+
+export type CompleteScriptResult = ZodSafeParseResult<MulmoScript>;
+
+/**
+ * Complete a partial MulmoScript with schema defaults and optional template
+ */
+export const completeScript = (data: PartialMulmoScript, templateName?: string): CompleteScriptResult => {
+  const withVersion = addMulmocastVersion(data);
+
+  const withTemplate = templateName
+    ? (() => {
+        const template = getScriptFromPromptTemplate(templateName);
+        return template ? mergeWithTemplate(withVersion, template) : withVersion;
+      })()
+    : withVersion;
+
+  return mulmoScriptSchema.safeParse(withTemplate);
+};
+
+/**
+ * Check if template exists
+ */
+export const templateExists = (templateName: string): boolean => {
+  return getScriptFromPromptTemplate(templateName) !== undefined;
+};

--- a/test/json/minimum_beats.json
+++ b/test/json/minimum_beats.json
@@ -1,0 +1,3 @@
+{
+  "beats": [{ "text": "Hello" }]
+}

--- a/test/tools/test_complete_script.ts
+++ b/test/tools/test_complete_script.ts
@@ -1,0 +1,101 @@
+import test from "node:test";
+import assert from "node:assert";
+import { addMulmocastVersion, mergeWithTemplate, completeScript } from "../../src/tools/complete_script.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
+import type { MulmoScript } from "../../src/types/type.js";
+
+test("addMulmocastVersion - adds version when not present", () => {
+  const input = { beats: [{ text: "Hello" }] };
+  const result = addMulmocastVersion(input);
+
+  assert.deepStrictEqual(result.$mulmocast, { version: currentMulmoScriptVersion });
+  assert.deepStrictEqual(result.beats, [{ text: "Hello" }]);
+});
+
+test("addMulmocastVersion - preserves existing version", () => {
+  const input = { $mulmocast: { version: "1.0" }, beats: [{ text: "Hello" }] };
+  const result = addMulmocastVersion(input);
+
+  assert.deepStrictEqual(result.$mulmocast, { version: "1.0" });
+});
+
+test("mergeWithTemplate - merges template with input (input takes precedence)", () => {
+  const template = {
+    title: "Template Title",
+    lang: "en",
+    imageParams: { provider: "openai", model: "dall-e-3" },
+    beats: [],
+  } as unknown as MulmoScript;
+
+  const input = {
+    title: "My Title",
+    imageParams: { model: "gpt-image-1" },
+    beats: [{ text: "Hello" }],
+  };
+
+  const result = mergeWithTemplate(input, template);
+
+  assert.strictEqual(result.title, "My Title");
+  assert.strictEqual(result.lang, "en");
+  assert.deepStrictEqual(result.imageParams, { provider: "openai", model: "gpt-image-1" });
+  assert.deepStrictEqual(result.beats, [{ text: "Hello" }]);
+});
+
+test("mergeWithTemplate - handles missing params in input", () => {
+  const template = {
+    title: "Template Title",
+    speechParams: { speakers: {} },
+    beats: [],
+  } as unknown as MulmoScript;
+
+  const input = {
+    beats: [{ text: "Hello" }],
+  };
+
+  const result = mergeWithTemplate(input, template);
+
+  assert.strictEqual(result.title, "Template Title");
+  assert.deepStrictEqual(result.speechParams, { speakers: {} });
+});
+
+test("completeScript - completes minimal input", () => {
+  const input = { beats: [{ text: "Hello" }] };
+  const result = completeScript(input);
+
+  assert.strictEqual(result.success, true);
+  if (result.success) {
+    assert.deepStrictEqual(result.data.$mulmocast, { version: currentMulmoScriptVersion });
+    assert.strictEqual(result.data.lang, "en");
+    assert.strictEqual(result.data.beats.length, 1);
+    assert.strictEqual(result.data.beats[0].text, "Hello");
+    assert.ok(result.data.canvasSize);
+    assert.ok(result.data.speechParams);
+    assert.ok(result.data.imageParams);
+  }
+});
+
+test("completeScript - returns errors for invalid input", () => {
+  const input = { beats: [] };
+  const result = completeScript(input);
+
+  assert.strictEqual(result.success, false);
+  if (!result.success) {
+    assert.ok(result.error.issues.length > 0);
+  }
+});
+
+test("completeScript - preserves custom values", () => {
+  const input = {
+    title: "Custom Title",
+    lang: "ja",
+    beats: [{ text: "Hello", imagePrompt: "A sunset" }],
+  };
+  const result = completeScript(input);
+
+  assert.strictEqual(result.success, true);
+  if (result.success) {
+    assert.strictEqual(result.data.title, "Custom Title");
+    assert.strictEqual(result.data.lang, "ja");
+    assert.strictEqual(result.data.beats[0].imagePrompt, "A sunset");
+  }
+});


### PR DESCRIPTION
## Summary
- Add `mulmo tool complete` CLI command to complete partial MulmoScript with schema defaults
- Support optional template merging with `-t` flag
- Output to custom path with `-o` flag, or defaults to `_completed.json` suffix

## Changes
- `src/tools/complete_script.ts` - Core data processing functions using Zod's `ZodSafeParseResult`
- `src/cli/commands/tool/complete/` - CLI command (builder, handler, index)
- `test/tools/test_complete_script.ts` - Unit tests (7 tests)
- `scripts/test/minimum_beats.json` - Minimal test file for CI
- `.github/workflows/pull_request.yaml` - Added CI test

## Usage
```bash
# Complete a minimal script with schema defaults
mulmo tool complete input.json

# Output to specific file
mulmo tool complete input.json -o output.json

# Apply template before completion
mulmo tool complete input.json -t template_name
```

## Test plan
- [x] Unit tests pass (`npx tsx test/tools/test_complete_script.ts`)
- [x] CLI works (`yarn cli tool complete scripts/test/minimum_beats.json`)
- [x] Build succeeds (`yarn build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI `complete` command that processes input script files, applies optional templates for styling, and outputs completed scripts with validated defaults.

* **Tests**
  * Added comprehensive test coverage for the new complete functionality.

* **Chores**
  * Updated CI workflow to test the new complete command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->