### PR TITLE
feat: add chart and mermaid content block types to slide DSL

### DIFF
--- a/.claude/skills/slide/SKILL.md
+++ b/.claude/skills/slide/SKILL.md
@@ -241,7 +241,7 @@ yarn cli tool complete beats.json -s slide_dark -o presentation.json
 - `accentColor?`: `"primary" | "accent" | "success" | "warning" | "danger" | "info" | "highlight"`
 - `style?`: `{ "bgColor?": "hex", "decorations?": boolean, "bgOpacity?": number, "footer?": "..." }`
 
-## Content Blocks (8 types)
+## Content Blocks (10 types)
 
 Used in the `content` array of layouts such as columns, comparison, grid, split, and matrix.
 
@@ -316,6 +316,20 @@ References an image defined in `imageParams.images`. The `ref` value is a key in
 - `ref` resolves to the image generated/loaded by `imageParams.images.<key>`
 - Works with all source types: `imagePrompt` (AI-generated), `image` with `path`/`url`/`base64`
 - Unknown ref keys throw an error
+
+### chart
+```json
+{ "type": "chart", "chartData": { "type": "bar", "data": { "labels": ["Q1", "Q2"], "datasets": [{ "data": [10, 20] }] } }, "title?": "Revenue" }
+```
+
+Renders a Chart.js chart inline. `chartData` is passed directly to `new Chart(ctx, chartData)`. Any Chart.js chart type (bar, line, pie, doughnut, radar, polarArea, etc.) is supported. Animation is automatically disabled for Puppeteer rendering. The Chart.js CDN is only loaded when a chart block is present.
+
+### mermaid
+```json
+{ "type": "mermaid", "code": "graph TD\n  A-->B\n  B-->C", "title?": "Flow Diagram" }
+```
+
+Renders a Mermaid diagram inline. `code` is the Mermaid diagram definition string. The Mermaid CDN is only loaded when a mermaid block is present. The mermaid theme (dark/default) is automatically chosen based on the slide background color.
 
 ## Shared Components
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ MulmoCast includes a powerful **Slide DSL** (`type: "slide"`) for creating struc
 ### Features
 
 - **11 Layouts**: title, columns, comparison, grid, bigQuote, stats, timeline, split, matrix, table, funnel
-- **8 Content Block Types**: text, bullets, code, callout, metric, divider, image, imageRef
+- **10 Content Block Types**: text, bullets, code, callout, metric, divider, image, imageRef, chart, mermaid
 - **13-Color Theme System**: Semantic color palette with dark/light support
 - **6 Preset Themes**: dark, pop, warm, creative, minimal, corporate
 

