### PR TITLE
refactor: improve readability of html_tailwind animation code

### DIFF
--- a/src/methods/mulmo_beat.ts
+++ b/src/methods/mulmo_beat.ts
@@ -2,9 +2,16 @@ import { MulmoBeat } from "../types/index.js";
 
 import { findImagePlugin } from "../utils/image_plugins/index.js";
 
+type AnimationConfig = { fps?: number };
+
+/** Type guard: checks if animation value is an object config like { fps: 30 } */
+const isAnimationObject = (animation: unknown): animation is AnimationConfig => {
+  return typeof animation === "object" && animation !== null && !Array.isArray(animation);
+};
+
 /** Check if a value is a valid animation config (true or non-array object) */
-const isAnimationEnabled = (animation: unknown): boolean => {
-  return animation === true || (typeof animation === "object" && animation !== null && !Array.isArray(animation));
+const isAnimationEnabled = (animation: unknown): animation is true | AnimationConfig => {
+  return animation === true || isAnimationObject(animation);
 };
 
 /** Check if a beat has html_tailwind animation enabled */
@@ -16,6 +23,7 @@ const isAnimatedHtmlTailwind = (beat: MulmoBeat): boolean => {
 
 export const MulmoBeatMethods = {
   isAnimationEnabled,
+  isAnimationObject,
   isAnimatedHtmlTailwind,
   getHtmlPrompt(beat: MulmoBeat) {
     if (beat?.htmlPrompt?.data) {

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -94,8 +94,8 @@ export const framesToVideo = (framesDir: string, outputPath: string, fps: number
   return new Promise((resolve, reject) => {
     ffmpeg()
       .input(`${framesDir}/frame_%05d.png`)
-      .inputOptions([`-framerate ${fps}`])
-      .outputOptions([`-c:v libx264`, `-pix_fmt yuv420p`, `-r ${fps}`, `-vf`, `scale=${safe.width}:${safe.height}`])
+      .inputOptions(["-framerate", String(fps)])
+      .outputOptions(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-r", String(fps), "-vf", `scale=${safe.width}:${safe.height}`])
       .output(outputPath)
       .on("end", () => resolve())
       .on("error", (err: Error) => reject(err))

--- a/src/utils/image_plugins/html_tailwind.ts
+++ b/src/utils/image_plugins/html_tailwind.ts
@@ -8,13 +8,20 @@ import { parrotingImagePath } from "./utils.js";
 
 export const imageType = "html_tailwind";
 
+const DEFAULT_ANIMATION_FPS = 30;
+
+/** Join html field into a single string (handles both string and string[]) */
+const joinHtml = (html: string | string[]): string => {
+  return Array.isArray(html) ? html.join("\n") : html;
+};
+
 const getAnimationConfig = (params: ImageProcessorParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return null;
   const animation = (beat.image as { animation?: unknown }).animation;
   if (!MulmoBeatMethods.isAnimationEnabled(animation)) return null;
-  if (animation === true) return { fps: 30 };
-  return { fps: (animation as { fps?: number }).fps ?? 30 };
+  if (MulmoBeatMethods.isAnimationObject(animation)) return { fps: animation.fps ?? DEFAULT_ANIMATION_FPS };
+  return { fps: DEFAULT_ANIMATION_FPS };
 };
 
 const processHtmlTailwindAnimated = async (params: ImageProcessorParams) => {
@@ -35,7 +42,7 @@ const processHtmlTailwindAnimated = async (params: ImageProcessorParams) => {
     throw new Error(`html_tailwind animation: totalFrames is ${totalFrames} (duration=${duration}, fps=${fps}). Increase duration or fps.`);
   }
 
-  const html = Array.isArray(beat.image.html) ? beat.image.html.join("\n") : beat.image.html;
+  const html = joinHtml(beat.image.html);
   const template = getHTMLFile("tailwind_animated");
   const htmlData = interpolate(template, {
     html_body: html,
@@ -65,7 +72,7 @@ const processHtmlTailwindStatic = async (params: ImageProcessorParams) => {
   const { beat, imagePath, canvasSize } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
-  const html = Array.isArray(beat.image.html) ? beat.image.html.join("\n") : beat.image.html;
+  const html = joinHtml(beat.image.html);
   const template = getHTMLFile("tailwind");
   const htmlData = interpolate(template, {
     html_body: html,
@@ -85,7 +92,7 @@ const processHtmlTailwind = async (params: ImageProcessorParams) => {
 const dumpHtml = async (params: ImageProcessorParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
-  return Array.isArray(beat.image.html) ? beat.image.html.join("\n") : beat.image.html;
+  return joinHtml(beat.image.html);
 };
 
 export const process = processHtmlTailwind;


### PR DESCRIPTION
## Summary

PR #1222 で追加された html_tailwind フレームベースアニメーション機能のコード可読性を改善。

- `scaleContentToFit` 共通関数を抽出し viewport スケーリングの重複を解消
- 省略された変数名 (`f`, `total`, `fpsVal`, `w`) を `frameIndex`, `totalFrameCount`, `framesPerSecond`, `mulmoWindow` にリネーム
- `isAnimationObject` 型ガードを追加し unsafe な型キャストを除去
- `joinHtml` ヘルパー関数を抽出し HTML 結合の3箇所の重複を解消
- `DEFAULT_ANIMATION_FPS` 名前付き定数を導入しマジックナンバーを除去
- FFmpeg `outputOptions` を1フラグ1要素に分割し可読性を向上

Closes #1237

## Changed Files

| File | Change |
|------|--------|
| `src/methods/mulmo_beat.ts` | `AnimationConfig` 型、`isAnimationObject` 型ガード追加、`isAnimationEnabled` を型述語に変更 |
| `src/utils/html_render.ts` | `scaleContentToFit` 抽出、evaluate 内変数名リネーム |
| `src/utils/image_plugins/html_tailwind.ts` | `joinHtml` 抽出、`DEFAULT_ANIMATION_FPS` 定数、型ガード利用 |
| `src/utils/ffmpeg_utils.ts` | `framesToVideo` の inputOptions/outputOptions を1フラグ1要素に分割 |

## Test plan

- [x] `yarn format` — 全ファイル unchanged
- [x] `yarn lint` — エラー0 (既存の warning のみ)
- [x] `yarn build` — 成功
- [x] `yarn ci_test` — 939 tests, 935 pass, 0 fail

## User Prompt

- PR #1222 (html_tailwind animation) のコード可読性改善を実施。重複コードの共通関数抽出、省略変数名のリネーム、型キャストの型ガード化、マジックナンバーの定数化、FFmpeg オプションの整理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined animation configuration handling with enhanced type validation
  * Improved HTML content rendering and automatic viewport scaling
  * Optimized FFmpeg video encoding option formatting for better compatibility
  * Consolidated HTML input processing across rendering pipelines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->