### PR TITLE
feat: add orientation option to story skill

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -62,6 +62,7 @@ If using Playwright, collect image URLs with `browser_evaluate`:
 **Subject**: [one line]
 **Target audience**: [who]
 **Tone**: [professional / conversational / energetic / serious]
+**Orientation**: [landscape (1280×720) / portrait (720×1280)]
 **Key insights** (3-5):
 1. ...
 
@@ -69,6 +70,8 @@ If using Playwright, collect image URLs with `browser_evaluate`:
 **Collected images** (N found):
 - [description]: [local path]
 ```
+
+Ask the user about orientation. Default to **landscape** (1280×720) for presentations and standard videos. Use **portrait** (720×1280) for short-form content (TikTok, Reels, Shorts, Stories).
 
 ### Theme-to-Content Matching
 
@@ -239,7 +242,7 @@ Select the BGM that best matches the tone from Phase 1's Topic Brief, and add it
 {
   "$mulmocast": { "version": "1.1" },
   "lang": "en",
-  "canvasSize": { "width": 1280, "height": 720 },
+  "canvasSize": { "width": 1280, "height": 720 },  // portrait: { "width": 720, "height": 1280 }
   "title": "Title",
   "description": "Brief description",
   "references": [{ "url": "...", "title": "...", "type": "article" }],


### PR DESCRIPTION
## Summary

- Add landscape/portrait orientation option to Phase 1 Topic Brief in story skill
- Default to landscape (1280×720), portrait (720×1280) for short-form content
- Add `canvasSize` comment in JSON template showing portrait alternative

## User Prompt

- たて動画も簡単にできるようにしてほしい。Phase 1で聞いて

## Test plan

- [x] Verify SKILL.md is valid markdown
- [ ] Run /story and confirm orientation is asked in Phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)