### PR TITLE
docs: add slide image plugin documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,8 @@ When publishing, if the diff includes changes under `src/types/`, MUST publish `
 - `src/tools/` - Higher-level tools for script generation and research
 - `src/types/` - TypeScript schemas and type definitions (core: schema.ts)
 - `src/utils/` - Utilities for file handling, FFmpeg, image processing, etc.
-- `src/utils/image_plugins/` - Image type processors (markdown, textSlide, mermaid, etc.)
+- `src/utils/image_plugins/` - Image type processors (markdown, textSlide, mermaid, slide, etc.)
+- `src/slide/` - Self-contained slide DSL module (schema, layouts, blocks, render)
 
 ### Methods Pattern (`src/methods/`)
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,49 @@ To force regeneration, delete the old files — including temporary files — un
 
 If you modify the text or instruction fields in a MulmoScript, mulmo will automatically detect the changes and regenerate the corresponding audio content upon re-run.
 
+## Slide Presentations
+
+MulmoCast includes a powerful **Slide DSL** (`type: "slide"`) for creating structured presentation slides with JSON. Slides are rendered via Tailwind CSS + Puppeteer into images.
+
+### Features
+
+- **11 Layouts**: title, columns, comparison, grid, bigQuote, stats, timeline, split, matrix, table, funnel
+- **7 Content Block Types**: text, bullets, code, callout, metric, divider, image
+- **13-Color Theme System**: Semantic color palette with dark/light support
+- **6 Preset Themes**: dark, pop, warm, creative, minimal, corporate
+
+### Usage
+
+Set a theme once with `slideParams.theme`, then use `"type": "slide"` in each beat:
+
+```json
+{
+  "$mulmocast": { "version": "1.1" },
+  "slideParams": {
+    "theme": { "colors": { "bg": "0F172A", "bgCard": "1E293B", "bgCardAlt": "334155", "text": "F8FAFC", "textMuted": "CBD5E1", "textDim": "64748B", "primary": "3B82F6", "accent": "8B5CF6", "success": "22C55E", "warning": "F59E0B", "danger": "EF4444", "info": "14B8A6", "highlight": "EC4899" }, "fonts": { "title": "Georgia", "body": "Calibri", "mono": "Consolas" } }
+  },
+  "beats": [
+    {
+      "text": "Welcome to the presentation",
+      "image": {
+        "type": "slide",
+        "slide": { "layout": "title", "title": "Main Title", "subtitle": "Subtitle" }
+      }
+    }
+  ]
+}
+```
+
+Or use a preset presentation style:
+
+```bash
+mulmo tool complete beats.json -s slide_dark -o presentation.json
+```
+
+Available preset styles: `slide_dark`, `slide_pop`, `slide_warm`, `slide_creative`, `slide_minimal`, `slide_corporate`
+
+For detailed layout specifications and content block reference, see the [Slide DSL documentation](./.claude/skills/slide/SKILL.md).
+
 ## Markdown Slide Styles
 
 MulmoCast includes 100 pre-designed CSS styles for markdown slides, organized in 10 categories:

--- a/docs/feature.md
+++ b/docs/feature.md
@@ -495,7 +495,47 @@ Display markdown content with complex layouts. Supports 2-column, 2x2 grid, head
 }
 ```
 
-#### 10.8 スタイル (Styles for Markdown/TextSlide)
+#### 10.8 構造化スライド (Slide DSL)
+
+JSON DSLで構造化プレゼンテーションスライドを生成。11レイアウト、7コンテンツブロック、13色テーマシステム。
+
+Generate structured presentation slides using JSON DSL. 11 layouts, 7 content blocks, 13-color theme system.
+
+```json
+{
+  "image": {
+    "type": "slide",
+    "slide": {
+      "layout": "columns",
+      "title": "Comparison",
+      "columns": [
+        { "title": "Plan A", "accentColor": "primary", "content": [{ "type": "bullets", "items": ["Fast", "Simple"] }] },
+        { "title": "Plan B", "accentColor": "accent", "content": [{ "type": "bullets", "items": ["Scalable", "Robust"] }] }
+      ]
+    }
+  }
+}
+```
+
+**レイアウト / Layouts:** title, columns, comparison, grid, bigQuote, stats, timeline, split, matrix, table, funnel
+
+**コンテンツブロック / Content Blocks:** text, bullets, code, callout, metric, divider, image
+
+**プリセットテーマ / Preset Themes:** dark, pop, warm, creative, minimal, corporate
+
+**プレゼンテーションスタイル / Presentation Styles:**
+```bash
+mulmo tool complete beats.json -s slide_dark -o presentation.json
+```
+
+**詳細ドキュメント / Documentation:** [Slide SKILL.md](../.claude/skills/slide/SKILL.md)
+**サンプル / Samples:**
+- [scripts/test/test_slide_01.json](../scripts/test/test_slide_01.json)
+- [scripts/test/test_slide_12.json](../scripts/test/test_slide_12.json) - 全11レイアウトデモ / All 11 layouts demo
+
+---
+
+#### 10.9 スタイル (Styles for Markdown/TextSlide)
 
 100種類のプリセットスタイルでmarkdownやtextSlideを装飾。
 
@@ -539,7 +579,7 @@ Decorate markdown and textSlide with 100 preset styles.
 
 View all styles with `npx mulmocast tool info --category markdown-styles`.
 
