### PR TITLE
feat: support image:refs in markdown plugin

### DIFF
--- a/plans/feat-markdown-image-refs.md
+++ b/plans/feat-markdown-image-refs.md
@@ -1,0 +1,66 @@
+# feat: imageRefs support for markdown plugin
+
+## Background
+
+`imageParams.images` で定義した参照画像は現在以下のプラグインで利用可能:
+
+| Plugin | Support | 方式 |
+|--------|---------|------|
+| html_tailwind | ✅ | `src="image:name"` → `resolveImageRefs()` で `file://` URL に変換 |
+| slide | ✅ | `{ "type": "imageRef", "ref": "name" }` ブロック → `resolveSlideImageRefs()` で data URL に変換 |
+| markdown | ❌ | 未対応 |
+
+## Goal
+
+markdown プラグインで `image:name` 参照を使えるようにする。
+
+## Approach
+
+markdown は最終的に HTML に変換して Puppeteer でレンダリングする。
+html_tailwind と同じ `resolveImageRefs()` パターンを適用できる。
+
+### 対応パターン
+
+1. **Markdown 画像構文**: `![alt](image:bg_office)` → `![alt](file:///path/to/bg_office.png)`
+2. **HTML img タグ**: markdown 内の `<img src="image:bg_office">` → html_tailwind と同じ
+
+### 実装手順
+
+1. **`resolveImageRefs` を共有ユーティリティに移動**
+   - 現在 `html_tailwind.ts` にある `resolveImageRefs()` を共通ユーティリティ化
+   - `resolveRelativeImagePaths()` も同様
+   - html_tailwind.ts からは re-export or import
+
+2. **Markdown 用の `image:` 参照解決を追加**
+   - markdown 画像構文 `![alt](image:name)` を解決する関数
+   - パターン: `!\[([^\]]*)\]\(image:([^)]+)\)` → `![alt](file:///resolved/path)`
+
+3. **markdown.ts の `generateHtml()` で imageRefs を解決**
+   - レンダリング前の HTML に `resolveImageRefs()` を適用
+   - markdown テキスト段階で `image:` を解決するか、HTML 変換後に解決するかの選択
+   - **HTML 変換後がベター**: markdown パーサーが `![](image:name)` を `<img src="image:name">` に変換するので、その後に `resolveImageRefs()` を適用すれば既存の関数がそのまま使える
+
+4. **テスト追加**
+   - `scripts/test/test_markdown_image_refs.json` — markdown で `image:` 参照を使うテストスクリプト
+   - ユニットテスト: `resolveImageRefs()` の共通化テスト
+
+5. **ドキュメント更新**
+   - `docs/image.md` — markdown での `image:` 参照の使い方
+
+## 実装の最小差分
+
+**Step 3 だけで動く可能性が高い**。markdown パーサー（`marked`）は `![](image:name)` を `<img src="image:name">` に変換する。つまり `generateHtml()` の出力に対して既存の `resolveImageRefs()` を呼ぶだけで OK。
+
+```typescript
+// markdown.ts の generateHtml() 内
+const rawHtml = /* 既存のHTML生成ロジック */;
+const resolvedHtml = resolveImageRefs(rawHtml, params.imageRefs ?? {});
+return resolvedHtml;
+```
+
+共通化（Step 1-2）は DRY のためだが、最小実装は import + 1行追加。
+
+## Non-goals
+
+- mermaid, chart, text_slide — これらは画像を埋め込む概念がないため対象外
+- markdown layout の schema 拡張 — `imageRef` ブロックタイプの追加は別 issue

--- a/scripts/test/test_markdown_image_refs.json
+++ b/scripts/test/test_markdown_image_refs.json
@@ -1,0 +1,59 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "lang": "en",
+  "canvasSize": { "width": 1920, "height": 1080 },
+  "title": "Markdown image:refs test",
+  "audioParams": {
+    "padding": 0,
+    "introPadding": 0,
+    "closingPadding": 0,
+    "outroPadding": 0
+  },
+  "imageParams": {
+    "images": {
+      "qaLandscape": {
+        "type": "image",
+        "source": {
+          "kind": "path",
+          "path": "images/qa_landscape.jpg"
+        }
+      },
+      "qaPortrait": {
+        "type": "image",
+        "source": {
+          "kind": "path",
+          "path": "images/qa_portrait.png"
+        }
+      }
+    }
+  },
+  "beats": [
+    {
+      "id": "markdown_text_image_ref",
+      "duration": 3,
+      "image": {
+        "type": "markdown",
+        "markdown": [
+          "# Markdown image:refs test",
+          "",
+          "![Landscape photo](image:qaLandscape)",
+          "",
+          "This image is resolved from `imageParams.images` via the `image:` scheme."
+        ]
+      }
+    },
+    {
+      "id": "markdown_layout_image_ref",
+      "duration": 3,
+      "image": {
+        "type": "markdown",
+        "markdown": {
+          "row-2": [
+            ["# Landscape", "![Landscape](image:qaLandscape)"],
+            ["# Portrait", "![Portrait](image:qaPortrait)"]
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/src/utils/image_plugins/markdown.ts
+++ b/src/utils/image_plugins/markdown.ts
@@ -5,6 +5,7 @@ import { parrotingImagePath } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
 import { type MulmoMarkdownLayout } from "../../types/type.js";
 import { generateLayoutHtml, layoutToMarkdown, toMarkdownString, parseMarkdown } from "./markdown_layout.js";
+import { resolveImageRefs } from "./html_tailwind.js";
 
 import { isObject } from "graphai";
 
@@ -75,7 +76,8 @@ const processMarkdown = async (params: ImageProcessorParams) => {
   const { beat, imagePath, canvasSize } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
-  const html = await generateHtml(params);
+  const rawHtml = await generateHtml(params);
+  const html = resolveImageRefs(rawHtml, params.imageRefs ?? {});
   const hasMermaid = containsMermaid(beat.image.markdown);
   await renderHTMLToImage(html, imagePath, canvasSize.width, canvasSize.height, hasMermaid);
 


### PR DESCRIPTION
## Summary
- Add `image:name` reference support to the markdown image plugin
- Markdown image syntax `![alt](image:name)` now resolves to `imageParams.images` definitions
- Reuses existing `resolveImageRefs()` from html_tailwind plugin

## User Prompt
- imageParams.images で作った画像を markdown でも使えるようにする

## Details

`marked` converts `![alt](image:name)` → `<img src="image:name">`, so applying the existing `resolveImageRefs()` to the generated HTML resolves all references.

Changes:
- `src/utils/image_plugins/markdown.ts`: Import `resolveImageRefs` from html_tailwind, apply to rendered HTML before Puppeteer screenshot
- `scripts/test/test_markdown_image_refs.json`: Test script with text and layout formats
- `plans/feat-markdown-image-refs.md`: Implementation plan

**Plugins supporting imageRefs after this PR:**

| Plugin | Support | Method |
|--------|---------|--------|
| html_tailwind | ✅ | `src="image:name"` in HTML |
| slide | ✅ | `imageRef` content block |
| markdown | ✅ **NEW** | `![alt](image:name)` in markdown |

## Test plan
- [x] `yarn build` passes
- [x] `yarn lint` passes (0 errors)
- [x] `yarn format` passes
- [ ] `mulmo images scripts/test/test_markdown_image_refs.json` renders images correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for image references in markdown. Users can now reference images using the `image:name` syntax within markdown content, which automatically resolves to the corresponding file path.

* **Tests**
  * Added test coverage for markdown image reference functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->