### PR TITLE
fix: extract shared block schemas to prevent drift

### DIFF
--- a/src/slide/schema.ts
+++ b/src/slide/schema.ts
@@ -142,8 +142,8 @@ export const tableBlockSchema = z.object({
   striped: z.boolean().optional(),
 });
 
-/** All content block types except section (used inside section to prevent recursion) */
-const nonSectionContentBlockSchema = z.discriminatedUnion("type", [
+/** Block schemas shared between contentBlockSchema and nonSectionContentBlockSchema */
+const baseBlockSchemas = [
   textBlockSchema,
   bulletsBlockSchema,
   codeBlockSchema,
@@ -155,7 +155,10 @@ const nonSectionContentBlockSchema = z.discriminatedUnion("type", [
   chartBlockSchema,
   mermaidBlockSchema,
   tableBlockSchema,
-]);
+] as const;
+
+/** All content block types except section (used inside section to prevent recursion) */
+const nonSectionContentBlockSchema = z.discriminatedUnion("type", [...baseBlockSchemas]);
 
 export const sectionBlockSchema = z.object({
   type: z.literal("section"),
@@ -166,20 +169,7 @@ export const sectionBlockSchema = z.object({
   sidebar: z.boolean().optional(),
 });
 
-export const contentBlockSchema = z.discriminatedUnion("type", [
-  textBlockSchema,
-  bulletsBlockSchema,
-  codeBlockSchema,
-  calloutBlockSchema,
-  metricBlockSchema,
-  dividerBlockSchema,
-  imageBlockSchema,
-  imageRefBlockSchema,
-  chartBlockSchema,
-  mermaidBlockSchema,
-  sectionBlockSchema,
-  tableBlockSchema,
-]);
+export const contentBlockSchema = z.discriminatedUnion("type", [...baseBlockSchemas, sectionBlockSchema]);
 
 // ═══════════════════════════════════════════════════════════
 // Shared Components


### PR DESCRIPTION
## Summary
- Extract base block schemas into a shared `baseBlockSchemas` constant
- `nonSectionContentBlockSchema` and `contentBlockSchema` now both derive from this shared array
- Prevents drift when adding new block types (only one place to add)

Addresses CodeRabbit review comment from PR #1205 on `src/slide/schema.ts`.

## User Prompt
- PRのCodeRabbitレビューで指摘されていた `nonSectionContentBlockSchema` と `contentBlockSchema` の重複問題を修正

## Test plan
- [x] `yarn build` passes
- [x] `yarn lint` passes (0 errors)
- [x] `yarn ci_test` passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal schema optimization for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->