### PR TITLE
chore: add BGM to mulmo.config.json.sample

### DIFF
--- a/mulmo.config.json.sample
+++ b/mulmo.config.json.sample
@@ -2,6 +2,13 @@
   "speechParams": {
     "provider": "elevenlabs"
   },
+  "audioParams": {
+    "bgm": {
+      "kind": "url",
+      "url": "https://github.com/receptron/mulmocast-media/raw/refs/heads/main/bgms/story001.mp3"
+    },
+    "bgmVolume": 0.15
+  },
   "imageParams": {
     "backgroundImage": {
       "source": { "kind": "path", "path": "branding/banner.jpg" },


### PR DESCRIPTION
## Summary

- Add `audioParams` with BGM (story001.mp3 "Whispered Melody") and `bgmVolume: 0.15` to `mulmo.config.json.sample`
- BGM source: [receptron/mulmocast-media](https://github.com/receptron/mulmocast-media/tree/main/bgms)

## User Prompt

- mulmo.config.jsonにBGMを入れたい。mulmocast-mediaレポジトリから選んで、sampleファイルを更新

## Test plan

- [x] Verify `mulmo.config.json.sample` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added audio parameters configuration support, including background music source and volume settings in the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->