### PR TITLE
docs: do not set duration on animated beats

### DIFF
--- a/.claude/skills/story/SKILL.md
+++ b/.claude/skills/story/SKILL.md
@@ -230,7 +230,6 @@ For beats that benefit from motion — cinematic intros, opening crawls, data vi
 
 ```json
 {
-  "duration": 3,
   "image": {
     "type": "html_tailwind",
     "html": ["<div id='el' style='opacity:0'>...</div>"],
@@ -247,7 +246,7 @@ Key rules:
 - `html`: HTML markup with Tailwind CSS (no `<script>` tags). Set initial styles inline (e.g., `style='opacity:0'`)
 - `script`: JavaScript code (no `<script>` tags). Use `MulmoAnimation` DSL or raw `render()` + `interpolate()`
 - `animation`: `true` (30fps) or `{ "fps": 15 }` for custom fps
-- `duration`: Required for animated beats (may be auto-calculated from audio)
+- **Do NOT set `duration`** — it is auto-calculated from the audio length. Setting it explicitly causes audio/video desync. Only set `duration` for silent beats or fixed-length intros.
 - Name the MulmoAnimation instance `animation` to enable auto-render (no manual `render()` needed)
 - Use `end: 'auto'` for animations that span the entire beat duration
 

--- a/docs/html_animation.md
+++ b/docs/html_animation.md
@@ -8,7 +8,6 @@ Puppeteer で1フレームずつスクリーンショットを撮影し、FFmpeg
 
 ```json
 {
-  "duration": 3,
   "image": {
     "type": "html_tailwind",
     "html": ["<div id='title'>Hello</div>"],
@@ -25,7 +24,7 @@ Puppeteer で1フレームずつスクリーンショットを撮影し、FFmpeg
 | `html` | `string \| string[]` | HTML マークアップ（`<script>` を含めない） |
 | `script` | `string \| string[]` | JavaScript コード（`<script>` タグ不要、テンプレートが自動で `<script>` ラップ） |
 | `animation` | `true \| { fps: number }` | アニメーション有効化。省略時は静止画 |
-| `duration` | `number` | ビートの長さ（秒）。アニメーション時は**必須** |
+| `duration` | `number` | ビートの長さ（秒）。**原則不要**（音声から自動算出）。無音ビートや固定長が必要な場合のみ指定 |
 
 ### FPS 設定
 
@@ -246,6 +245,6 @@ function render(frame, totalFrames, fps) {
 ## 制約
 
 - `animation` と `moviePrompt` の併用不可（同一ビートで両方指定するとエラー）
-- `duration` は `animation` 使用時に**必須**（音声生成と画像生成が並列のため、事前にフレーム数を確定する必要がある）。ただし音声から自動計算される場合は省略可
+- `duration` は**原則不要**（音声の長さから自動算出される）。明示的に設定すると音声と映像がずれる原因になるため、無音ビートや固定長が必要な場合のみ指定すること
 - `end: 'auto'` を指定すると、ビート全体の長さ（`totalFrames / fps`）が `end` として使用される。ビート全体にわたるアニメーション（スクロールなど）に便利
 - CSS animation / transition はテンプレートで無効化済み（`animation-play-state: paused`, `transition: none`）

--- a/docs/llm/html_animation_reference.md
+++ b/docs/llm/html_animation_reference.md
@@ -7,7 +7,6 @@ The runtime template injects helper functions (`interpolate`, `Easing`, `MulmoAn
 
 ```json
 {
-  "duration": 3,
   "image": {
     "type": "html_tailwind",
     "html": ["<div id='el'>...</div>"],
@@ -20,7 +19,7 @@ The runtime template injects helper functions (`interpolate`, `Easing`, `MulmoAn
 - `html`: HTML markup only (no `<script>` tags)
 - `script`: JavaScript code (no `<script>` tags — automatically wrapped)
 - `animation`: `true` (30fps) or `{ "fps": 15 }` for custom fps
-- `duration`: Required (seconds). totalFrames = floor(duration * fps)
+- `duration`: **Do NOT set** — automatically calculated from audio length. Only set explicitly for silent beats or when you need a fixed duration.
 
 ## Available Runtime APIs
 
@@ -169,7 +168,7 @@ No `render()` needed — auto-render detects the `animation` variable and genera
 ## Constraints
 
 - `animation` and `moviePrompt` cannot be used together on the same beat
-- `duration` is required when `animation` is set (may be auto-calculated from audio)
+- Do NOT set `duration` on animated beats — it is auto-calculated from the audio. Setting it explicitly can cause audio/video desync. Only set `duration` for silent beats or fixed-length intros.
 - `end: 'auto'` uses the beat's total duration (`totalFrames / fps`) as the end time — useful for full-beat animations like scrolling crawls
 - CSS animations/transitions are disabled in the template (deterministic frame rendering)
 - All elements that will be animated should have initial styles set inline (e.g., `style='opacity:0'`)


### PR DESCRIPTION
## Summary

- Updated animation docs and story skill to recommend **not setting `duration`** on animated beats
- Duration is auto-calculated from audio length; setting it explicitly causes audio/video desync
- Only set `duration` for silent beats or fixed-length intros

## User Prompt

> textと動画のdurationがおかしい。音声が終わらない段階で映像が切り替わる。durationを入れないように指定できる？

## Files changed

- `docs/llm/html_animation_reference.md`
- `docs/html_animation.md`
- `.claude/skills/story/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated duration field guidance for animated beats: duration is now auto-calculated from audio length rather than manually required. Users should only specify duration for silent beats or fixed-length scenarios to prevent audio/video desynchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->