### PR TITLE
fix: ensure background fills viewport in screenshot rendering

### DIFF
--- a/assets/html/tailwind.html
+++ b/assets/html/tailwind.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
+<!-- h-full on html and body ensures background fills entire viewport for screenshot rendering -->
+<html lang="en" class="h-full">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,7 +8,7 @@
   <!-- Tailwind CSS CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-white text-gray-800 min-h-screen flex flex-col">
+<body class="bg-white text-gray-800 h-full flex flex-col">
   ${html_body}
 </body>
 </html>

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -22,7 +22,8 @@ export const renderHTMLToImage = async (
 
   // Adjust page settings if needed (like width, height, etc.)
   await page.setViewport({ width, height });
-  await page.addStyleTag({ content: "html,body{margin:0;padding:0;overflow:hidden}" });
+  // height:100% ensures background fills viewport; background:white prevents transparent areas
+  await page.addStyleTag({ content: "html,body{height:100%;margin:0;padding:0;overflow:hidden;background:white}" });
 
   if (isMermaid) {
     await page.waitForFunction(


### PR DESCRIPTION
## Summary
- Add `height:100%` and `background:white` to injected CSS in markdown.ts
- Update tailwind.html to use `h-full` class on html and body elements

## Problem
When rendering HTML/Markdown to images, content that doesn't naturally fill the viewport could result in transparent or partially-filled backgrounds.

## Solution
Ensure both html and body elements have full height and white background, so the entire viewport is filled consistently.

## Changes
- `src/utils/markdown.ts`: Updated addStyleTag CSS
- `assets/html/tailwind.html`: Changed from `min-h-screen` to `h-full`

## Test plan
- [ ] CI passes
- [ ] Rendered images have solid white background

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewport rendering height to ensure content displays at full screen extent
  * Improved background color rendering to consistently display white instead of transparent areas
  * Optimized rendering output with proper height and background display settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->