-#### 10.9 Markdown内Mermaid埋め込み (Mermaid in Markdown)
+#### 10.10 Markdown内Mermaid埋め込み (Mermaid in Markdown)
 
 markdownコンテンツ内でmermaidダイアグラムを直接使用可能。レイアウト機能と組み合わせて図とテキストを並べて表示。
 

--- a/docs/image.md
+++ b/docs/image.md
@@ -830,7 +830,64 @@ markdown コンテンツ内で mermaid コードブロックを直接使用で�
 }
 ```
 
-### beat 
+### slide（構造化スライド）
+
+JSON DSLで構造化されたプレゼンテーションスライドを生成。11種のレイアウト、7種のコンテンツブロック、13色のテーマシステムをサポート。Tailwind CSS + Puppeteerでレンダリング。
+
+テーマは`slideParams.theme`でグローバルに設定するか、`beat.image.theme`でbeat単位に上書き可能。
+
+```json
+{
+  "type": "slide",
+  "slide": {
+    "layout": "title",
+    "title": "Main Title",
+    "subtitle": "Subtitle"
+  }
+}
+```
+
+#### columns レイアウト
+```json
+{
+  "type": "slide",
+  "slide": {
+    "layout": "columns",
+    "title": "Three Approaches",
+    "columns": [
+      { "title": "Plan A", "accentColor": "primary", "content": [{ "type": "bullets", "items": ["Feature 1", "Feature 2"] }] },
+      { "title": "Plan B", "accentColor": "accent", "content": [{ "type": "bullets", "items": ["Feature 3", "Feature 4"] }] },
+      { "title": "Plan C", "accentColor": "success", "content": [{ "type": "bullets", "items": ["Feature 5", "Feature 6"] }] }
+    ]
+  }
+}
+```
+
+#### stats レイアウト
+```json
+{
+  "type": "slide",
+  "slide": {
+    "layout": "stats",
+    "title": "Key Metrics",
+    "stats": [
+      { "value": "99.9%", "label": "Uptime", "color": "success", "change": "+0.1%" },
+      { "value": "2.3M", "label": "Users", "color": "primary", "change": "+15%" }
+    ]
+  }
+}
+```
+
+利用可能なレイアウト: `title`, `columns`, `comparison`, `grid`, `bigQuote`, `stats`, `timeline`, `split`, `matrix`, `table`, `funnel`
+
+利用可能なコンテンツブロック: `text`, `bullets`, `code`, `callout`, `metric`, `divider`, `image`
+
+プリセットテーマ: `dark`, `pop`, `warm`, `creative`, `minimal`, `corporate`（`assets/slide_themes/`に格納）
+
+**詳細なスキーマ定義**: [src/slide/schema.ts](../src/slide/schema.ts)
+**サンプル**: [scripts/test/test_slide_12.json](../scripts/test/test_slide_12.json)
+
+### beat
 #### 前のbeatのimageを使う
 ```json
 {

--- a/docs/image_plugin.md
+++ b/docs/image_plugin.md
@@ -14,6 +14,21 @@ beatのimage プロパティがセットされているとImage Pluginによっ�
 ```
 
 pluginの実装は[src/utils/image_plugins/](../src/utils/image_plugins)にある。
+
+現在のplugin一覧:
+- `image` - 画像ファイル参照（URL/ローカル）
+- `movie` - 動画ファイル参照
+- `textSlide` - テキストベースのスライド
+- `markdown` - Markdownレンダリング（レイアウト機能付き）
+- `chart` - Chart.jsチャート
+- `mermaid` - Mermaidダイアグラム
+- `html_tailwind` - カスタムHTML + Tailwind CSS
+- `slide` - 構造化スライドDSL（11レイアウト、Tailwind CSS + Puppeteer）
+- `beat` - 他のbeatの画像を参照
+- `voice_over` - ナレーション重ね（画像生成なし）
+- `vision` - Vision API
+- `source` - ソースファイル参照
+
 pluginを追加する場合は、
 
 - このdirにPluginのソースを追加

--- a/docs/ja/imagePreprocessAgent.md
+++ b/docs/ja/imagePreprocessAgent.md
@@ -55,6 +55,7 @@ type PreprocessResult = {
 - `markdown`: Markdown画像生成
 - `chart`: チャート画像生成
 - `mermaid`: mermaid図表生成
+- `slide`: 構造化スライドDSL（11レイアウト、Tailwind CSS + Puppeteer）
 
 プラグイン処理時：
 - セッション状態を管理（`MulmoStudioContextMethods.setBeatSessionState`）


### PR DESCRIPTION
## Summary

- Add slide image plugin (`type: "slide"`) documentation across all relevant docs
- Update README.md with Slide Presentations section (layouts, themes, usage)
- Update docs/image.md with slide examples (title, columns, stats layouts)
- Update docs/image_plugin.md with complete plugin list including slide
- Update docs/feature.md with slide DSL as section 10.8
- Update docs/ja/imagePreprocessAgent.md with slide in plugin list
- Update CLAUDE.md with `src/slide/` directory reference

## User Prompt

- READMEやdocs以下でslide image plugin (PR #1182) の情報が反映されていないドキュメントを更新

## Test plan

- [x] `yarn build` passes
- [x] All links in documentation point to existing files
- [x] Documentation follows existing patterns (Japanese + English bilingual in feature.md, Japanese in image.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Slide DSL for creating structured presentation slides with 11 layouts, 7 content block types, and 13-color theme system.

* **Documentation**
  * Added comprehensive guides on Slide DSL usage, including JSON examples, preset themes, layouts, content blocks, and rendering capabilities via Tailwind CSS + Puppeteer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->