### PR TITLE
feat: add bottomOffset option to captionParams

### DIFF
--- a/assets/html/caption.html
+++ b/assets/html/caption.html
@@ -21,7 +21,7 @@
       /* Text positioned at the bottom */
       width: 80%;
       position: absolute;
-      bottom: 0px;
+      bottom: ${bottomOffset}%;
       /* Enable text wrapping */
       word-wrap: break-word;
       overflow-wrap: break-word;

--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -112,6 +112,7 @@ const generateBeatCaptions = async (beat: MulmoBeat, context: MulmoStudioContext
         width: `${canvasSize.width}`,
         height: `${canvasSize.height}`,
         styles: (mergedCaptionParams.styles ?? []).join(";\n"),
+        bottomOffset: `${mergedCaptionParams.bottomOffset ?? 0}`,
       });
       await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height, false, true);
       return {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -207,6 +207,7 @@ export const mulmoCaptionParamsSchema = z
     styles: z.array(z.string()).optional(), // css styles
     captionSplit: captionSplitSchema.optional(), // how to determine caption timing
     textSplit: textSplitSchema.optional(), // how to split text into segments (default: none)
+    bottomOffset: z.number().min(0).max(100).optional(), // bottom offset in percentage (e.g., 20 = 20% from bottom)
   })
   .strict();
 


### PR DESCRIPTION
## Summary

- Add `bottomOffset` (0-100%) parameter to `captionParams` schema
- Captions can now be positioned higher to avoid overlapping with YouTube/video player controls
- Default is `0` (bottom edge, same as before)

## Usage

```json
{
  "captionParams": {
    "bottomOffset": 20
  }
}
```

## User Prompt

- キャプションが下にくっついて表示されるが、YouTubeなどでは下部分がメニューに被るので、offsetをパーセンテージで指定できるようにしたい

## Test plan

- [x] `yarn build` passes
- [x] Generated movie with `bottomOffset: 20` — caption positioned ~20% from bottom
- [x] Default (no `bottomOffset`) keeps caption at bottom as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Captions now support customizable vertical positioning through a new `bottomOffset` parameter (0-100% range), enabling flexible placement control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->