### PR TITLE
feat: include beat id in MulmoViewerBeat and bundle output

### DIFF
--- a/src/actions/bundle.ts
+++ b/src/actions/bundle.ts
@@ -86,7 +86,15 @@ export const mulmoViewerBundle = async (context: MulmoStudioContext, options: Mu
     const sudioBeats = context.studio.beats[index];
     const { duration, startAt } = sudioBeats;
     // console.log(context.studio.beats[index]);
-    resultJson.push({ text: beat.text, duration, startTime: startAt, endTime: (startAt ?? 0) + (duration ?? 0), audioSources: {}, multiLinguals: {} });
+    resultJson.push({
+      id: beat.id,
+      text: beat.text,
+      duration,
+      startTime: startAt,
+      endTime: (startAt ?? 0) + (duration ?? 0),
+      audioSources: {},
+      multiLinguals: {},
+    });
   });
 
   // audio

--- a/src/types/viewer.ts
+++ b/src/types/viewer.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 export const mulmoViewerBeatSchema = z.object({
+  id: z.string().optional(),
   text: z.string().optional(),
   duration: z.number().optional(),
   startTime: z.number().optional(),


### PR DESCRIPTION
## Summary

- Add `id?: string` to `mulmoViewerBeatSchema` in `src/types/viewer.ts`
- Pass `beat.id` through in `mulmoViewerBundle()` so `mulmo_view.json` includes beat IDs
- Enables downstream consumers (e.g., mulmocast-slides) to reference beats by ID for features like FAQ `relatedBeats`

## User Prompt

MulmoBeat には `id` があるが MulmoViewerBeat には含まれておらず、bundle 生成時に失われていた。`mulmo_view.json` にも beat の `id` を含めるようにする。

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` — no new errors (existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced beat data structure to include identifier information, improving data tracking and reference capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->