### PR TITLE
feat: add BGM auto-selection to story skill

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -211,6 +211,26 @@ For image-only beats without slide layout, use `imagePrompt` as a beat-level str
 
 ## Phase 5: Assembly & Review
 
+### Select BGM
+
+Choose background music from the [mulmocast-media BGM catalog](https://github.com/receptron/mulmocast-media/tree/main/bgms) that matches the story mood:
+
+| BGM | Title | Mood | Best for |
+|-----|-------|------|----------|
+| `story001.mp3` | Whispered Melody | smooth, piano | Calm narratives, reflective stories |
+| `story002.mp3` | Rise and Shine | techno, inspiring, piano | Motivational, startup, tech innovation |
+| `story003.mp3` | Chasing the Sunset | piano, inspiring | Uplifting stories, journeys, aspirations |
+| `story004.mp3` | Whispering Keys | classical, ambient | Academic, research, thoughtful content |
+| `story005.mp3` | Whisper of Ivory | piano solo, classical | Elegant, formal, documentary |
+| `theme001.mp3` | Rise of the Flame | classical, emotional | Epic achievements, milestones, announcements |
+| `vibe001.mp3` | Let It Vibe! | rap, dance | Pop culture, entertainment, energetic |
+| `olympic001.mp3` | Olympic-style Theme | epic orchestral fanfare | Grand openings, celebrations, competitions |
+| `morning001.mp3` | Morning Dance | morning, piano solo | Lifestyle, daily routines, light topics |
+
+**URL pattern**: `https://github.com/receptron/mulmocast-media/raw/refs/heads/main/bgms/{name}`
+
+Select the BGM that best matches the tone from Phase 1's Topic Brief, and add it to `audioParams`.
+
 ### Combine narrations + visuals into MulmoScript JSON
 
 > **Note**: The template below shows commonly used beat fields. If you need a field not listed here, run `npx mulmo tool schema` to verify it exists in the schema before adding it. The beat schema is strict — unrecognized fields will cause validation errors.
@@ -224,6 +244,10 @@ For image-only beats without slide layout, use `imagePrompt` as a beat-level str
   "description": "Brief description",
   "references": [{ "url": "...", "title": "...", "type": "article" }],
   "speechParams": { "speakers": { "Presenter": { "voiceId": "shimmer" } } },
+  "audioParams": {
+    "bgm": { "kind": "url", "url": "https://github.com/receptron/mulmocast-media/raw/refs/heads/main/bgms/story001.mp3" },
+    "bgmVolume": 0.15
+  },
   "slideParams": { "theme": { } },
   "imageParams": { "provider": "google", "images": { } },
   "beats": [


### PR DESCRIPTION
## Summary

- Add BGM catalog table (9 tracks from mulmocast-media) to story skill Phase 5
- Skill now selects BGM matching story mood/tone and adds `audioParams` to MulmoScript
- Add `audioParams.bgm` + `bgmVolume: 0.15` to JSON template

## User Prompt

- skillでBGM自動追加したい。mulmocast-mediaから適当に選んで、ストーリにあうのを選択しているようにしてほしい

## Test plan

- [x] Verify SKILL.md is valid markdown
- [ ] Run /story and confirm BGM is included in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Phase 5 section with guidance for selecting and attaching background music (BGM) to narration.
  * Included a BGM catalog reference and URL patterns for accessing background music resources.
  * Updated the JSON template documentation to support audio parameters, including background music settings and volume control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->