### PR TITLE
fix: correct CLI command typo in slide skill (image → images)

### DIFF
--- a/.claude/skills/slide/SKILL.md
+++ b/.claude/skills/slide/SKILL.md
@@ -375,8 +375,8 @@ Renders a Mermaid diagram inline. `code` is the Mermaid diagram definition strin
 yarn cli tool complete beats.json -s slide_dark -o presentation.json
 
 # 3. Generate slide images
-yarn cli image presentation.json -o output/
+yarn cli images presentation.json -o output/
 
 # 4. Preview a specific beat
-yarn cli image presentation.json -o output/ --beat 0
+yarn cli images presentation.json -o output/ --beat 0
 ```


### PR DESCRIPTION
SKILL 内のコマンドに誤りがあったので修正しました。

```bash
Unknown argument: image
error Command failed with exit code 1.
```
```bash
mulmo <command> [options]

Commands:
  mulmo translate <file>  Translate Mulmo script
  mulmo audio <file>      Generate audio files
  mulmo images <file>     Generate image files
  mulmo movie <file>      Generate movie file
  mulmo pdf <file>        Generate PDF files
  mulmo markdown <file>   Generate markdown files
  mulmo bundle <file>     Generate bundle files
  mulmo html <file>       Generate html files
  mulmo tool <command>    Generate Mulmo script and other tools
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples to reflect the correct command syntax for proper usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->