### PR TITLE
feat: detect external images and use networkidle0 with timeout

### DIFF
--- a/src/utils/html_render.ts
+++ b/src/utils/html_render.ts
@@ -19,8 +19,7 @@ export const renderHTMLToImage = async (
 
   // Set the page content to the HTML generated from the Markdown
   // Use networkidle0 only for external images, otherwise use domcontentloaded for faster rendering
-  // Only match <img> tags with external src, not <script> tags
-  const hasExternalImages = /<img[^>]+src=["']https?:\/\//.test(html);
+  const hasExternalImages = html.includes("<img") && /src=["']https?:\/\//.test(html);
   const waitUntil = hasExternalImages ? "networkidle0" : "domcontentloaded";
   await page.setContent(html, { waitUntil, timeout: 30000 });
 


### PR DESCRIPTION
- External images in markdown now load correctly by detecting src="https?://" patterns and using networkidle0 wait strategy
- Added explicit 30s timeout to prevent infinite waits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable HTML rendering for pages that include externally hosted images by adjusting page load waiting behavior.
  * Added a 30s render timeout to prevent long hangs and improve page load stability.

* **Improvements**
  * More robust handling of embedded diagrams so visuals render consistently once their renderer is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->