### PR TITLE
feat: add style property support for textSlide

### DIFF
--- a/scripts/test/test_text_slide_style.json
+++ b/scripts/test/test_text_slide_style.json
@@ -1,0 +1,85 @@
+{
+  "$mulmocast": {
+    "version": "1.0",
+    "credit": "closing"
+  },
+  "title": "Text Slide Style Test",
+  "speechParams": {
+    "speakers": {
+      "Presenter": {
+        "voiceId": "shimmer",
+        "displayName": {
+          "en": "Presenter"
+        }
+      }
+    }
+  },
+  "beats": [
+    {
+      "speaker": "Presenter",
+      "text": "This is a corporate blue style slide.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Corporate Blue",
+          "subtitle": "Business Style",
+          "bullets": [
+            "Professional appearance",
+            "Blue gradient background",
+            "Clean typography"
+          ]
+        },
+        "style": "corporate-blue"
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This is a cyber neon style slide.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Cyber Neon",
+          "subtitle": "Tech Style",
+          "bullets": [
+            "Glowing green text",
+            "Dark background",
+            "Futuristic feel"
+          ]
+        },
+        "style": "cyber-neon"
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This is a zen garden style slide.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Zen Garden",
+          "subtitle": "Japanese Style",
+          "bullets": [
+            "Minimalist design",
+            "Calm colors",
+            "Elegant typography"
+          ]
+        },
+        "style": "zen-garden"
+      }
+    },
+    {
+      "speaker": "Presenter",
+      "text": "This slide uses default style without specifying style property.",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "Default Style",
+          "subtitle": "No Style Specified",
+          "bullets": [
+            "Uses textSlideParams",
+            "Fallback behavior"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -166,6 +166,7 @@ export const mulmoTextSlideMediaSchema = z
       subtitle: z.string().optional(),
       bullets: z.array(z.string()).optional(),
     }),
+    style: z.string().optional(),
   })
   .strict();
 

--- a/src/utils/image_plugins/markdown.ts
+++ b/src/utils/image_plugins/markdown.ts
@@ -1,8 +1,7 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
-import { parrotingImagePath } from "./utils.js";
-import { getMarkdownStyle } from "../../data/markdownStyles.js";
+import { parrotingImagePath, resolveStyle } from "./utils.js";
 import { type MulmoMarkdownLayout } from "../../types/type.js";
 import { generateLayoutHtml, layoutToMarkdown, toMarkdownString } from "./markdown_layout.js";
 
@@ -38,9 +37,7 @@ const generateHtml = async (params: ImageProcessorParams): Promise<string> => {
   if (!beat.image || beat.image.type !== imageType) return "";
 
   const md = beat.image.markdown;
-  const styleName = beat.image.style;
-  const customStyle = styleName ? getMarkdownStyle(styleName) : undefined;
-  const style = customStyle ? customStyle.css : params.textSlideStyle;
+  const style = resolveStyle(beat.image.style, params.textSlideStyle);
 
   if (isMarkdownLayout(md)) {
     const htmlBody = await generateLayoutHtml(md);

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -1,6 +1,6 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { renderMarkdownToImage } from "../html_render.js";
-import { parrotingImagePath } from "./utils.js";
+import { parrotingImagePath, resolveStyle } from "./utils.js";
 
 import { marked } from "marked";
 
@@ -11,6 +11,8 @@ const processTextSlide = async (params: ImageProcessorParams) => {
   if (!beat.image || beat.image.type !== imageType) return;
 
   const slide = beat.image.slide;
+  const style = resolveStyle(beat.image.style, textSlideStyle);
+
   const markdown = dumpMarkdown(params) ?? "";
   const topMargin = (() => {
     if (slide.bullets?.length && slide.bullets.length > 0) {
@@ -19,7 +21,7 @@ const processTextSlide = async (params: ImageProcessorParams) => {
     const marginTop = slide.subtitle ? canvasSize.height * 0.4 : canvasSize.height * 0.45;
     return `body {margin-top: ${marginTop}px;}`;
   })();
-  await renderMarkdownToImage(markdown, textSlideStyle + topMargin, imagePath, canvasSize.width, canvasSize.height);
+  await renderMarkdownToImage(markdown, style + topMargin, imagePath, canvasSize.width, canvasSize.height);
   return imagePath;
 };
 

--- a/src/utils/image_plugins/utils.ts
+++ b/src/utils/image_plugins/utils.ts
@@ -1,5 +1,11 @@
 import { ImageProcessorParams } from "../../types/index.js";
+import { getMarkdownStyle } from "../../data/markdownStyles.js";
 
 export const parrotingImagePath = (params: ImageProcessorParams) => {
   return params.imagePath;
+};
+
+export const resolveStyle = (styleName: string | undefined, fallbackStyle: string): string => {
+  const customStyle = styleName ? getMarkdownStyle(styleName) : undefined;
+  return customStyle ? customStyle.css : fallbackStyle;
 };


### PR DESCRIPTION
## Summary
- Add `style` property to `textSlide` image type, enabling the use of 100 preset styles from markdownStyles
- Extract `resolveStyle` helper function to share between `markdown.ts` and `text_slide.ts`
- Refactor both plugins to use the shared function

## Usage
```json
{
  "image": {
    "type": "textSlide",
    "slide": {
      "title": "Hello World",
      "subtitle": "Subtitle",
      "bullets": ["Item 1", "Item 2"]
    },
    "style": "corporate-blue"
  }
}
```

## Test plan
- [x] Added test script `scripts/test/test_text_slide_style.json`
- [x] Verified images generate correctly with `yarn images`
- [x] Build passes
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Text slides now support custom style properties, enabling per-slide visual customization with multiple style options (corporate-blue, cyber-neon, zen-garden, and default styling).
  * Style resolution logic automatically applies custom styles or falls back to default styling when no custom style is specified.

* **Tests**
  * Added test data for text slide style scenarios covering multiple style variants and default behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->