### PR TITLE
WIP: fix lipSync beat transition freeze

### DIFF
--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -35,6 +35,7 @@ export const getVideoPart = (
   speed: number,
   filters?: MulmoVideoFilter[],
   frameCount?: number,
+  isLipSync?: boolean,
 ) => {
   const videoId = `v${inputIndex}`;
 
@@ -43,9 +44,14 @@ export const getVideoPart = (
   // Handle different media types
   const originalDuration = duration * speed;
   if (isMovie) {
-    // For videos, extend with last frame if shorter than required duration
-    // tpad will extend the video by cloning the last frame, then trim will ensure exact duration
-    videoFilters.push(`tpad=stop_mode=clone:stop_duration=${originalDuration * 2}`); // Use 2x duration to ensure coverage
+    if (!isLipSync) {
+      // For regular videos, extend with last frame if shorter than required duration.
+      // tpad will extend the video by cloning the last frame, then trim will ensure exact duration.
+      // NOTE: We skip tpad for lipSync videos because the lipSync agent already adjusts
+      // the output duration to match the audio. Applying tpad would clone the last frame
+      // and create visible freezes at beat transitions.
+      videoFilters.push(`tpad=stop_mode=clone:stop_duration=${originalDuration * 2}`); // Use 2x duration to ensure coverage
+    }
   } else {
     videoFilters.push("loop=loop=-1:size=1:start=0");
   }
@@ -518,7 +524,8 @@ export const createVideo = async (audioArtifactFilePath: string, outputVideoPath
     );
     const speed = beat.movieParams?.speed ?? 1.0;
     const filters = beat.movieParams?.filters;
-    const { videoId, videoPart } = getVideoPart(inputIndex, isMovie, duration, canvasInfo, getFillOption(context, beat), speed, filters, frameCount);
+    const isLipSync = !!studioBeat.lipSyncFile;
+    const { videoId, videoPart } = getVideoPart(inputIndex, isMovie, duration, canvasInfo, getFillOption(context, beat), speed, filters, frameCount, isLipSync);
     ffmpegContext.filterComplex.push(videoPart);
 
     // for transition

--- a/src/agents/lipsync_replicate_agent.ts
+++ b/src/agents/lipsync_replicate_agent.ts
@@ -3,7 +3,7 @@ import { GraphAILogger } from "graphai";
 import type { AgentFunction, AgentFunctionInfo } from "graphai";
 import Replicate from "replicate";
 import { provider2LipSyncAgent } from "../types/provider2agent.js";
-import { ffmpegGetMediaDuration, trimVideoToBuffer } from "../utils/ffmpeg_utils.js";
+import { ffmpegGetMediaDuration, getBufferDuration, adjustVideoDuration } from "../utils/ffmpeg_utils.js";
 import {
   apiKeyMissingError,
   agentGenerationError,
@@ -102,13 +102,16 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
       const arrayBuffer = await videoResponse.arrayBuffer();
       const videoBuffer = Buffer.from(arrayBuffer);
 
-      // Trim the lipSync output to match the audio duration to prevent
-      // frozen frames at the end of each beat (the lipSync model often
-      // outputs slightly longer video than the input audio).
+      // Adjust the lipSync output duration to exactly match the audio duration.
+      // The lipSync model (latentsync) outputs at 25fps and truncates to whole
+      // frames, so the output is typically 0.1-0.3s shorter than the audio.
+      // Without this fix, movie.js pads the gap with tpad=stop_mode=clone,
+      // causing visible frozen frames at beat transitions.
       const { duration: audioDuration } = await ffmpegGetMediaDuration(audioFile);
-      if (audioDuration > 0) {
-        GraphAILogger.info(`lipSync: trimming video to audio duration ${audioDuration}s`);
-        return { buffer: await trimVideoToBuffer(videoBuffer, audioDuration) };
+      const videoDuration = await getBufferDuration(videoBuffer);
+      if (audioDuration > 0 && Math.abs(videoDuration - audioDuration) > 0.01) {
+        GraphAILogger.info(`lipSync: adjusting video from ${videoDuration}s to ${audioDuration}s (speed: ${(videoDuration / audioDuration).toFixed(4)}x)`);
+        return { buffer: await adjustVideoDuration(videoBuffer, audioDuration) };
       }
 
       return { buffer: videoBuffer };

--- a/src/utils/ffmpeg_utils.ts
+++ b/src/utils/ffmpeg_utils.ts
@@ -183,36 +183,64 @@ export const trimMusic = (inputFile: string, startTime: number, duration: number
   });
 };
 
-export const trimVideoToBuffer = (inputBuffer: Buffer, duration: number): Promise<Buffer> => {
-  return new Promise<Buffer>((resolve, reject) => {
-    if (duration <= 0) {
-      reject(new Error(`Invalid duration: duration (${duration}) must be greater than 0`));
-      return;
-    }
+export const getBufferDuration = async (buffer: Buffer): Promise<number> => {
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const tmpFile = path.default.join(os.default.tmpdir(), `probe_${Date.now()}.mp4`);
+  fs.writeFileSync(tmpFile, buffer);
+  try {
+    const { duration } = await ffmpegGetMediaDuration(tmpFile);
+    return duration;
+  } finally {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  }
+};
 
-    const chunks: Buffer[] = [];
-    const inputStream = new Readable();
-    inputStream.push(inputBuffer);
-    inputStream.push(null);
+export const adjustVideoDuration = async (inputBuffer: Buffer, targetDuration: number): Promise<Buffer> => {
+  if (targetDuration <= 0) {
+    throw new Error(`Invalid duration: targetDuration (${targetDuration}) must be greater than 0`);
+  }
 
-    ffmpeg(inputStream)
-      .duration(duration)
-      .outputOptions(["-c:v", "libx264", "-c:a", "aac", "-movflags", "frag_keyframe+empty_moov"])
-      .format("mp4")
-      .on("error", (err) => {
-        GraphAILogger.error("Error occurred while trimming video:", err);
-        reject(err);
-      })
-      .on("end", () => {
-        const buffer = Buffer.concat(chunks);
-        GraphAILogger.log(`Video trimmed to ${duration}s, buffer size: ${buffer.length} bytes`);
-        resolve(buffer);
-      })
-      .pipe()
-      .on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-      });
-  });
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const tmpDir = os.default.tmpdir();
+  const tmpInput = path.default.join(tmpDir, `lipsync_adjust_in_${Date.now()}.mp4`);
+  const tmpOutput = path.default.join(tmpDir, `lipsync_adjust_out_${Date.now()}.mp4`);
+
+  fs.writeFileSync(tmpInput, inputBuffer);
+
+  try {
+    const { duration: inputDuration } = await ffmpegGetMediaDuration(tmpInput);
+    // The lipSync model tends to freeze in the last ~0.2s of output.
+    // Strategy: trim the frozen tail, then stretch the remaining (moving)
+    // frames to fill the target duration via setpts.
+    const trimTail = 0.2;
+    const usableDuration = Math.max(inputDuration - trimTail, inputDuration * 0.9);
+    const stretchFactor = targetDuration / usableDuration;
+
+    await new Promise<void>((resolve, reject) => {
+      ffmpeg(tmpInput)
+        .inputOptions(["-t", String(usableDuration)])
+        .videoFilters(`setpts=${stretchFactor}*PTS`)
+        .outputOptions(["-c:v", "libx264", "-preset", "ultrafast", "-c:a", "aac"])
+        .output(tmpOutput)
+        .on("error", (err) => {
+          GraphAILogger.error("Error occurred while adjusting video duration:", err);
+          reject(err);
+        })
+        .on("end", () => {
+          GraphAILogger.log(`Video adjusted to ${targetDuration}s (was ${inputDuration}s, trimmed tail ${trimTail}s, stretch ${stretchFactor.toFixed(4)})`);
+          resolve();
+        })
+        .run();
+    });
+
+    const resultBuffer = fs.readFileSync(tmpOutput);
+    return resultBuffer;
+  } finally {
+    if (fs.existsSync(tmpInput)) fs.unlinkSync(tmpInput);
+    if (fs.existsSync(tmpOutput)) fs.unlinkSync(tmpOutput);
+  }
 };
 
 export const createSilentAudio = (filePath: string, durationSec: number): Promise<void> => {


### PR DESCRIPTION
## Summary

Fixes #1274 — lipSync beats show frozen last frame at transitions.

**⚠️ WIP — not ready to merge**

- ✅ Skip `tpad=stop_mode=clone` for lipSync beats → eliminates frozen frame at beat boundaries
- ❌ `adjustVideoDuration` (setpts stretch) breaks lip sync — needs different approach
- ❌ Still frame at end of video not fully resolved

## Changes

- **`src/actions/movie.ts`** — `getVideoPart()` accepts `isLipSync` param, skips tpad for lipSync beats
- **`src/utils/ffmpeg_utils.ts`** — Added `getBufferDuration()` and `adjustVideoDuration()` utilities
- **`src/agents/lipsync_replicate_agent.ts`** — Calls `adjustVideoDuration()` after lipSync generation

## Next steps

1. Remove or rethink `adjustVideoDuration` — setpts stretching desynchronizes lip movements from audio
2. Investigate end-of-video still frame (may be duration calculation issue in movie.ts)
3. Consider crossfade or accept 0.1-0.3s gap per beat

## Test plan

- [ ] Build sample-lipsync2 (4-beat lipSync script) and verify beat transitions
- [ ] Verify lip sync stays in sync with audio
- [ ] Verify no still frame at end of video

🤖 Generated with [Claude Code](https://claude.com/claude-code)