--- a/plans/feat-slide-chart-mermaid.md
+++ b/plans/feat-slide-chart-mermaid.md
@@ -1,0 +1,35 @@
+# feat: slide content block に chart / mermaid タイプ追加
+
+## Summary
+
+スライド DSL の content block に `chart`（Chart.js）と `mermaid` タイプを追加。
+既にビートレベルで動いている Chart.js / Mermaid の仕組みをスライド内の content block として使えるようにする。
+
+## Schema
+
+- `chartBlockSchema`: `{ type: "chart", chartData: Record<string, unknown>, title?: string }`
+- `mermaidBlockSchema`: `{ type: "mermaid", code: string, title?: string }`
+- `contentBlockSchema` の discriminatedUnion に追加（8 → 10 types）
+
+## CDN Injection
+
+`generateSlideHTML` で content block を走査し、chart/mermaid が存在する場合のみ CDN script タグを `<head>` に注入。Mermaid のテーマはスライドの bg 色の明暗から自動判定。
+
+## ID Generation
+
+`src/slide/utils.ts` にカウンタベースの `generateSlideId(prefix)` を追加。Node.js 依存なし。
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/slide/schema.ts` | `chartBlockSchema`, `mermaidBlockSchema` 追加 |
+| `src/slide/blocks.ts` | `renderChart`, `renderMermaid` 追加 |
+| `src/slide/render.ts` | CDN script 条件注入 |
+| `src/slide/utils.ts` | `generateSlideId`, `detectBlockTypes` 追加 |
+| `src/slide/index.ts` | 新 schema/type を export |
+| `README.md` | Content Block Types を 10 に更新 |
+| `.claude/skills/slide/SKILL.md` | chart, mermaid ドキュメント追加 |
+| `test/slide/test_blocks.ts` | chart, mermaid ブロックテスト |
+| `test/slide/test_render.ts` | CDN 条件注入テスト |
+| `scripts/test/test_slide_chart_mermaid.json` | サンプル MulmoScript |

--- a/scripts/test/test_slide_chart_mermaid.json
+++ b/scripts/test/test_slide_chart_mermaid.json
@@ -1,0 +1,148 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "lang": "en",
+  "title": "Chart & Mermaid Content Blocks Demo",
+  "slideParams": {
+    "theme": {
+      "colors": {
+        "bg": "0F172A",
+        "bgCard": "1E293B",
+        "bgCardAlt": "334155",
+        "text": "F8FAFC",
+        "textMuted": "CBD5E1",
+        "textDim": "64748B",
+        "primary": "3B82F6",
+        "accent": "8B5CF6",
+        "success": "22C55E",
+        "warning": "F59E0B",
+        "danger": "EF4444",
+        "info": "14B8A6",
+        "highlight": "EC4899"
+      },
+      "fonts": { "title": "Georgia", "body": "Calibri", "mono": "Consolas" }
+    }
+  },
+  "beats": [
+    {
+      "text": "This slide shows a bar chart inside a columns layout.",
+      "image": {
+        "type": "slide",
+        "slide": {
+          "layout": "columns",
+          "title": "Quarterly Revenue",
+          "subtitle": "FY2025 performance overview",
+          "columns": [
+            {
+              "title": "Revenue by Quarter",
+              "accentColor": "primary",
+              "content": [
+                {
+                  "type": "chart",
+                  "title": "Revenue ($ millions)",
+                  "chartData": {
+                    "type": "bar",
+                    "data": {
+                      "labels": ["Q1", "Q2", "Q3", "Q4"],
+                      "datasets": [
+                        {
+                          "label": "Revenue",
+                          "data": [12, 19, 15, 24],
+                          "backgroundColor": ["#3B82F6", "#8B5CF6", "#22C55E", "#F59E0B"]
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "title": "Key Takeaways",
+              "accentColor": "success",
+              "content": [
+                { "type": "metric", "value": "$70M", "label": "Total Revenue", "color": "primary" },
+                { "type": "bullets", "items": ["Q4 strongest quarter", "24% QoQ growth in Q4", "Exceeded annual target by 8%"] }
+              ]
+            }
+          ]
+        }
+      }
+    },
+    {
+      "text": "This slide demonstrates a mermaid diagram in a split layout.",
+      "image": {
+        "type": "slide",
+        "slide": {
+          "layout": "split",
+          "left": {
+            "title": "System Architecture",
+            "accentColor": "accent",
+            "content": [
+              {
+                "type": "mermaid",
+                "title": "Data Flow",
+                "code": "graph TD\n  A[Client] --> B[API Gateway]\n  B --> C[Auth Service]\n  B --> D[App Service]\n  D --> E[Database]\n  D --> F[Cache]"
+              }
+            ]
+          },
+          "right": {
+            "title": "Components",
+            "accentColor": "info",
+            "content": [
+              {
+                "type": "bullets",
+                "items": [
+                  "API Gateway handles routing",
+                  "Auth Service manages tokens",
+                  "App Service processes requests",
+                  "Database stores persistent data",
+                  "Cache layer for performance"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "text": "This slide combines both chart and mermaid in a comparison layout.",
+      "image": {
+        "type": "slide",
+        "slide": {
+          "layout": "comparison",
+          "title": "Pipeline Analysis",
+          "left": {
+            "title": "Conversion Funnel",
+            "accentColor": "primary",
+            "content": [
+              {
+                "type": "chart",
+                "chartData": {
+                  "type": "doughnut",
+                  "data": {
+                    "labels": ["Leads", "Qualified", "Proposals", "Won"],
+                    "datasets": [
+                      {
+                        "data": [500, 200, 80, 35],
+                        "backgroundColor": ["#3B82F6", "#8B5CF6", "#22C55E", "#F59E0B"]
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "right": {
+            "title": "Process Flow",
+            "accentColor": "accent",
+            "content": [
+              {
+                "type": "mermaid",
+                "code": "graph LR\n  A[Lead] --> B[Qualify]\n  B --> C[Propose]\n  C --> D[Close]\n  D --> E[Onboard]"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/slide/index.ts
+++ b/src/slide/index.ts
@@ -6,7 +6,16 @@ export { renderSlideContent } from "./layouts/index.js";
 export { renderContentBlock, renderContentBlocks } from "./blocks.js";
 
 // Schemas
-export { mulmoSlideMediaSchema, slideLayoutSchema, slideThemeSchema, contentBlockSchema, imageRefBlockSchema, accentColorKeySchema } from "./schema.js";
+export {
+  mulmoSlideMediaSchema,
+  slideLayoutSchema,
+  slideThemeSchema,
+  contentBlockSchema,
+  imageRefBlockSchema,
+  chartBlockSchema,
+  mermaidBlockSchema,
+  accentColorKeySchema,
+} from "./schema.js";
 
 // Types
 export type {
@@ -17,6 +26,8 @@ export type {
   SlideThemeFonts,
   ContentBlock,
   ImageRefBlock,
+  ChartBlock,
+  MermaidBlock,
   AccentColorKey,
   TitleSlide,
   ColumnsSlide,

--- a/src/slide/render.ts
+++ b/src/slide/render.ts
@@ -1,11 +1,35 @@
 import type { SlideTheme, SlideLayout } from "./schema.js";
-import { escapeHtml, buildTailwindConfig, sanitizeHex } from "./utils.js";
+import { escapeHtml, buildTailwindConfig, sanitizeHex, detectBlockTypes } from "./utils.js";
 import { renderSlideContent } from "./layouts/index.js";
+
+/** Determine if a hex color is dark (luminance < 128) */
+const isDarkBg = (hex: string): boolean => {
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return (r * 299 + g * 587 + b * 114) / 1000 < 128;
+};
+
+/** Build CDN script tags for chart/mermaid when needed */
+const buildCdnScripts = (theme: SlideTheme, slide: SlideLayout): string => {
+  const { hasChart, hasMermaid } = detectBlockTypes(slide);
+  const scripts: string[] = [];
+  if (hasChart) {
+    scripts.push('<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>');
+  }
+  if (hasMermaid) {
+    const mermaidTheme = isDarkBg(theme.colors.bg) ? "dark" : "default";
+    scripts.push(`<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad:true,theme:'${mermaidTheme}'})</script>`);
+  }
+  return scripts.join("\n");
+};
 
 /** Generate a complete HTML document for a single slide */
 export const generateSlideHTML = (theme: SlideTheme, slide: SlideLayout): string => {
   const content = renderSlideContent(slide);
   const twConfig = buildTailwindConfig(theme);
+  const cdnScripts = buildCdnScripts(theme, slide);
 
   const slideStyle = slide.style;
   const bgCls = slideStyle?.bgColor ? "" : "bg-d-bg";
@@ -19,6 +43,7 @@ export const generateSlideHTML = (theme: SlideTheme, slide: SlideLayout): string
 <meta name="viewport" content="width=1280">
 <script src="https://cdn.tailwindcss.com"></script>
 <script>tailwind.config = ${twConfig}</script>
+${cdnScripts}
 <style>
   html, body { height: 100%; margin: 0; padding: 0; overflow: hidden; }
 </style>

--- a/src/slide/schema.ts
+++ b/src/slide/schema.ts
@@ -99,6 +99,18 @@ export const imageRefBlockSchema = z.object({
   fit: z.enum(["contain", "cover"]).optional(),
 });
 
+export const chartBlockSchema = z.object({
+  type: z.literal("chart"),
+  chartData: z.record(z.string(), z.unknown()),
+  title: z.string().optional(),
+});
+
+export const mermaidBlockSchema = z.object({
+  type: z.literal("mermaid"),
+  code: z.string(),
+  title: z.string().optional(),
+});
+
 export const contentBlockSchema = z.discriminatedUnion("type", [
   textBlockSchema,
   bulletsBlockSchema,
@@ -108,6 +120,8 @@ export const contentBlockSchema = z.discriminatedUnion("type", [
   dividerBlockSchema,
   imageBlockSchema,
   imageRefBlockSchema,
+  chartBlockSchema,
+  mermaidBlockSchema,
 ]);
 
 // ═══════════════════════════════════════════════════════════
@@ -398,6 +412,8 @@ export type MetricBlock = z.infer<typeof metricBlockSchema>;
 export type DividerBlock = z.infer<typeof dividerBlockSchema>;
 export type ImageBlock = z.infer<typeof imageBlockSchema>;
 export type ImageRefBlock = z.infer<typeof imageRefBlockSchema>;
+export type ChartBlock = z.infer<typeof chartBlockSchema>;
+export type MermaidBlock = z.infer<typeof mermaidBlockSchema>;
 export type CalloutBar = z.infer<typeof calloutBarSchema>;
 export type Card = z.infer<typeof cardSchema>;
 export type SlideStyle = z.infer<typeof slideStyleSchema>;

--- a/src/slide/utils.ts
+++ b/src/slide/utils.ts
@@ -1,4 +1,4 @@
-import type { SlideTheme, SlideThemeColors, AccentColorKey } from "./schema.js";
+import type { SlideTheme, SlideThemeColors, AccentColorKey, SlideLayout, ContentBlock } from "./schema.js";
 
 /** Escape HTML special characters */
 export const escapeHtml = (s: string): string => {
@@ -124,4 +124,66 @@ export const slideHeader = (data: { accentColor?: string; stepLabel?: string; ti
   }
   lines.push(`</div>`);
   return lines.join("\n");
+};
+
+// ═══════════════════════════════════════════════════════════
+// Counter-based ID generation (unique within a single slide)
+// ═══════════════════════════════════════════════════════════
+
+let slideIdCounter = 0;
+
+/** Generate a unique ID with the given prefix (e.g. "chart-0", "mermaid-1") */
+export const generateSlideId = (prefix: string): string => `${prefix}-${slideIdCounter++}`;
+
+/** Reset the ID counter (for testing) */
+export const resetSlideIdCounter = (): void => {
+  slideIdCounter = 0;
+};
+
+// ═══════════════════════════════════════════════════════════
+// Content block type detection
+// ═══════════════════════════════════════════════════════════
+
+type BlockTypeFlags = { hasChart: boolean; hasMermaid: boolean };
+
+/** Collect all content block arrays from a slide layout */
+const collectContentArrays = (slide: SlideLayout): ContentBlock[][] => {
+  const arrays: ContentBlock[][] = [];
+  const pushIfPresent = (content: ContentBlock[] | undefined) => {
+    if (content) arrays.push(content);
+  };
+  switch (slide.layout) {
+    case "columns":
+      slide.columns.forEach((col) => pushIfPresent(col.content));
+      break;
+    case "comparison":
+      pushIfPresent(slide.left.content);
+      pushIfPresent(slide.right.content);
+      break;
+    case "grid":
+      slide.items.forEach((item) => pushIfPresent(item.content));
+      break;
+    case "split":
+      pushIfPresent(slide.left?.content);
+      pushIfPresent(slide.right?.content);
+      break;
+    case "matrix":
+      slide.cells.forEach((cell) => pushIfPresent(cell.content));
+      break;
+  }
+  return arrays;
+};
+
+/** Detect whether chart or mermaid content blocks exist in a slide */
+export const detectBlockTypes = (slide: SlideLayout): BlockTypeFlags => {
+  const arrays = collectContentArrays(slide);
+  let hasChart = false;
+  let hasMermaid = false;
+  arrays.forEach((blocks) => {
+    blocks.forEach((block) => {
+      if (block.type === "chart") hasChart = true;
+      if (block.type === "mermaid") hasMermaid = true;
+    });
+  });
+  return { hasChart, hasMermaid };
 };

--- a/test/slide/test_render.ts
+++ b/test/slide/test_render.ts
@@ -147,3 +147,81 @@ test("generateSlideHTML: works with light theme colors", () => {
   assert.ok(html.includes("#FFFFFF"));
   assert.ok(html.includes("Trebuchet MS"));
 });
+
+// ═══════════════════════════════════════════════════════════
+// CDN script conditional injection
+// ═══════════════════════════════════════════════════════════
+
+test("generateSlideHTML: does NOT include Chart.js CDN when no chart blocks", () => {
+  const html = generateSlideHTML(theme, { layout: "title", title: "No Chart" });
+  assert.ok(!html.includes("chart.js"));
+});
+
+test("generateSlideHTML: does NOT include Mermaid CDN when no mermaid blocks", () => {
+  const html = generateSlideHTML(theme, { layout: "title", title: "No Mermaid" });
+  assert.ok(!html.includes("mermaid"));
+});
+
+test("generateSlideHTML: includes Chart.js CDN when chart block exists", () => {
+  const slide: SlideLayout = {
+    layout: "columns",
+    title: "Chart Slide",
+    columns: [
+      {
+        title: "Revenue",
+        content: [{ type: "chart", chartData: { type: "bar", data: { labels: ["Q1"], datasets: [{ data: [100] }] } } }],
+      },
+    ],
+  };
+  const html = generateSlideHTML(theme, slide);
+  assert.ok(html.includes('src="https://cdn.jsdelivr.net/npm/chart.js"'));
+});
+
+test("generateSlideHTML: includes Mermaid CDN with dark theme for dark bg", () => {
+  const slide: SlideLayout = {
+    layout: "split",
+    left: { content: [{ type: "mermaid", code: "graph TD\n  A-->B" }] },
+  };
+  const html = generateSlideHTML(theme, slide);
+  assert.ok(html.includes("mermaid.min.js"));
+  assert.ok(html.includes("theme:'dark'"));
+});
+
+test("generateSlideHTML: includes Mermaid CDN with default theme for light bg", () => {
+  const lightTheme: SlideTheme = {
+    colors: {
+      bg: "FFFFFF",
+      bgCard: "F8FAFC",
+      bgCardAlt: "F1F5F9",
+      text: "0F172A",
+      textMuted: "475569",
+      textDim: "94A3B8",
+      primary: "2563EB",
+      accent: "7C3AED",
+      success: "059669",
+      warning: "D97706",
+      danger: "DC2626",
+      info: "0891B2",
+      highlight: "DB2777",
+    },
+    fonts: { title: "Trebuchet MS", body: "Calibri", mono: "Consolas" },
+  };
+  const slide: SlideLayout = {
+    layout: "split",
+    left: { content: [{ type: "mermaid", code: "graph TD\n  A-->B" }] },
+  };
+  const html = generateSlideHTML(lightTheme, slide);
+  assert.ok(html.includes("theme:'default'"));
+});
+
+test("generateSlideHTML: includes both CDNs when chart and mermaid blocks coexist", () => {
+  const slide: SlideLayout = {
+    layout: "comparison",
+    title: "Both",
+    left: { title: "Chart", content: [{ type: "chart", chartData: { type: "pie", data: {} } }] },
+    right: { title: "Mermaid", content: [{ type: "mermaid", code: "graph LR\n  A-->B" }] },
+  };
+  const html = generateSlideHTML(theme, slide);
+  assert.ok(html.includes("chart.js"));
+  assert.ok(html.includes("mermaid.min.js"));
+});


### PR DESCRIPTION
## Summary

- Add `chart` (Chart.js) and `mermaid` content block types to the slide DSL, enabling inline charts and diagrams within slide layouts (columns, comparison, grid, split, matrix)
- CDN scripts are conditionally injected only when the respective block type is present in the slide
- Mermaid theme (dark/default) is auto-detected from slide background color luminance

## User Prompt

slide content block に chart（Chart.js）と mermaid タイプを追加する。既にビートレベルでは chart / mermaid が動いているので、同じ仕組みをスライド内の content block として使えるようにする。

## Implementation Details

### Schema (`src/slide/schema.ts`)
- `chartBlockSchema`: `{ type: "chart", chartData: Record<string, unknown>, title?: string }`
- `mermaidBlockSchema`: `{ type: "mermaid", code: string, title?: string }`
- `contentBlockSchema` discriminated union expanded from 8 to 10 types

### Block Rendering (`src/slide/blocks.ts`)
- `renderChart`: `<canvas>` + inline `<script>` with Chart.js init, animation disabled for Puppeteer
- `renderMermaid`: `<div class="mermaid">` with escaped code

### CDN Injection (`src/slide/render.ts`)
- Scans content blocks via `detectBlockTypes()` to conditionally inject Chart.js / Mermaid CDN
- `isDarkBg()` determines mermaid theme from background hex color

### Utilities (`src/slide/utils.ts`)
- `generateSlideId(prefix)`: counter-based ID generation (no Node.js dependency, standalone-package ready)
- `detectBlockTypes(slide)` + `collectContentArrays(slide)`: layout-aware content block scanning

### Docs & Tests
- 14 new tests (9 block + 5 CDN injection)
- Sample script: `scripts/test/test_slide_chart_mermaid.json`
- Updated README.md, SKILL.md, and plan file

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes (no new warnings)
- [x] `yarn ci_test` passes (all 14 new tests green)
- [x] Sample script validates in schema validation test
- [ ] Visual verification: `yarn cli image scripts/test/test_slide_chart_mermaid.json -o output/ --beat 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)