### PR TITLE
fix: prevent moviePrompt beats from being absorbed into spill over group

### DIFF
--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -63,10 +63,11 @@ const getMediaDurationsOfAllBeats = (context: MulmoStudioContext): Promise<Media
       const beat = context.studio.script.beats[index];
       const { duration: movieDuration, hasAudio: hasMovieAudio } = await getMovieDuration(context, beat);
       const audioDuration = studioBeat.audioFile ? (await ffmpegGetMediaDuration(studioBeat.audioFile)).duration : 0;
+      const hasMoviePrompt = Boolean(beat.moviePrompt);
       return {
         movieDuration,
         audioDuration,
-        hasMedia: movieDuration + audioDuration > 0,
+        hasMedia: movieDuration + audioDuration > 0 || hasMoviePrompt,
         silenceDuration: 0,
         hasMovieAudio,
       };


### PR DESCRIPTION
## Summary

- **Fix**: Beats with `moviePrompt` and empty `text` are no longer incorrectly absorbed into the previous beat's spill over group, which was causing the previous beat's video to be cut short

Closes #1295

## Root Cause

In `combineAudioFilesAgent`, `getMediaDurationsOfAllBeats` computed `hasMedia` based only on `movieDuration + audioDuration > 0`. For beats with `text: ""` + `moviePrompt`:
- `audioDuration = 0` (no TTS for empty text)
- `movieDuration = 0` (`getMovieDuration` only checks `beat.image?.type === "movie"`, not `moviePrompt`)
- → `hasMedia = false`

This caused `getSpillOverGroup` to absorb the beat into the previous beat's group, splitting the previous beat's audio across both beats and shortening the previous beat's duration.

## Fix

Add `moviePrompt` presence to the `hasMedia` check:

```typescript
const hasMoviePrompt = Boolean(beat.moviePrompt);
hasMedia: movieDuration + audioDuration > 0 || hasMoviePrompt,
```

## User Prompt

- scripts/aaa.jsonのmovieにすると、beat5の動画の映像が最後まで再生されなくて、次の動画が再生される。音声はbeat5が最後までながれ、beat6の映像にbeat5の音声が流れる。beat6のtextに言葉を入れると正しく動く。バグの原因を探して修正してほしい

## Test plan

- [ ] Build succeeds (`yarn build`)
- [ ] Lint passes (`yarn lint`)
- [ ] Test with script having Beat N (text + moviePrompt) followed by Beat N+1 (text: "" + moviePrompt) — verify Beat N's video plays to completion


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media detection when combining audio files. The system now more accurately recognizes all types of associated media content, resulting in more reliable audio file handling and combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->