### PR TITLE
fix: remediate axios DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,9 @@
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "resolutions": {
+    "axios": ">=1.13.5"
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,13 +973,13 @@ asynckit@^0.4.0:
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.7.7:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
-  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+axios@>=1.13.5, axios@^1.7.7:
+  version "1.13.6"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz"
+  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.0"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
     proxy-from-env "^1.1.0"
 
 b4a@^1.6.4:


### PR DESCRIPTION
Bumps axios to >=1.13.5 to fix CVE-2026-25639 (DoS via __proto__ key in mergeConfig, CVSS 7.5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced use of a newer axios release (1.13.5 or later) across installs to ensure security and stability fixes are applied.
  * Standardized the project package manager to a specific Yarn release to improve reproducible installs and developer consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->