### PR TITLE
feat: add backgroundImage and style support to mermaid type

### DIFF
--- a/scripts/test/test_background_image.json
+++ b/scripts/test/test_background_image.json
@@ -108,6 +108,40 @@
           "size": "cover"
         }
       }
+    },
+    {
+      "text": "マークダウンにMermaid図を埋め込むこともできます。",
+      "image": {
+        "type": "markdown",
+        "markdown": "# システム構成\n\n```mermaid\ngraph TD\n    A[ユーザー] --> B[API]\n    B --> C[データベース]\n```",
+        "backgroundImage": {
+          "source": {
+            "kind": "url",
+            "url": "https://raw.githubusercontent.com/SingularitySociety/societys_statement/main/images/mulmocast/mulmocast-logo.png"
+          },
+          "opacity": 0.2,
+          "size": "cover"
+        }
+      }
+    },
+    {
+      "text": "Mermaidタイプでも背景画像が使えます。",
+      "image": {
+        "type": "mermaid",
+        "title": "アーキテクチャ",
+        "code": {
+          "kind": "text",
+          "text": "graph LR\n    Client --> Gateway\n    Gateway --> Service\n    Service --> Database[(DB)]"
+        },
+        "backgroundImage": {
+          "source": {
+            "kind": "url",
+            "url": "https://raw.githubusercontent.com/SingularitySociety/societys_statement/main/images/mulmocast/mulmocast-logo.png"
+          },
+          "opacity": 0.2,
+          "size": "cover"
+        }
+      }
     }
   ]
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -220,6 +220,8 @@ export const mulmoMermaidMediaSchema = z
     title: z.string().describe("The title of the diagram"),
     code: mediaSourceMermaidSchema.describe("The code of the mermaid diagram"),
     appendix: z.array(z.string()).optional().describe("The appendix of the mermaid diagram; typically, style information."),
+    style: z.string().optional(),
+    backgroundImage: backgroundImageSchema,
   })
   .strict();
 

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -1,5 +1,6 @@
-import { BackgroundImage, MulmoStudioContext } from "../../types/index.js";
+import { BackgroundImage, MulmoStudioContext, ImageProcessorParams } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
+import { resolveStyle } from "./utils.js";
 
 const DEFAULT_FETCH_TIMEOUT_MS = 30000;
 
@@ -58,6 +59,23 @@ const fetchUrlAsDataUrl = async (url: string, timeoutMs = DEFAULT_FETCH_TIMEOUT_
 // Convert size option to CSS background-size value
 const sizeToCSS = (size: string): string => {
   return size === "fill" ? "100% 100%" : size;
+};
+
+/**
+ * Resolve combined style from background image and custom style.
+ * Common pattern used by markdown, textSlide, mermaid plugins.
+ */
+export const resolveCombinedStyle = async (
+  params: ImageProcessorParams,
+  beatBackgroundImage: BackgroundImage | undefined,
+  beatStyle: string | undefined,
+): Promise<string> => {
+  const { context, textSlideStyle } = params;
+  const globalBackgroundImage = context.studio.script.imageParams?.backgroundImage;
+  const resolvedBackgroundImage = resolveBackgroundImage(beatBackgroundImage, globalBackgroundImage);
+  const backgroundCSS = await backgroundImageToCSS(resolvedBackgroundImage, context);
+  const style = resolveStyle(beatStyle, textSlideStyle);
+  return backgroundCSS + style;
 };
 
 export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | undefined, context: MulmoStudioContext): Promise<string> => {

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -3,6 +3,7 @@ import { MulmoMediaSourceMethods } from "../../methods/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
+import { resolveCombinedStyle } from "./bg_image_util.js";
 
 export const imageType = "mermaid";
 
@@ -22,15 +23,16 @@ export const generateMermaidHtml = (code: string, title?: string): string => {
 };
 
 const processMermaid = async (params: ImageProcessorParams) => {
-  const { beat, imagePath, canvasSize, context, textSlideStyle } = params;
+  const { beat, imagePath, canvasSize, context } = params;
   if (!beat?.image || beat.image.type !== imageType) return;
 
   const template = getHTMLFile("mermaid");
   const diagram_code = await MulmoMediaSourceMethods.getText(beat.image.code, context);
   if (diagram_code) {
+    const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
     const htmlData = interpolate(template, {
       title: beat.image.title,
-      style: textSlideStyle,
+      style: combinedStyle,
       diagram_code: `${diagram_code}\n${beat.image.appendix?.join("\n") ?? ""}`,
     });
     await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height, true);

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -1,26 +1,18 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { renderMarkdownToImage } from "../html_render.js";
-import { parrotingImagePath, resolveStyle } from "./utils.js";
-import { resolveBackgroundImage, backgroundImageToCSS } from "./bg_image_util.js";
+import { parrotingImagePath } from "./utils.js";
+import { resolveCombinedStyle } from "./bg_image_util.js";
 
 import { marked } from "marked";
 
 export const imageType = "textSlide";
 
 const processTextSlide = async (params: ImageProcessorParams) => {
-  const { beat, context, imagePath, textSlideStyle, canvasSize } = params;
+  const { beat, imagePath, canvasSize } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
   const slide = beat.image.slide;
-  const style = resolveStyle(beat.image.style, textSlideStyle);
-
-  // Resolve background image (beat level overrides global)
-  const globalBackgroundImage = context.studio.script.imageParams?.backgroundImage;
-  const beatBackgroundImage = beat.image.backgroundImage;
-  const resolvedBackgroundImage = resolveBackgroundImage(beatBackgroundImage, globalBackgroundImage);
-  const backgroundCSS = await backgroundImageToCSS(resolvedBackgroundImage, context);
-
-  const combinedStyle = backgroundCSS + style;
+  const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
 
   const markdown = dumpMarkdown(params) ?? "";
   const topMargin = (() => {


### PR DESCRIPTION
## Summary
- Fix timeout issue when markdown contains mermaid code block with backgroundImage
- Add `backgroundImage` and `style` fields to mermaid schema
- Add `resolveCombinedStyle()` common function to reduce code duplication

## Changes
- `src/types/schema.ts`: Add `style` and `backgroundImage` to mermaid schema
- `src/utils/image_plugins/bg_image_util.ts`: Add `resolveCombinedStyle()` common function
- `src/utils/image_plugins/markdown.ts`: Use tailwind template for markdown with mermaid, use `resolveCombinedStyle()`
- `src/utils/image_plugins/mermaid.ts`: Add backgroundImage/style support using `resolveCombinedStyle()`
- `src/utils/image_plugins/text_slide.ts`: Refactor to use `resolveCombinedStyle()`
- `scripts/test/test_background_image.json`: Add test cases

## Test plan
- [x] `yarn build` passes
- [x] `yarn images scripts/test/test_background_image.json -f` completes without timeout
- [x] Generated images show mermaid diagrams with background images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background image support for Markdown and Mermaid slides
  * Enabled custom styling options for enhanced visual customization of slide content

* **Refactor**
  * Improved internal style and background image resolution across slide rendering components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->