### PR TITLE
refactor: Rename markdown.ts to html_render.ts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,7 @@ export default [
   sonarjs.configs.recommended,
   ...tseslint.configs.recommended,
   {
-    files: ['**/utils/markdown.ts'],
+    files: ['**/utils/html_render.ts'],
     languageOptions: {
       globals: {
         ...globals.browser,

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -4,7 +4,7 @@ import type { GraphData } from "graphai";
 import * as agents from "@graphai/vanilla";
 import { getHTMLFile, getCaptionImagePath, getOutputStudioFilePath } from "../utils/file.js";
 import { localizedText, processLineBreaks } from "../utils/utils.js";
-import { renderHTMLToImage, interpolate } from "../utils/markdown.js";
+import { renderHTMLToImage, interpolate } from "../utils/html_render.js";
 import { MulmoStudioContextMethods, MulmoPresentationStyleMethods } from "../methods/index.js";
 import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 

--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -3,7 +3,7 @@ import { MulmoStudioContext, MulmoBeat, MulmoCanvasDimension, MulmoImageParams, 
 import { MulmoPresentationStyleMethods, MulmoStudioContextMethods, MulmoBeatMethods, MulmoMediaSourceMethods } from "../methods/index.js";
 import { getBeatPngImagePath, getBeatMoviePaths, getAudioFilePath } from "../utils/file.js";
 import { imagePrompt, htmlImageSystemPrompt } from "../utils/prompt.js";
-import { renderHTMLToImage } from "../utils/markdown.js";
+import { renderHTMLToImage } from "../utils/html_render.js";
 import { beatId } from "../utils/utils.js";
 import { localizedPath } from "./audio.js";
 

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -6,7 +6,7 @@ import { MulmoStudioContext, PDFMode, PDFSize } from "../types/index.js";
 import { MulmoPresentationStyleMethods } from "../methods/index.js";
 import { localizedText, isHttp } from "../utils/utils.js";
 import { getOutputPdfFilePath, writingMessage, getHTMLFile, mulmoCreditPath } from "../utils/file.js";
-import { interpolate } from "../utils/markdown.js";
+import { interpolate } from "../utils/html_render.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
 const isCI = process.env.CI === "true";

--- a/src/utils/html_render.ts
+++ b/src/utils/html_render.ts
@@ -28,8 +28,8 @@ export const renderHTMLToImage = async (
   if (isMermaid) {
     await page.waitForFunction(
       () => {
-        const el = document.querySelector(".mermaid");
-        return el && (el as HTMLElement).dataset.ready === "true";
+        const element = document.querySelector(".mermaid");
+        return element && (element as HTMLElement).dataset.ready === "true";
       },
       { timeout: 20000 },
     );
@@ -48,15 +48,15 @@ export const renderHTMLToImage = async (
 
   // Measure the size of the page and scale the page to the width and height
   await page.evaluate(
-    ({ vw, vh }) => {
-      const de = document.documentElement;
-      const sw = Math.max(de.scrollWidth, document.body.scrollWidth || 0);
-      const sh = Math.max(de.scrollHeight, document.body.scrollHeight || 0);
-      const scale = Math.min(vw / (sw || vw), vh / (sh || vh), 1); // <=1 で縮小のみ
-      de.style.overflow = "hidden";
+    ({ viewportWidth, viewportHeight }) => {
+      const docElement = document.documentElement;
+      const scrollWidth = Math.max(docElement.scrollWidth, document.body.scrollWidth || 0);
+      const scrollHeight = Math.max(docElement.scrollHeight, document.body.scrollHeight || 0);
+      const scale = Math.min(viewportWidth / (scrollWidth || viewportWidth), viewportHeight / (scrollHeight || viewportHeight), 1);
+      docElement.style.overflow = "hidden";
       (document.body as HTMLElement).style.zoom = String(scale);
     },
-    { vw: width, vh: height },
+    { viewportWidth: width, viewportHeight: height },
   );
 
   // Step 3: Capture screenshot of the page (which contains the Markdown-rendered HTML)

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -1,6 +1,6 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
-import { renderHTMLToImage, interpolate } from "../markdown.js";
+import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 import nodeProcess from "node:process";
 

--- a/src/utils/image_plugins/html_tailwind.ts
+++ b/src/utils/image_plugins/html_tailwind.ts
@@ -1,6 +1,6 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
-import { renderHTMLToImage, interpolate } from "../markdown.js";
+import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 
 export const imageType = "html_tailwind";

--- a/src/utils/image_plugins/markdown.ts
+++ b/src/utils/image_plugins/markdown.ts
@@ -1,5 +1,5 @@
 import { ImageProcessorParams } from "../../types/index.js";
-import { renderMarkdownToImage } from "../markdown.js";
+import { renderMarkdownToImage } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 
 import { marked } from "marked";

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -1,7 +1,7 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/index.js";
 import { getHTMLFile } from "../file.js";
-import { renderHTMLToImage, interpolate } from "../markdown.js";
+import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 import nodeProcess from "node:process";
 

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -1,5 +1,5 @@
 import { ImageProcessorParams } from "../../types/index.js";
-import { renderMarkdownToImage } from "../markdown.js";
+import { renderMarkdownToImage } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 
 import { marked } from "marked";


### PR DESCRIPTION
## Summary
- Rename `src/utils/markdown.ts` to `src/utils/html_render.ts`
- Update all import references
- Expand abbreviated variable names for clarity

## Rationale
The file primarily handles HTML-to-image rendering with Puppeteer. The name `html_render.ts` better reflects its purpose than `markdown.ts`.

## Test plan
- [x] `yarn build` passes
- [x] `yarn images scripts/test/test_render_stress.json -f` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization to improve module structure and maintainability.
  * Enhanced variable naming for improved code clarity.
  * Updated build configuration to reflect restructured modules.

---

*This release contains internal improvements with no user-facing changes.*

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->