### PR TITLE
refactor: deduplicate slide rendering helpers

### DIFF
--- a/src/slide/blocks.ts
+++ b/src/slide/blocks.ts
@@ -1,5 +1,5 @@
 import type { ContentBlock, BulletItem, SectionBlock, TableBlock, TableCellValue } from "./schema.js";
-import { escapeHtml, c, generateSlideId, renderInlineMarkup } from "./utils.js";
+import { escapeHtml, c, generateSlideId, renderInlineMarkup, blockTitle, resolveChangeColor, resolveAccent } from "./utils.js";
 
 // ─── Table cell rendering (shared with layouts/table.ts) ───
 
@@ -56,8 +56,7 @@ export const renderTableCore = (headers: string[] | undefined, rows: TableCellVa
 };
 
 const renderTableBlock = (block: TableBlock): string => {
-  const titleHtml = block.title ? `<p class="text-sm font-bold text-d-text font-body mb-2">${renderInlineMarkup(block.title)}</p>` : "";
-  return `<div class="overflow-auto">${titleHtml}${renderTableCore(block.headers, block.rows, block.rowHeaders, block.striped)}</div>`;
+  return `<div class="overflow-auto">${blockTitle(block.title)}${renderTableCore(block.headers, block.rows, block.rowHeaders, block.striped)}</div>`;
 };
 
 /** Render a single content block to HTML */
