### PR TITLE
fix: extract last frame for animated html_tailwind PDF output

### DIFF
--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -53,6 +53,7 @@ type ImageHtmlPreprocessAgentResponse = {
 };
 type ImageOnlyMoviePreprocessAgentResponse = ImagePreprocessAgentResponseBase & {
   imageFromMovie: boolean;
+  useLastFrame?: boolean;
 };
 
 type ImagePluginPreprocessAgentResponse = ImagePreprocessAgentResponseBase & {
@@ -155,6 +156,7 @@ export const imagePreprocessAgent = async (namedInputs: {
         imagePath, // for thumbnail extraction
         movieFile: animatedVideoPath, // .mp4 path for the pipeline
         imageFromMovie: true, // triggers extractImageFromMovie
+        useLastFrame: true, // extract last frame for PDF/static (animation complete state)
         referenceImageForMovie: pluginPath,
         markdown,
         html,

--- a/src/actions/images.ts
+++ b/src/actions/images.ts
@@ -207,13 +207,14 @@ export const beat_graph_data = {
     },
     imageFromMovie: {
       if: ":preprocessor.imageFromMovie",
-      agent: async (namedInputs: { movieFile: string; imageFile: string }) => {
-        return await extractImageFromMovie(namedInputs.movieFile, namedInputs.imageFile);
+      agent: async (namedInputs: { movieFile: string; imageFile: string; useLastFrame: boolean }) => {
+        return await extractImageFromMovie(namedInputs.movieFile, namedInputs.imageFile, namedInputs.useLastFrame);
       },
       inputs: {
         onComplete: [":movieGenerator", ":imagePlugin"], // :imagePlugin for animated html_tailwind video generation
         imageFile: ":preprocessor.imagePath",
         movieFile: ":preprocessor.movieFile",
+        useLastFrame: ":preprocessor.useLastFrame",
       },
       defaultValue: {},
     },

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -131,9 +131,13 @@ export const ffmpegGetMediaDuration = (filePath: string) => {
   });
 };
 
-export const extractImageFromMovie = (movieFile: string, imagePath: string): Promise<object> => {
+export const extractImageFromMovie = (movieFile: string, imagePath: string, useLastFrame = false): Promise<object> => {
   return new Promise<object>((resolve, reject) => {
-    ffmpeg(movieFile)
+    const command = ffmpeg(movieFile);
+    if (useLastFrame) {
+      command.inputOptions(["-sseof", "-0.1"]);
+    }
+    command
       .outputOptions(["-frames:v 1"])
       .output(imagePath)
       .on("end", () => resolve({}))


### PR DESCRIPTION
## Summary

- Animated `html_tailwind` beats produced blank pages in PDF output because `extractImageFromMovie` extracted frame 0 (initial state with all elements at opacity: 0)
- Added `useLastFrame` option using ffmpeg's `-sseof -0.1` to extract the last frame (animation complete state)
- Only enabled for animated `html_tailwind` beats; other movie types keep first-frame behavior

Closes #1246

## User Prompt

- animatedってpdfも正しく作られる？ → 全ページ空白だった → 直して

## Test plan

- [x] `yarn format && yarn lint && yarn build` passes
- [x] `yarn pdf scripts/samples/mulmocast_intro_animated.json -f` generates PDF with all 20 pages correctly rendered (253KB → 1.4MB)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to extract the last frame from animated movies and HTML animations when generating preview images. Animated HTML content will automatically use the last frame extraction for improved preview generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->