### PR TITLE
Revert "Reuse Puppeteer browser for HTML-to-image rendering to reduce Chrome launches"

### DIFF
--- a/assets/html/chart.html
+++ b/assets/html/chart.html
@@ -17,33 +17,21 @@
 <body>
     <h1>${title}</h1>
     <div class="chart-container">
-        <canvas id="myChart" data-chart-ready="false"></canvas>
+        <canvas id="myChart"></canvas>
     </div>
 
     <!-- Plain JavaScript instead of TypeScript -->
     <script>
-        // Wait for DOM and Chart.js to be ready, then render.
-        function initChart() {
-            if (!window.Chart) return false;
-            const ctx = document.getElementById('myChart');
-            if (!ctx) return false;
-            const chartData = ${chart_data};
-            new Chart(ctx, chartData);
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    ctx.dataset.chartReady = "true";
-                });
-            });
-            return true;
-        }
-
-        function waitForChart() {
-            if (initChart()) return;
-            setTimeout(waitForChart, 50);
-        }
-
+        // Wait for DOM to be fully loaded
         document.addEventListener('DOMContentLoaded', function() {
-            waitForChart();
+            // Get the canvas element
+            const ctx = document.getElementById('myChart');
+            
+            // Create the data object (no TypeScript interfaces)
+            const chartData = ${chart_data};
+
+            // Initialize the chart
+            new Chart(ctx, chartData);
         });
     </script>
 </body>


### PR DESCRIPTION
Reverts receptron/mulmocast-cli#1131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined chart initialization by consolidating multi-stage setup into a single direct handler, removing complex readiness checks and lifecycle management complexity.
  * Optimized HTML-to-image rendering by removing shared browser pooling mechanisms and animation frame waiting logic, transitioning to individual browser instances per rendering operation for simplified resource control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->