@@ -181,11 +180,10 @@ const renderCallout = (block: ContentBlock & { type: "callout" }): string => {
 const renderMetric = (block: ContentBlock & { type: "metric" }): string => {
   const lines: string[] = [];
   lines.push(`<div class="text-center">`);
-  lines.push(`  <p class="text-4xl font-bold text-${c(block.color || "primary")}">${renderInlineMarkup(block.value)}</p>`);
+  lines.push(`  <p class="text-4xl font-bold text-${c(resolveAccent(block.color))}">${renderInlineMarkup(block.value)}</p>`);
   lines.push(`  <p class="text-sm text-d-dim mt-1">${renderInlineMarkup(block.label)}</p>`);
   if (block.change) {
-    const changeColor = /\+/.test(block.change) ? "success" : "danger";
-    lines.push(`  <p class="text-sm font-bold text-${c(changeColor)} mt-1">${escapeHtml(block.change)}</p>`);
+    lines.push(`  <p class="text-sm font-bold text-${c(resolveChangeColor(block.change))} mt-1">${escapeHtml(block.change)}</p>`);
   }
   lines.push(`</div>`);
   return lines.join("\n");
@@ -209,9 +207,8 @@ const renderImageRefPlaceholder = (block: ContentBlock & { type: "imageRef" }): 
 const renderChart = (block: ContentBlock & { type: "chart" }): string => {
   const chartId = generateSlideId("chart");
   const chartData = JSON.stringify(block.chartData);
-  const titleHtml = block.title ? `<p class="text-sm font-bold text-d-text font-body mb-2">${renderInlineMarkup(block.title)}</p>` : "";
   return `<div class="flex-1 min-h-0 flex flex-col">
-  ${titleHtml}
+  ${blockTitle(block.title)}
   <div class="flex-1 min-h-0 relative">
     <canvas id="${chartId}" data-chart-ready="false"></canvas>
   </div>
@@ -230,9 +227,8 @@ const renderChart = (block: ContentBlock & { type: "chart" }): string => {
 
 const renderMermaid = (block: ContentBlock & { type: "mermaid" }): string => {
   const mermaidId = generateSlideId("mermaid");
-  const titleHtml = block.title ? `<p class="text-sm font-bold text-d-text font-body mb-2">${renderInlineMarkup(block.title)}</p>` : "";
   return `<div class="flex-1 min-h-0 flex flex-col">
-  ${titleHtml}
+  ${blockTitle(block.title)}
   <div class="flex-1 min-h-0 flex justify-center items-center">
     <div id="${mermaidId}" class="mermaid">${escapeHtml(block.code)}</div>
   </div>
@@ -252,7 +248,7 @@ const renderSectionContent = (block: SectionBlock): string => {
 };
 
 const renderSectionSidebar = (block: SectionBlock): string => {
-  const color = block.color || "primary";
+  const color = resolveAccent(block.color);
   const chars = block.label
     .split("")
     .map((ch) => escapeHtml(ch))
@@ -265,7 +261,7 @@ const renderSectionSidebar = (block: SectionBlock): string => {
 };
 
 const renderSectionDefault = (block: SectionBlock): string => {
-  const color = block.color || "primary";
+  const color = resolveAccent(block.color);
   const badge = `<span class="min-w-[80px] px-3 py-1 rounded text-sm font-bold text-white bg-${c(color)} shrink-0">${renderInlineMarkup(block.label)}</span>`;
   return `<div class="flex gap-4 items-start">
   ${badge}

--- a/src/slide/layouts/big_quote.ts
+++ b/src/slide/layouts/big_quote.ts
@@ -1,15 +1,15 @@
 import type { BigQuoteSlide } from "../schema.js";
-import { renderInlineMarkup, c } from "../utils.js";
+import { renderInlineMarkup, accentBar, resolveAccent } from "../utils.js";
 
 export const layoutBigQuote = (data: BigQuoteSlide): string => {
-  const accent = data.accentColor || "primary";
+  const accent = resolveAccent(data.accentColor);
   const parts: string[] = [];
   parts.push(`<div class="flex flex-col items-center justify-center h-full px-20">`);
-  parts.push(`  <div class="h-[3px] w-24 bg-${c(accent)} mb-8"></div>`);
+  parts.push(`  ${accentBar(accent, "w-24 mb-8")}`);
   parts.push(`  <blockquote class="text-[32px] text-d-text font-title italic text-center leading-relaxed">`);
   parts.push(`    &ldquo;${renderInlineMarkup(data.quote)}&rdquo;`);
   parts.push(`  </blockquote>`);
-  parts.push(`  <div class="h-[3px] w-24 bg-${c(accent)} mt-8 mb-6"></div>`);
+  parts.push(`  ${accentBar(accent, "w-24 mt-8 mb-6")}`);
   if (data.author) {
     parts.push(`  <p class="text-lg text-d-muted font-body">${renderInlineMarkup(data.author)}</p>`);
   }

--- a/src/slide/layouts/columns.ts
+++ b/src/slide/layouts/columns.ts
@@ -1,9 +1,9 @@
 import type { ColumnsSlide, Card } from "../schema.js";
-import { renderInlineMarkup, c, cardWrap, numBadge, iconSquare, slideHeader, renderCalloutBar } from "../utils.js";
+import { renderInlineMarkup, c, cardWrap, numBadge, iconSquare, slideHeader, renderOptionalCallout, resolveAccent } from "../utils.js";
 import { renderCardContentBlocks } from "../blocks.js";
 
 const buildColumnCard = (col: Card): string => {
-  const accent = col.accentColor || "primary";
+  const accent = resolveAccent(col.accentColor);
   const inner: string[] = [];
 
   if (col.icon) {
@@ -53,9 +53,7 @@ export const layoutColumns = (data: ColumnsSlide): string => {
   parts.push(colElements.join("\n"));
   parts.push(`</div>`);
 
-  if (data.callout) {
-    parts.push(`<div class="mt-auto pb-4">${renderCalloutBar(data.callout)}</div>`);
-  }
+  parts.push(renderOptionalCallout(data.callout));
   if (data.bottomText) {
     parts.push(`<p class="text-center text-sm text-d-dim font-body pb-4">${renderInlineMarkup(data.bottomText)}</p>`);
   }

--- a/src/slide/layouts/comparison.ts
+++ b/src/slide/layouts/comparison.ts
@@ -1,9 +1,9 @@
 import type { ComparisonSlide, ComparisonPanel } from "../schema.js";
-import { renderInlineMarkup, c, cardWrap, slideHeader, renderCalloutBar } from "../utils.js";
+import { renderInlineMarkup, c, cardWrap, slideHeader, renderOptionalCallout, resolveAccent } from "../utils.js";
 import { renderContentBlocks } from "../blocks.js";
 
 const buildPanel = (panel: ComparisonPanel): string => {
-  const accent = panel.accentColor || "primary";
+  const accent = resolveAccent(panel.accentColor);
   const inner: string[] = [];
 
   inner.push(`<h3 class="text-xl font-bold text-${c(accent)} font-body">${renderInlineMarkup(panel.title)}</h3>`);
@@ -29,9 +29,7 @@ export const layoutComparison = (data: ComparisonSlide): string => {
   parts.push(buildPanel(data.right));
   parts.push(`</div>`);
 
-  if (data.callout) {
-    parts.push(`<div class="mt-auto pb-4">${renderCalloutBar(data.callout)}</div>`);
-  }
+  parts.push(renderOptionalCallout(data.callout));
 
   return parts.join("\n");
 };

--- a/src/slide/layouts/funnel.ts
+++ b/src/slide/layouts/funnel.ts
@@ -1,5 +1,5 @@
 import type { FunnelSlide } from "../schema.js";
-import { renderInlineMarkup, c, slideHeader, renderCalloutBar } from "../utils.js";
+import { renderInlineMarkup, c, slideHeader, renderOptionalCallout, resolveItemColor } from "../utils.js";
 
 export const layoutFunnel = (data: FunnelSlide): string => {
   const parts: string[] = [slideHeader(data)];
@@ -9,7 +9,7 @@ export const layoutFunnel = (data: FunnelSlide): string => {
   parts.push(`<div class="flex flex-col items-center gap-2 px-12 mt-6 flex-1">`);
 
   stages.forEach((stage, i) => {
-    const color = stage.color || data.accentColor || "primary";
+    const color = resolveItemColor(stage.color, data.accentColor);
     const widthPct = 100 - (i / Math.max(total - 1, 1)) * 55;
     parts.push(`<div class="bg-${c(color)} rounded-lg flex items-center justify-between px-6 py-4" style="width: ${widthPct}%">`);
     parts.push(`  <div class="flex items-center gap-3">`);
@@ -26,9 +26,7 @@ export const layoutFunnel = (data: FunnelSlide): string => {
 
   parts.push(`</div>`);
 
-  if (data.callout) {
-    parts.push(`<div class="mt-auto pb-4">${renderCalloutBar(data.callout)}</div>`);
-  }
+  parts.push(renderOptionalCallout(data.callout));
 
   return parts.join("\n");
 };

--- a/src/slide/layouts/grid.ts
+++ b/src/slide/layouts/grid.ts
@@ -1,21 +1,15 @@
 import type { GridSlide } from "../schema.js";
-import { renderInlineMarkup, c, cardWrap, numBadge, iconSquare } from "../utils.js";
+import { renderInlineMarkup, cardWrap, numBadge, iconSquare, slideHeader, resolveAccent } from "../utils.js";
 import { renderCardContentBlocks } from "../blocks.js";
 
 export const layoutGrid = (data: GridSlide): string => {
-  const accent = data.accentColor || "primary";
   const nCols = data.gridColumns || 3;
-  const parts: string[] = [];
-
-  parts.push(`<div class="h-[3px] bg-${c(accent)} shrink-0"></div>`);
-  parts.push(`<div class="px-12 pt-5 shrink-0">`);
-  parts.push(`  <h2 class="text-[42px] leading-tight font-title font-bold text-d-text">${renderInlineMarkup(data.title)}</h2>`);
-  parts.push(`</div>`);
+  const parts: string[] = [slideHeader(data)];
 
   parts.push(`<div class="grid grid-cols-${nCols} gap-4 px-12 mt-5 flex-1 min-h-0 overflow-hidden content-center">`);
 
   (data.items || []).forEach((item) => {
-    const itemAccent = item.accentColor || "primary";
+    const itemAccent = resolveAccent(item.accentColor);
     const inner: string[] = [];
 
     if (item.icon) {

--- a/src/slide/layouts/matrix.ts
+++ b/src/slide/layouts/matrix.ts
@@ -1,5 +1,5 @@
 import type { MatrixSlide } from "../schema.js";
-import { renderInlineMarkup, c, cardWrap, slideHeader } from "../utils.js";
+import { renderInlineMarkup, c, cardWrap, slideHeader, resolveAccent } from "../utils.js";
 import { renderContentBlocks } from "../blocks.js";
 
 export const layoutMatrix = (data: MatrixSlide): string => {
@@ -29,7 +29,7 @@ export const layoutMatrix = (data: MatrixSlide): string => {
     Array.from({ length: cols }).forEach((_col, ci) => {
       const idx = r * cols + ci;
       const cell = cells[idx] || { label: "" };
-      const accent = cell.accentColor || "primary";
+      const accent = resolveAccent(cell.accentColor);
       const inner: string[] = [];
       inner.push(`<h3 class="text-lg font-bold text-${c(accent)} font-body">${renderInlineMarkup(cell.label)}</h3>`);
       if (cell.items) {

--- a/src/slide/layouts/split.ts
+++ b/src/slide/layouts/split.ts
@@ -1,5 +1,5 @@
 import type { SplitSlide, SplitPanel } from "../schema.js";
-import { renderInlineMarkup, c } from "../utils.js";
+import { renderInlineMarkup, c, accentBar, resolveAccent } from "../utils.js";
 import { renderContentBlocks } from "../blocks.js";
 
 const resolveValign = (valign: "top" | "center" | "bottom" | undefined): string => {
@@ -37,9 +37,9 @@ const buildSplitPanel = (panel: SplitPanel, fallbackAccent: string, ratio: numbe
 };
 
 export const layoutSplit = (data: SplitSlide): string => {
-  const accent = data.accentColor || "primary";
+  const accent = resolveAccent(data.accentColor);
   const parts: string[] = [];
-  parts.push(`<div class="h-[3px] bg-${c(accent)} shrink-0"></div>`);
+  parts.push(accentBar(accent));
 
   const leftRatio = data.left?.ratio || 50;
   const rightRatio = data.right?.ratio || 50;

--- a/src/slide/layouts/stats.ts
+++ b/src/slide/layouts/stats.ts
@@ -1,29 +1,23 @@
 import type { StatsSlide } from "../schema.js";
-import { renderInlineMarkup, c, renderCalloutBar, renderHeaderText } from "../utils.js";
+import { renderInlineMarkup, c, resolveItemColor, resolveChangeColor, centeredSlideHeader, renderOptionalCallout } from "../utils.js";
 
 export const layoutStats = (data: StatsSlide): string => {
-  const accent = data.accentColor || "primary";
   const stats = data.stats || [];
   const parts: string[] = [];
 
-  parts.push(`<div class="h-[3px] bg-${c(accent)} shrink-0"></div>`);
-  parts.push(`<div class="flex-1 flex flex-col justify-center px-12 min-h-0">`);
-
-  // Header inside centering wrapper
-  parts.push(renderHeaderText(data));
+  parts.push(centeredSlideHeader(data));
 
   // Stats cards
   parts.push(`<div class="flex gap-6 mt-10">`);
 
   stats.forEach((stat) => {
-    const color = stat.color || data.accentColor || "primary";
+    const color = resolveItemColor(stat.color, data.accentColor);
     parts.push(`<div class="flex-1 bg-d-card rounded-lg shadow-lg p-10 text-center">`);
     parts.push(`  <div class="h-[3px] bg-${c(color)} rounded-full w-12 mx-auto mb-6"></div>`);
     parts.push(`  <p class="text-[52px] font-bold text-${c(color)} font-body leading-none">${renderInlineMarkup(stat.value)}</p>`);
     parts.push(`  <p class="text-lg text-d-muted font-body mt-4">${renderInlineMarkup(stat.label)}</p>`);
     if (stat.change) {
-      const changeColor = /\+/.test(stat.change) ? "success" : "danger";
-      parts.push(`  <p class="text-base font-bold text-${c(changeColor)} font-body mt-3">${renderInlineMarkup(stat.change)}</p>`);
+      parts.push(`  <p class="text-base font-bold text-${c(resolveChangeColor(stat.change))} font-body mt-3">${renderInlineMarkup(stat.change)}</p>`);
     }
     parts.push(`</div>`);
   });
@@ -31,9 +25,7 @@ export const layoutStats = (data: StatsSlide): string => {
   parts.push(`</div>`);
   parts.push(`</div>`);
 
-  if (data.callout) {
-    parts.push(`<div class="mt-auto pb-4">${renderCalloutBar(data.callout)}</div>`);
-  }
+  parts.push(renderOptionalCallout(data.callout));
 
   return parts.join("\n");
 };

--- a/src/slide/layouts/table.ts
+++ b/src/slide/layouts/table.ts
@@ -1,5 +1,5 @@
 import type { TableSlide } from "../schema.js";
-import { slideHeader, renderCalloutBar } from "../utils.js";
+import { slideHeader, renderOptionalCallout } from "../utils.js";
 import { renderTableCore } from "../blocks.js";
 
 export const layoutTable = (data: TableSlide): string => {
@@ -9,9 +9,7 @@ export const layoutTable = (data: TableSlide): string => {
   parts.push(renderTableCore(data.headers, data.rows, data.rowHeaders, data.striped));
   parts.push(`</div>`);
 
-  if (data.callout) {
-    parts.push(`<div class="mt-auto pb-4">${renderCalloutBar(data.callout)}</div>`);
-  }
+  parts.push(renderOptionalCallout(data.callout));
 
   return parts.join("\n");
 };

--- a/src/slide/layouts/timeline.ts
+++ b/src/slide/layouts/timeline.ts
@@ -1,23 +1,18 @@
 import type { TimelineSlide } from "../schema.js";
-import { renderInlineMarkup, c, renderHeaderText } from "../utils.js";
+import { renderInlineMarkup, c, resolveItemColor, centeredSlideHeader } from "../utils.js";
 
 export const layoutTimeline = (data: TimelineSlide): string => {
-  const accent = data.accentColor || "primary";
   const parts: string[] = [];
   const items = data.items || [];
 
-  parts.push(`<div class="h-[3px] bg-${c(accent)} shrink-0"></div>`);
-  parts.push(`<div class="flex-1 flex flex-col justify-center px-12 min-h-0">`);
-
-  // Header inside centering wrapper
-  parts.push(renderHeaderText(data));
+  parts.push(centeredSlideHeader(data));
 
   // Timeline items
   parts.push(`<div class="flex items-start mt-10 relative">`);
   parts.push(`<div class="absolute left-4 right-4 top-[52px] h-[2px] bg-d-alt"></div>`);
 
   items.forEach((item) => {
-    const color = item.color || data.accentColor || "primary";
+    const color = resolveItemColor(item.color, data.accentColor);
     const dotBorder = item.done ? `bg-${c(color)}` : `bg-d-alt`;
     const dotInner = item.done ? "bg-d-text" : `bg-${c(color)}`;
     parts.push(`<div class="flex-1 flex flex-col items-center text-center relative z-10">`);

--- a/src/slide/layouts/title.ts
+++ b/src/slide/layouts/title.ts
@@ -1,9 +1,9 @@
 import type { TitleSlide } from "../schema.js";
-import { renderInlineMarkup } from "../utils.js";
+import { renderInlineMarkup, accentBar } from "../utils.js";
 
 export const layoutTitle = (data: TitleSlide): string => {
   return [
-    `<div class="h-[3px] bg-d-primary"></div>`,
+    accentBar("primary"),
     `<div class="absolute -top-20 -right-8 w-[360px] h-[360px] rounded-full bg-d-primary opacity-10"></div>`,
     `<div class="absolute -bottom-12 -left-16 w-[280px] h-[280px] rounded-full bg-d-accent opacity-10"></div>`,
     `<div class="flex flex-col justify-center h-full px-16 relative z-10">`,
@@ -14,7 +14,7 @@ export const layoutTitle = (data: TitleSlide): string => {
       ? `  <div class="bg-d-card px-4 py-2 mt-6 inline-block rounded"><p class="text-sm text-d-dim font-body">${renderInlineMarkup(data.note)}</p></div>`
       : "",
     `</div>`,
-    `<div class="absolute bottom-0 left-0 right-0 h-[3px] bg-d-accent"></div>`,
+    accentBar("accent", "absolute bottom-0 left-0 right-0"),
   ]
     .filter(Boolean)
     .join("\n");

--- a/src/slide/utils.ts
+++ b/src/slide/utils.ts
@@ -1,4 +1,4 @@
-import type { SlideTheme, SlideThemeColors, AccentColorKey, SlideLayout, ContentBlock } from "./schema.js";
+import type { SlideTheme, SlideThemeColors, AccentColorKey, SlideLayout, ContentBlock, CalloutBar } from "./schema.js";
 
 /** Escape HTML special characters */
 export const escapeHtml = (s: string): string => {
@@ -52,6 +52,35 @@ export const sanitizeHex = (s: string): string => {
 /** Accent color key → Tailwind class segment: "primary" → "d-primary" */
 export const c = (key: string): string => {
   return `d-${sanitizeCssClass(key)}`;
+};
+
+// ═══════════════════════════════════════════════════════════
+// Shared micro-helpers for HTML generation
+// ═══════════════════════════════════════════════════════════
+
+/** Default accent color used when none is specified */
+const DEFAULT_ACCENT = "primary";
+
+/** Resolve accent color key with "primary" as fallback */
+export const resolveAccent = (color: string | undefined): string => color || DEFAULT_ACCENT;
+
+/** Resolve item-level color with slide-level fallback then "primary" */
+export const resolveItemColor = (itemColor: string | undefined, slideAccent: string | undefined): string => itemColor || slideAccent || DEFAULT_ACCENT;
+
+/** Render a horizontal accent bar (3px full-width). Pass extraClass for width/margin variants. */
+export const accentBar = (colorKey: string, extraClass?: string): string => `<div class="h-[3px] bg-${c(colorKey)} shrink-0 ${extraClass || ""}"></div>`;
+
+/** Render an optional block title (chart, mermaid, table) */
+export const blockTitle = (title: string | undefined): string =>
+  title ? `<p class="text-sm font-bold text-d-text font-body mb-2">${renderInlineMarkup(title)}</p>` : "";
+
+/** Resolve change indicator color: "success" for positive (+), "danger" for negative */
+export const resolveChangeColor = (change: string): string => (/\+/.test(change) ? "success" : "danger");
+
+/** Render the optional callout bar at the bottom of a slide, or empty string */
+export const renderOptionalCallout = (callout: CalloutBar | undefined): string => {
+  if (!callout) return "";
+  return `<div class="mt-auto pb-4">${renderCalloutBar(callout)}</div>`;
 };
 
 type TailwindColorKey = "bg" | "card" | "alt" | "text" | "muted" | "dim" | AccentColorKey;
@@ -112,7 +141,7 @@ export const iconSquare = (icon: string, colorKey: string): string => {
 /** Render a card wrapper with accent top bar */
 export const cardWrap = (accentColor: string, innerHtml: string, extraClass?: string): string => {
   return `<div class="bg-d-card rounded-lg shadow-lg overflow-hidden flex flex-col min-h-0 ${sanitizeCssClass(extraClass || "")}">
-  <div class="h-[3px] bg-${c(accentColor)} shrink-0"></div>
+  ${accentBar(accentColor)}
   <div class="p-5 flex flex-col flex-1 min-h-0 overflow-hidden">
 ${innerHtml}
   </div>
@@ -135,7 +164,7 @@ export const renderCalloutBar = (obj: { text: string; label?: string; color?: st
 
 /** Render header text elements (stepLabel + title + subtitle) without wrapping div */
 export const renderHeaderText = (data: { accentColor?: string; stepLabel?: string; title: string; subtitle?: string }): string => {
-  const accent = data.accentColor || "primary";
+  const accent = resolveAccent(data.accentColor);
   const lines: string[] = [];
   if (data.stepLabel) {
     lines.push(`<p class="text-sm font-bold text-${c(accent)} font-body">${renderInlineMarkup(data.stepLabel)}</p>`);
@@ -149,8 +178,14 @@ export const renderHeaderText = (data: { accentColor?: string; stepLabel?: strin
 
 /** Render the common slide header (accent bar + title + subtitle) */
 export const slideHeader = (data: { accentColor?: string; stepLabel?: string; title: string; subtitle?: string }): string => {
-  const accent = data.accentColor || "primary";
-  return [`<div class="h-[3px] bg-${c(accent)} shrink-0"></div>`, `<div class="px-12 pt-5 shrink-0">`, renderHeaderText(data), `</div>`].join("\n");
+  const accent = resolveAccent(data.accentColor);
+  return [accentBar(accent), `<div class="px-12 pt-5 shrink-0">`, renderHeaderText(data), `</div>`].join("\n");
+};
+
+/** Render accent bar + vertically-centered wrapper with header text (used by stats, timeline) */
+export const centeredSlideHeader = (data: { accentColor?: string; stepLabel?: string; title: string; subtitle?: string }): string => {
+  const accent = resolveAccent(data.accentColor);
+  return [accentBar(accent), `<div class="flex-1 flex flex-col justify-center px-12 min-h-0">`, renderHeaderText(data)].join("\n");
 };
 
 // ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

### Commit 1: Initial deduplication

- Extract `renderSectionContent()` in `blocks.ts` to eliminate duplicated content rendering between `renderSectionSidebar` and `renderSectionDefault`
- Extract `renderHeaderText()` in `utils.ts` to share stepLabel+title+subtitle rendering across `slideHeader`, `stats`, and `timeline` layouts
- Fix `renderMetric` change color detection to use `/\+/.test()` regex (consistent with `stats.ts`)

### Commit 2: Thorough DRY pass across all slide layouts

Analyzed all 17 files in `src/slide/` for duplication patterns. Added 7 shared helpers to `utils.ts`:

| Helper | Eliminated pattern | Occurrences |
|--------|-------------------|-------------|
| `resolveAccent()` | `\|\| "primary"` magic string | 18+ |
| `resolveItemColor()` | `item.color \|\| slide.accent \|\| "primary"` 3-level fallback | 3 |
| `accentBar()` | `<div class="h-[3px] bg-...">` HTML pattern | 11 |
| `renderOptionalCallout()` | `if (data.callout) { ... renderCalloutBar ... }` guard + wrapper | 5 |
| `blockTitle()` | chart/mermaid/table title HTML | 3 |
| `resolveChangeColor()` | `+` detection → success/danger branch | 2 |
| `centeredSlideHeader()` | stats/timeline accent bar + centering wrapper + header text | 2 |

Additional: `grid.ts` now uses `slideHeader()` instead of manual title rendering, gaining `subtitle`/`stepLabel` support for free.

## User Prompt

- src/slide以下で重複コード、大きな関数などあれば直して。なければそのままでよい
- もっとhtml作成部分DRYにできないか徹底的に考えて

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes (0 errors)
- [x] `yarn ci_test` passes (all tests green)
- [x] No visual changes — only internal refactoring of HTML generation helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated layout rendering logic across multiple components to improve code consistency.
  * Introduced centralized utilities for color resolution and accent bar rendering.
  * Reduced inline HTML duplication by centralizing title and header rendering across layouts.
  * Updated color handling for metrics, items, and change indicators through dedicated resolvers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->