### PR TITLE
chore: upgrade TypeScript to 6.0.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "globals": "^17.3.0",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "6.0.0-beta",
     "typescript-eslint": "^8.56.1"
   },
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     // },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["archiver", "fluent-ffmpeg", "jsdom", "yargs"],  /* Explicit for TS 6.0 compatibility (new default: []) */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -3901,7 +3901,12 @@ typescript-eslint@^8.56.1:
     "@typescript-eslint/typescript-estree" "8.56.1"
     "@typescript-eslint/utils" "8.56.1"
 
-typescript@>=5, typescript@^5.9.3:
+typescript@6.0.0-beta:
+  version "6.0.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.0-beta.tgz#2f87bd0cd1a291f675b3414a02a00bd4f7b48357"
+  integrity sha512-CldZdztDpQRLM1HC6WDQjQkQN5Ub5zRau737a1diGh3lPmb9oRsaWHk1y5iqK0o7+1bNJ0oXfEGRkAogFZBL+Q==
+
+typescript@>=5:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## Summary
- Upgrade TypeScript from 5.x to 6.0.0-beta
- Explicitly set `types` in tsconfig.json to `["archiver", "fluent-ffmpeg", "jsdom", "yargs"]`
  - TS 6.0 changes the default of `types` from all `@types/*` to `[]`
- `typescript-eslint` shows peer dependency warnings (`<6.0.0`) but works correctly

## User Prompt
- TypeScript 6.0のデフォルト値変更に備えて tsconfig.json で設定を明示
- 6.0.0-beta 入れてみよう

## Test plan
- [x] `yarn build` passes (0 errors)
- [x] `yarn lint` passes (0 errors, warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TypeScript dependency to version 6.0.0-beta
  * Updated TypeScript compiler configuration for 6.0 compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->