### PR TITLE
fix: remove justify-center from card layouts to fix vertical spacing

### DIFF
--- a/src/slide/layouts/columns.ts
+++ b/src/slide/layouts/columns.ts
@@ -25,14 +25,13 @@ const buildColumnCard = (col: Card): string => {
 
   if (col.content) {
     const centerCls = col.icon ? "text-center" : "";
-    inner.push(`<div class="mt-3 space-y-3 flex-1 min-h-0 overflow-auto flex flex-col justify-center ${centerCls}">`);
+    inner.push(`<div class="mt-4 space-y-4 flex-1 min-h-0 overflow-auto flex flex-col ${centerCls}">`);
     inner.push(renderCardContentBlocks(col.content));
     inner.push(`</div>`);
   }
 
   if (col.footer) {
-    inner.push(`<div class="flex-1"></div>`);
-    inner.push(`<p class="text-sm text-d-dim font-body mt-3">${escapeHtml(col.footer)}</p>`);
+    inner.push(`<p class="text-sm text-d-dim font-body mt-auto pt-3">${escapeHtml(col.footer)}</p>`);
   }
 
   return cardWrap(accent, inner.join("\n"), "flex-1");
@@ -50,7 +49,7 @@ export const layoutColumns = (data: ColumnsSlide): string => {
     }
   });
 
-  parts.push(`<div class="flex gap-4 px-12 mt-5 flex-1 min-h-0 items-stretch">`);
+  parts.push(`<div class="flex gap-4 px-12 mt-5 flex-1 min-h-0 items-start">`);
   parts.push(colElements.join("\n"));
   parts.push(`</div>`);
 

--- a/src/slide/layouts/comparison.ts
+++ b/src/slide/layouts/comparison.ts
@@ -9,14 +9,13 @@ const buildPanel = (panel: ComparisonPanel): string => {
   inner.push(`<h3 class="text-xl font-bold text-${c(accent)} font-body">${escapeHtml(panel.title)}</h3>`);
 
   if (panel.content) {
-    inner.push(`<div class="mt-4 space-y-3 flex-1 min-h-0 overflow-auto flex flex-col justify-center">`);
+    inner.push(`<div class="mt-5 space-y-4 flex-1 min-h-0 overflow-auto flex flex-col">`);
     inner.push(renderContentBlocks(panel.content));
     inner.push(`</div>`);
   }
 
   if (panel.footer) {
-    if (!panel.content) inner.push(`<div class="flex-1"></div>`);
-    inner.push(`<p class="text-sm text-d-dim font-body mt-3">${escapeHtml(panel.footer)}</p>`);
+    inner.push(`<p class="text-sm text-d-dim font-body mt-auto pt-3">${escapeHtml(panel.footer)}</p>`);
   }
 
   return cardWrap(accent, inner.join("\n"), "flex-1");
@@ -25,7 +24,7 @@ const buildPanel = (panel: ComparisonPanel): string => {
 export const layoutComparison = (data: ComparisonSlide): string => {
   const parts: string[] = [slideHeader(data)];
 
-  parts.push(`<div class="flex gap-5 px-12 mt-5 flex-1 min-h-0 items-stretch">`);
+  parts.push(`<div class="flex gap-5 px-12 mt-5 flex-1 min-h-0 items-start">`);
   parts.push(buildPanel(data.left));
   parts.push(buildPanel(data.right));
   parts.push(`</div>`);


### PR DESCRIPTION
## Summary

- comparison / columns レイアウトのカード内で `justify-center` を削除し、コンテンツを上から自然に流すように修正
- カード高さをコンテンツに合わせる (`items-stretch` → `items-start`)
- footer を `mt-auto` でカード下部に固定（`flex-1` spacer を削除）
- spacing を拡大 (`space-y-3` → `space-y-4`) でコンテンツ間の呼吸感を向上

## User Prompt

- カード系レイアウト（comparison / columns）で、コンテンツが少ない場合にカード内が `justify-center` で垂直中央寄せされ、タイトルとコンテンツの間に大きな不自然な余白が生まれていた問題を修正
- カードの高さをコンテンツに合わせてコンパクトにする

## Test plan

- [x] `yarn build` 成功
- [x] `yarn lint` 0 errors
- [x] `yarn format` 実行済み
- [x] 全52件のスライドレイアウトテスト pass
- [x] comparison スライド（5p）の目視確認
- [x] columns スライド（6p）の目視確認
- [x] 他レイアウト（title, split 等）に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical spacing in content containers for improved visual hierarchy.
  * Enhanced footer positioning by anchoring to container bottom with adjusted padding.
  * Updated column alignment behavior for better content distribution across layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->