### PR TITLE
fix: separate CLI main function to prevent auto-execution

### DIFF
--- a/src/cli/bin.ts
+++ b/src/cli/bin.ts
@@ -1,70 +1,9 @@
 #!/usr/bin/env node
 
-import dotenv from "dotenv";
-import yargs from "yargs/yargs";
-import { hideBin } from "yargs/helpers";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
-import { dirname, join } from "path";
-import * as translateCmd from "./commands/translate/index.js";
-import * as audioCmd from "./commands/audio/index.js";
-import * as imagesCmd from "./commands/image/index.js";
-import * as movieCmd from "./commands/movie/index.js";
-import * as pdfCmd from "./commands/pdf/index.js";
-import * as markdownCmd from "./commands/markdown/index.js";
-import * as bundleCmd from "./commands/bundle/index.js";
-import * as htmlCmd from "./commands/html/index.js";
-import * as toolCmd from "./commands/tool/index.js";
+import { cliMain } from "./main.js";
 import { GraphAILogger } from "graphai";
 
-dotenv.config({ quiet: true });
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const packageJson = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf8"));
-
-export const main = async () => {
-  const cli = yargs(hideBin(process.argv))
-    .scriptName("mulmo")
-    .version(packageJson.version)
-    .usage("$0 <command> [options]")
-    .option("v", {
-      alias: "verbose",
-      describe: "verbose log",
-      demandOption: true,
-      default: false,
-      type: "boolean",
-    })
-    .command(translateCmd)
-    .command(audioCmd)
-    .command(imagesCmd)
-    .command(movieCmd)
-    .command(pdfCmd)
-    .command(markdownCmd)
-    .command(bundleCmd)
-    .command(htmlCmd)
-    .command(toolCmd)
-    .demandCommand()
-    .strict()
-    .help()
-    .showHelpOnFail(false)
-    .fail((msg, err, y) => {
-      // if yargs detect error, show help and exit
-      if (msg) {
-        y.showHelp();
-        GraphAILogger.info("\\n" + msg);
-        process.exit(1);
-      }
-      if (err) {
-        throw err;
-      }
-    })
-    .alias("help", "h");
-
-  await cli.parseAsync();
-};
-
-main().catch((error) => {
+cliMain().catch((error) => {
   GraphAILogger.info("An unexpected error occurred:", error);
   process.exit(1);
 });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,67 @@
+import dotenv from "dotenv";
+import yargs from "yargs/yargs";
+import { hideBin } from "yargs/helpers";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import * as translateCmd from "./commands/translate/index.js";
+import * as audioCmd from "./commands/audio/index.js";
+import * as imagesCmd from "./commands/image/index.js";
+import * as movieCmd from "./commands/movie/index.js";
+import * as pdfCmd from "./commands/pdf/index.js";
+import * as markdownCmd from "./commands/markdown/index.js";
+import * as bundleCmd from "./commands/bundle/index.js";
+import * as htmlCmd from "./commands/html/index.js";
+import * as toolCmd from "./commands/tool/index.js";
+import { GraphAILogger } from "graphai";
+
+dotenv.config({ quiet: true });
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJson = JSON.parse(readFileSync(join(__dirname, "../../package.json"), "utf8"));
+
+/**
+ * CLI main function for programmatic usage.
+ * This function only defines the CLI, it does not execute automatically.
+ */
+export const cliMain = async () => {
+  const cli = yargs(hideBin(process.argv))
+    .scriptName("mulmo")
+    .version(packageJson.version)
+    .usage("$0 <command> [options]")
+    .option("v", {
+      alias: "verbose",
+      describe: "verbose log",
+      demandOption: true,
+      default: false,
+      type: "boolean",
+    })
+    .command(translateCmd)
+    .command(audioCmd)
+    .command(imagesCmd)
+    .command(movieCmd)
+    .command(pdfCmd)
+    .command(markdownCmd)
+    .command(bundleCmd)
+    .command(htmlCmd)
+    .command(toolCmd)
+    .demandCommand()
+    .strict()
+    .help()
+    .showHelpOnFail(false)
+    .fail((msg, err, y) => {
+      // if yargs detect error, show help and exit
+      if (msg) {
+        y.showHelp();
+        GraphAILogger.info("\n" + msg);
+        process.exit(1);
+      }
+      if (err) {
+        throw err;
+      }
+    })
+    .alias("help", "h");
+
+  await cli.parseAsync();
+};

--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -10,4 +10,4 @@ export * from "./methods/index.js";
 export * from "./agents/index.js";
 
 // CLI entry point for programmatic usage (e.g., mulmocast-easy)
-export { main as cliMain } from "./cli/bin.js";
+export { cliMain } from "./cli/main.js";


### PR DESCRIPTION
## Problem

When `mulmocast-easy` imports `cliMain` from mulmocast, the CLI was automatically executed because `cli/bin.ts` contained both the function definition and its invocation.

## Solution

- Create `cli/main.ts` with only the `cliMain` function (no side effects)
- Update `cli/bin.ts` to import and execute `cliMain`
- Export `cliMain` from `index.node.ts` without triggering execution

## Test

```bash
node -e "import('./lib/index.node.js').then(m => console.log(typeof m.cliMain))"
# Output: function (no CLI execution)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized CLI module structure to centralize command orchestration logic, with no changes to end-user functionality or available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->