### PR TITLE
fix: strip HTML tags from caption timing calculation

### DIFF
--- a/src/actions/captions.ts
+++ b/src/actions/captions.ts
@@ -59,10 +59,13 @@ const getSplitTexts = (
   return [text];
 };
 
-// Strip HTML tags to get plain text length
+// HTML tags commonly used in caption texts
+const CAPTION_HTML_TAGS = "span|br|b|i|em|strong|u|s|div|p|a|sub|sup|mark";
+const captionTagRegex = new RegExp(`</?(?:${CAPTION_HTML_TAGS})(?:\\s[^>]*)?\\/?>`, "gi");
+
+// Strip known HTML tags to get plain text length (for timing calculation, not sanitization)
 export const stripHtmlTags = (text: string): string => {
-  // eslint-disable-next-line sonarjs/slow-regex -- [^>]* with no nested quantifiers; not vulnerable to backtracking
-  return text.replace(/<[^>]*>/g, "");
+  return text.replace(captionTagRegex, "");
 };
 
 // Calculate timing ratios based on text length (HTML tags excluded)

--- a/test/actions/test_caption_html_strip.ts
+++ b/test/actions/test_caption_html_strip.ts
@@ -39,6 +39,21 @@ test("stripHtmlTags: handles tags with complex attributes", () => {
   assert.strictEqual(result, "テスト重要です");
 });
 
+test("stripHtmlTags: preserves literal angle brackets in math expressions", () => {
+  const result = stripHtmlTags("2 < 3 > 1");
+  assert.strictEqual(result, "2 < 3 > 1");
+});
+
+test("stripHtmlTags: preserves comparison operators", () => {
+  const result = stripHtmlTags("x<10 and y>5");
+  assert.strictEqual(result, "x<10 and y>5");
+});
+
+test("stripHtmlTags: preserves generic syntax", () => {
+  const result = stripHtmlTags("vector<int> data");
+  assert.strictEqual(result, "vector<int> data");
+});
+
 // --- calculateTimingRatios ---
 
 test("calculateTimingRatios: plain text calculates by length", () => {


### PR DESCRIPTION
## Summary

- Strip HTML tags before calculating caption split timing ratios
- Prevents `<span style='color:#EF4444'>` etc. from inflating text length and skewing caption display timing
- Added `stripHtmlTags` utility function and 13 unit tests

## Problem

When `texts` contains HTML styled spans (e.g., `<span style='color:#EF4444'>AI頭脳が一斉離脱</span>`), the caption timing calculation used the raw string length including HTML tags. This caused shorter text segments with long style attributes to get disproportionately more display time.

## User Prompt

- textsにHTMLを入れるケースがあり、HTMLタグも文字長に数えられてしまう。HTMLタグはfilterして数えてほしい

## Test plan

- [x] `yarn build` passes
- [x] `yarn lint` passes (0 errors)
- [x] 13 unit tests pass (7 for `stripHtmlTags`, 6 for `calculateTimingRatios`)
- [x] Generated movie from qwen-exodus script with HTML-styled texts — caption timing correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved caption timing calculations to accurately handle HTML-formatted captions by properly accounting for markup in duration computations.

* **Tests**
  * Added comprehensive test coverage for caption handling utilities, including HTML tag stripping in various formats, plain text processing, and timing ratio calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->