### PR TITLE
Replace gemini-3-pro-preview with gemini-3.1-pro-preview

### DIFF
--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -298,7 +298,7 @@ export const provider2LLMAgent = {
     agentName: "geminiAgent",
     defaultModel: "gemini-2.5-flash",
     max_tokens: 8192,
-    models: ["gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
+    models: ["gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"],
     keyName: "GEMINI_API_KEY",
   },
   groq: {


### PR DESCRIPTION
## 概要

`gemini-3-pro-preview` が非推奨になったため、`gemini-3.1-pro-preview` に置換。

- `src/types/provider2agent.ts` - Gemini プロバイダーのモデルリスト

## 参考

- https://ai.google.dev/gemini-api/docs/deprecations
<img width="1092" height="344" alt="image" src="https://github.com/user-attachments/assets/866c71bc-6d80-426a-b643-3c7d723b1355" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Google Gemini model availability: Gemini 3 Pro Preview version updated to Gemini 3.1 Pro Preview, with all other available models remaining unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->