### PR TITLE
docs: add schema validation note to /story skill

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -213,6 +213,8 @@ For image-only beats without slide layout, use `imagePrompt` as a beat-level str
 
 ### Combine narrations + visuals into MulmoScript JSON
 
+> **Note**: The template below shows commonly used beat fields. If you need a field not listed here, run `npx mulmo tool schema` to verify it exists in the schema before adding it. The beat schema is strict — unrecognized fields will cause validation errors.
+
 ```json
 {
   "$mulmocast": { "version": "1.1" },


### PR DESCRIPTION
何度か /story を実行した時に beat 内に title を入れることがありました。
そのため、schema コマンドを使ってくださいという、SKILL の更新提案です。

```
⏺ Bash(yarn images generative_lecture.json 2>&1)
  ⎿  Error: Exit code 1
     yarn run v1.22.22
     $ npx tsx ./src/cli/bin.ts images generative_lecture.json
     Error: invalid MulmoScript Schema: /Users/yasutaka/Documents/mac-workspace
     /mulmo/mulmocast-cli/generative_lecture.json
      [
       {
         "code": "unrecognized_keys",
         "keys": [
           "title"
         ],
     … +182 lines (ctrl+o to see all)

⏺ beatsにtitleフィールドは使えないようです。全beat から削除します。
```


## Summary
`/story` スキルの Assembly フェーズに、beat スキーマの strict バリデーションに関する注記を追加。

## Background
`/story` スキルで MulmoScript を生成する際、テンプレートに存在しない `title` フィールドを beat に追加してしまい、スキーマバリデーションエラーが発生した。`mulmoBeatSchema` は `.strict()` で定義されており、未定義フィールドは拒否される。

## Changes
- テンプレートに載っていないフィールドを使う前に `npx mulmo tool schema` で確認するよう注記を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added schema validation guidance to story skill documentation, including instructions for checking unlisted fields and handling unrecognized fields during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->