### PR TITLE
feat: use --grouped flag in story skill movie command

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -62,7 +62,7 @@ If using Playwright, collect image URLs with `browser_evaluate`:
 **Subject**: [one line]
 **Target audience**: [who]
 **Tone**: [professional / conversational / energetic / serious]
-**Orientation**: [landscape (1280×720) / portrait (720×1280)]
+**Orientation**: [landscape (1280×720) / portrait (1080×1920)]
 **Key insights** (3-5):
 1. ...
 
@@ -71,7 +71,7 @@ If using Playwright, collect image URLs with `browser_evaluate`:
 - [description]: [local path]
 ```
 
-Ask the user about orientation. Default to **landscape** (1280×720) for presentations and standard videos. Use **portrait** (720×1280) for short-form content (TikTok, Reels, Shorts, Stories).
+Ask the user about orientation. Default to **landscape** (1280×720) for presentations and standard videos. Use **portrait** (1080×1920) for short-form content (TikTok, Reels, Shorts, Stories).
 
 ### Theme-to-Content Matching
 
@@ -99,6 +99,8 @@ Ask the user about orientation. Default to **landscape** (1280×720) for present
 | Long (report, multi-chapter) | 15-25 beats | HOOK → (CHAPTER → BEATS) × N → CLOSE |
 
 When user asks for condensed/few slides, aim for 3-5 dense beats.
+
+**YouTube Shorts constraint**: When portrait orientation is selected for Shorts, limit to **3-5 beats** with short narrations (1-2 sentences each) to keep total duration **≤ 60 seconds**. Each beat typically produces ~8-12 seconds of audio.
 
 ### Present Beat Outline for approval
 
@@ -242,7 +244,7 @@ Select the BGM that best matches the tone from Phase 1's Topic Brief, and add it
 {
   "$mulmocast": { "version": "1.1" },
   "lang": "en",
-  "canvasSize": { "width": 1280, "height": 720 },  // portrait: { "width": 720, "height": 1280 }
+  "canvasSize": { "width": 1280, "height": 720 },  // portrait: { "width": 1080, "height": 1920 }
   "title": "Title",
   "description": "Brief description",
   "references": [{ "url": "...", "title": "...", "type": "article" }],


### PR DESCRIPTION
## Summary

- Use `--grouped` flag when running `yarn movie` in story skill
- Outputs all files under `output/<basename>/` for cleaner organization

## User Prompt

- groupedのoptionを追加したけど、skillでmovieを作るときは、groupedで作ったほうが扱いやすいよね？

## Test plan

- [x] Verify SKILL.md is valid markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated movie-generation CLI examples to show the correct `--grouped` flag usage.
  * Raised default portrait resolution in topic brief examples from 720×1280 to 1080×1920.
  * Added a YouTube Shorts planning guideline: 3–5 short beats with brief narration, total ≤60 seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->