### PR TITLE
fix: address CodeRabbit review comments for animated PDF

### DIFF
--- a/assets/html/js/auto_render.js
+++ b/assets/html/js/auto_render.js
@@ -32,7 +32,7 @@ if (typeof window.render === "function") {
  */
 window.renderFinal = function () {
   const mulmo = window.__MULMO;
-  const lastFrame = Math.max(0, mulmo.totalFrames - 1);
+  const lastFrame = Math.max(0, (mulmo.totalFrames || 0) - 1);
   mulmo.frame = lastFrame;
   if (typeof window.render === "function") {
     return window.render(lastFrame, mulmo.totalFrames, mulmo.fps);

--- a/src/utils/image_plugins/html_tailwind.ts
+++ b/src/utils/image_plugins/html_tailwind.ts
@@ -164,7 +164,8 @@ const processHtmlTailwindAnimated = async (params: ImageProcessorParams) => {
   const finalHtml = buildAnimatedHtml(params, FINAL_FRAME_TOTAL, fps);
   await renderHTMLToFinalFrame(finalHtml, finalFramePath, canvasSize.width, canvasSize.height);
 
-  return imagePath;
+  // Return video path when video was generated, otherwise return the static PNG path
+  return duration !== undefined ? imagePath : finalFramePath;
 };
 
 const processHtmlTailwindStatic = async (params: ImageProcessorParams) => {


### PR DESCRIPTION
## Summary

- Defensive fallback for `totalFrames` in `renderFinal` (`auto_render.js`) — prevents `NaN` if `totalFrames` is undefined
- Return `finalFramePath` (PNG) instead of `imagePath` (MP4) when video was not generated due to missing duration

Follow-up to #1300 — these fixes were missed in the merge.

## Test plan

- [ ] `yarn build` and `yarn lint` pass
- [ ] `yarn ci_test` passes
- [ ] PDF generation for animated beats without duration works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed animation rendering to gracefully handle missing frame metadata, preventing errors during output generation.
  * Improved animation export logic to correctly return video or frame-based output based on duration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->