### PR TITLE
feat: align MulmoViewerData/MulmoViewerBeat with mulmocast-viewer types

### DIFF
--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -218,8 +218,9 @@ export type MulmoViewerBeat = {
   duration?: number;
   startTime?: number;
   endTime?: number;
+  importance?: number;
   multiLinguals?: Record<string, string>;
-  audioSources?: Record<string, string>;
+  audioSources?: Record<string, string | undefined>;
   imageSource?: string;
   videoSource?: string;
   videoWithAudioSource?: string;
@@ -230,5 +231,7 @@ export type MulmoViewerBeat = {
 export type MulmoViewerData = {
   beats: MulmoViewerBeat[];
   bgmSource?: string;
+  bgmFile?: string;
   title?: string;
+  lang?: string;
 };


### PR DESCRIPTION
## Summary
- Add `importance?: number` to `MulmoViewerBeat`
- Add `bgmFile?: string` and `lang?: string` to `MulmoViewerData`
- Fix `audioSources` type from `Record<string, string>` to `Record<string, string | undefined>` to match viewer

All fields are optional, so this is a non-breaking change.

## User Prompt
- mulmocast-viewer の `ViewerData` / `BundleItem` と mulmocast-cli の `MulmoViewerData` / `MulmoViewerBeat` の型を揃えるため、cli 側に不足フィールドを追加

## Test plan
- [x] `yarn format` passes
- [x] `yarn lint` passes (0 errors)
- [x] `yarn build` passes
- [x] All added fields are optional — no breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Beat structure now supports importance levels for enhanced control
  * Added background music file support to viewer data
  * Added language selection capability to viewer data
  * Enhanced flexibility in audio source handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->