### PR TITLE
feat: export cliMain for programmatic CLI usage

### DIFF
--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -8,3 +8,6 @@ export * from "./utils/context.js";
 export * from "./utils/ffmpeg_utils.js";
 export * from "./methods/index.js";
 export * from "./agents/index.js";
+
+// CLI entry point for programmatic usage (e.g., mulmocast-easy)
+export { main as cliMain } from "./cli/bin.js";


### PR DESCRIPTION
## Summary

Export the CLI main function as `cliMain` to allow other packages to call the CLI programmatically.

## Use Case

`mulmocast-easy` (ffmpeg同梱パッケージ) で、ffmpeg パスを設定した後に CLI を呼び出すために必要:

```typescript
import { setFfmpegPath, setFfprobePath, cliMain } from "mulmocast";
import ffmpegFfprobeStatic from "ffmpeg-ffprobe-static";

setFfmpegPath(ffmpegFfprobeStatic.ffmpegPath);
setFfprobePath(ffmpegFfprobeStatic.ffprobePath);

cliMain();
```

## Changes

- Export `main` as `cliMain` from `index.node.ts`

## Test plan

- [x] `yarn build` passes
- [ ] Can import and call `cliMain()` from external package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a programmatic CLI entry point, enabling direct integration of command-line functionality into applications and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->