### PR TITLE
docs: update /story skill to use yarn movie as single command

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -254,6 +254,12 @@ For beats showing statistics or research findings, add `"reference": "Source: ..
 
 ### Write the file and present output
 
+Generate the movie directly — `yarn movie` automatically generates images and audio as well, so separate `yarn images` / `yarn audio` steps are unnecessary.
+
+```bash
+yarn movie <filename>
+```
+
 ```text
 Wrote: <filename>
 
@@ -261,8 +267,5 @@ Summary:
 - N beats, [theme] theme
 - Key topics: [brief list]
 
-Next steps:
-- Preview: yarn cli images <filename>
-- Audio: yarn audio <filename>
-- Video: yarn movie <filename>
+Output: output/video/<basename>.mp4
 ```


### PR DESCRIPTION
## Summary
- `yarn movie` automatically generates images and audio, so separate `yarn images` / `yarn audio` steps are unnecessary
- Simplified the /story skill output section to reflect this

## User Prompt
- movieつくるときはmovieだけで、audioとimageも作られる。skillに反映しておいて。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified movie generation workflow with a consolidated command approach, eliminating the need for separate image and audio generation steps.
  * Enhanced output guidance with clear, direct path information for final video files.
  * Refreshed example output format including updated structure and summary sections for better user comprehension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->