### PR TITLE
fix: guard against prototype pollution in setBeatSessionState

### DIFF
--- a/src/methods/mulmo_studio_context.ts
+++ b/src/methods/mulmo_studio_context.ts
@@ -74,18 +74,16 @@ export const MulmoStudioContextMethods = {
     notifyStateChange(context, sessionType, result);
   },
   setBeatSessionState(context: MulmoStudioContext, sessionType: BeatSessionType | undefined, index: number, id: string | undefined, value: boolean) {
-    if (!sessionType) {
+    if (!sessionType || !Object.hasOwn(context.sessionState.inBeatSession, sessionType)) {
       return;
     }
     const key = beatId(id, index);
+    const session = context.sessionState.inBeatSession[sessionType];
     if (value) {
-      if (!context.sessionState.inBeatSession[sessionType]) {
-        context.sessionState.inBeatSession[sessionType] = {};
-      }
-      context.sessionState.inBeatSession[sessionType][key] = true;
+      session[key] = true;
     } else {
       // NOTE: Setting to false causes the parse error in rebuildStudio in preprocess.ts
-      delete context.sessionState.inBeatSession[sessionType][key];
+      delete session[key];
     }
     notifyBeatStateChange(context, sessionType, key);
   },


### PR DESCRIPTION
## Summary
- Add `Object.hasOwn()` check in `setBeatSessionState` to prevent prototype pollution via dynamic property access
- Extract `inBeatSession[sessionType]` into a local variable to reduce repeated dynamic lookups

## Background
GitHub CodeQL code scanning [alert #6](https://github.com/receptron/mulmocast-cli/security/code-scanning/6) flagged a **prototype-polluting assignment** vulnerability in `src/methods/mulmo_studio_context.ts:88`.

The `sessionType` parameter is used as a dynamic key to access `context.sessionState.inBeatSession[sessionType]`. If a malicious `__proto__` string were injected as `sessionType`, it could modify `Object.prototype` and affect all objects in the runtime — a classic prototype pollution attack.

While the TypeScript type `BeatSessionType` restricts values to a fixed union (`"audio" | "image" | "movie" | ...`), this is a compile-time guarantee only. At runtime, the value could theoretically be anything. Adding `Object.hasOwn()` provides a runtime guard that ensures only own properties of the `inBeatSession` object are accessed, which CodeQL recognizes as a safe pattern.

## User Prompt
- CodeQL security alert #6 (prototype-polluting assignment) を修正。`sessionType` の動的プロパティアクセスに `Object.hasOwn()` ガードを追加

## Test plan
- [x] `yarn build` passes
- [x] `yarn lint` passes (warnings only)
- [x] `yarn ci_test` — 622 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session state management to prevent potential edge-case issues and ensure more reliable session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->