### PR TITLE
feat: add Chart.js plugins (sankey, treemap) and waterfall slide layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,8 +396,9 @@ MulmoCast includes a powerful **Slide DSL** (`type: "slide"`) for creating struc
 
 ### Features
 
-- **11 Layouts**: title, columns, comparison, grid, bigQuote, stats, timeline, split, matrix, table, funnel
+- **12 Layouts**: title, columns, comparison, grid, bigQuote, stats, timeline, split, matrix, table, funnel, waterfall
 - **10 Content Block Types**: text, bullets, code, callout, metric, divider, image, imageRef, chart, mermaid
+- **Chart.js Plugins**: sankey (`chartjs-chart-sankey`) and treemap (`chartjs-chart-treemap`) auto-loaded by chart type
 - **13-Color Theme System**: Semantic color palette with dark/light support
 - **6 Preset Themes**: dark, pop, warm, creative, minimal, corporate
 

--- a/assets/html/chart.html
+++ b/assets/html/chart.html
@@ -6,13 +6,17 @@
     <title>Simple Chart.js Bar Chart</title>
     <style>
         ${style}
+        html, body { height: 100%; margin: 0; }
+        body { display: flex; flex-direction: column; align-items: center; justify-content: center; }
         .chart-container {
             width: ${chart_width}px;
-            margin: 0 auto;
+            height: 70vh;
+            position: relative;
         }
     </style>
     <!-- Include Chart.js from CDN -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    ${chart_plugins}
 </head>
 <body>
     <h1>${title}</h1>
@@ -20,24 +24,55 @@
         <canvas id="myChart" data-chart-ready="false"></canvas>
     </div>
 
-    <!-- Plain JavaScript instead of TypeScript -->
     <script>
-        // Wait for DOM and Chart.js to be ready, then render.
         function initChart() {
             if (!window.Chart) return false;
-            const ctx = document.getElementById('myChart');
+            var ctx = document.getElementById('myChart');
             if (!ctx) return false;
-            const chartData = ${chart_data};
+            var chartData = ${chart_data};
 
             // Disable animation for static image generation
             if (!chartData.options) chartData.options = {};
             chartData.options.animation = false;
+            chartData.options.responsive = true;
+            chartData.options.maintainAspectRatio = false;
 
-            // Initialize the chart
+            // Treemap: convert backgroundColor array to scriptable function
+            if (chartData.type === 'treemap') {
+                chartData.data.datasets.forEach(function(ds) {
+                    if (Array.isArray(ds.backgroundColor)) {
+                        var colors = ds.backgroundColor;
+                        ds.backgroundColor = function(ctx) {
+                            return colors[ctx.dataIndex % colors.length];
+                        };
+                    }
+                });
+            }
 
-            new Chart(ctx, chartData);
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
+            // Sankey: convert colorFrom/colorTo objects to lookup functions
+            if (chartData.type === 'sankey') {
+                chartData.data.datasets.forEach(function(ds) {
+                    if (ds.colorFrom && typeof ds.colorFrom === 'object') {
+                        var fromMap = ds.colorFrom;
+                        ds.colorFrom = function(c) { return fromMap[c.dataset.data[c.dataIndex].from] || '#999'; };
+                    }
+                    if (ds.colorTo && typeof ds.colorTo === 'object') {
+                        var toMap = ds.colorTo;
+                        ds.colorTo = function(c) { return toMap[c.dataset.data[c.dataIndex].to] || '#999'; };
+                    }
+                });
+            }
+
+            try {
+                var chart = new Chart(ctx, chartData);
+                chart.resize();
+                chart.update();
+            } catch (e) {
+                console.error('Chart init error:', e);
+            }
+
+            requestAnimationFrame(function() {
+                requestAnimationFrame(function() {
                     ctx.dataset.chartReady = "true";
                 });
             });

--- a/scripts/test/test_ir_visualizations.json
+++ b/scripts/test/test_ir_visualizations.json
@@ -1,0 +1,317 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "title": "IR Visualization Samples",
+  "description": "Sankey, Treemap, and Waterfall chart demos for financial presentations",
+  "lang": "en",
+  "canvasSize": { "width": 1280, "height": 720 },
+  "beats": [
+    {
+      "text": "Sankey: Consolidated Balance Sheet",
+      "image": {
+        "type": "chart",
+        "title": "",
+        "chartData": {
+          "type": "sankey",
+          "data": {
+            "datasets": [
+              {
+                "data": [
+                  { "from": "cash", "to": "current_a", "flow": 3000 },
+                  { "from": "receivable", "to": "current_a", "flow": 2000 },
+                  { "from": "inventory", "to": "current_a", "flow": 1500 },
+                  { "from": "other_ca", "to": "current_a", "flow": 500 },
+                  { "from": "ppe", "to": "fixed_a", "flow": 4500 },
+                  { "from": "intangible", "to": "fixed_a", "flow": 1000 },
+                  { "from": "investments", "to": "fixed_a", "flow": 2000 },
+                  { "from": "other_fa", "to": "fixed_a", "flow": 500 },
+                  { "from": "current_a", "to": "total_a", "flow": 7000 },
+                  { "from": "fixed_a", "to": "total_a", "flow": 8000 },
+                  { "from": "total_a", "to": "liabilities", "flow": 10000 },
+                  { "from": "total_a", "to": "equity", "flow": 5000 },
+                  { "from": "liabilities", "to": "payable", "flow": 2000 },
+                  { "from": "liabilities", "to": "short_debt", "flow": 1500 },
+                  { "from": "liabilities", "to": "other_cl", "flow": 1000 },
+                  { "from": "liabilities", "to": "long_debt", "flow": 4000 },
+                  { "from": "liabilities", "to": "other_fl", "flow": 1500 },
+                  { "from": "equity", "to": "retained", "flow": 4000 },
+                  { "from": "equity", "to": "other_cap", "flow": 700 },
+                  { "from": "equity", "to": "other_eq", "flow": 300 }
+                ],
+                "priority": {
+                  "cash": 4,
+                  "receivable": 5,
+                  "inventory": 6,
+                  "other_ca": 7,
+                  "ppe": 0,
+                  "intangible": 1,
+                  "investments": 2,
+                  "other_fa": 3,
+                  "current_a": 1,
+                  "fixed_a": 0,
+                  "total_a": 0,
+                  "liabilities": 0,
+                  "equity": 1,
+                  "payable": 2,
+                  "short_debt": 3,
+                  "other_cl": 4,
+                  "long_debt": 0,
+                  "other_fl": 1,
+                  "retained": 5,
+                  "other_cap": 6,
+                  "other_eq": 7
+                },
+                "column": {
+                  "cash": 0,
+                  "receivable": 0,
+                  "inventory": 0,
+                  "other_ca": 0,
+                  "ppe": 0,
+                  "intangible": 0,
+                  "investments": 0,
+                  "other_fa": 0,
+                  "current_a": 1,
+                  "fixed_a": 1,
+                  "total_a": 2,
+                  "liabilities": 3,
+                  "equity": 3,
+                  "payable": 4,
+                  "short_debt": 4,
+                  "other_cl": 4,
+                  "long_debt": 4,
+                  "other_fl": 4,
+                  "retained": 4,
+                  "other_cap": 4,
+                  "other_eq": 4
+                },
+                "labels": {
+                  "cash": "Cash\n$3,000M",
+                  "receivable": "Receivables\n$2,000M",
+                  "inventory": "Inventory\n$1,500M",
+                  "other_ca": "Other Current\n$500M",
+                  "ppe": "PP&E\n$4,500M",
+                  "intangible": "Intangibles\n$1,000M",
+                  "investments": "Investments\n$2,000M",
+                  "other_fa": "Other Fixed\n$500M",
+                  "current_a": "Current Assets\n$7,000M",
+                  "fixed_a": "Fixed Assets\n$8,000M",
+                  "total_a": "Total Assets\n$15,000M",
+                  "liabilities": "Liabilities\n$10,000M",
+                  "equity": "Equity\n$5,000M",
+                  "payable": "Payables\n$2,000M",
+                  "short_debt": "Short-term Debt\n$1,500M",
+                  "other_cl": "Other Current Liab.\n$1,000M",
+                  "long_debt": "Long-term Debt\n$4,000M",
+                  "other_fl": "Other Fixed Liab.\n$1,500M",
+                  "retained": "Retained Earnings\n$4,000M",
+                  "other_cap": "Other Capital\n$700M",
+                  "other_eq": "Other Equity\n$300M"
+                },
+                "colorFrom": {
+                  "cash": "#555",
+                  "receivable": "#555",
+                  "inventory": "#555",
+                  "other_ca": "#555",
+                  "ppe": "#555",
+                  "intangible": "#555",
+                  "investments": "#555",
+                  "other_fa": "#555",
+                  "current_a": "#555",
+                  "fixed_a": "#555",
+                  "total_a": "#555",
+                  "liabilities": "#DC2626",
+                  "equity": "#16A34A"
+                },
+                "colorTo": {
+                  "current_a": "#555",
+                  "fixed_a": "#555",
+                  "total_a": "#555",
+                  "liabilities": "#DC2626",
+                  "equity": "#16A34A",
+                  "payable": "#DC2626",
+                  "short_debt": "#DC2626",
+                  "other_cl": "#DC2626",
+                  "long_debt": "#DC2626",
+                  "other_fl": "#DC2626",
+                  "retained": "#16A34A",
+                  "other_cap": "#16A34A",
+                  "other_eq": "#16A34A"
+                },
+                "colorMode": "gradient",
+                "color": "#333",
+                "borderWidth": 1,
+                "nodeWidth": 20,
+                "nodePadding": 48,
+                "size": "max"
+              }
+            ]
+          },
+          "options": {
+            "layout": {
+              "padding": { "top": 10, "left": 100, "right": 100, "bottom": 10 }
+            },
+            "plugins": {
+              "legend": { "display": false },
+              "title": { "display": true, "text": "Consolidated Balance Sheet FY2025 ($M)", "font": { "size": 18 } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "Treemap: Business Portfolio Composition",
+      "image": {
+        "type": "chart",
+        "title": "Business Portfolio (Treemap)",
+        "chartData": {
+          "type": "treemap",
+          "data": {
+            "datasets": [
+              {
+                "tree": [
+                  { "name": "Cloud SVC", "value": 420 },
+                  { "name": "Cloud Infra", "value": 180 },
+                  { "name": "Enterprise SW", "value": 350 },
+                  { "name": "Enterprise Spt", "value": 120 },
+                  { "name": "Consumer App", "value": 200 },
+                  { "name": "Consumer HW", "value": 80 },
+                  { "name": "Other", "value": 50 }
+                ],
+                "key": "value",
+                "labels": {
+                  "display": true,
+                  "align": "center",
+                  "position": "middle",
+                  "color": "white",
+                  "font": { "size": 14, "weight": "bold" }
+                },
+                "backgroundColor": ["#3B82F6", "#60A5FA", "#6366F1", "#818CF8", "#10B981", "#34D399", "#94A3B8"],
+                "borderColor": "white",
+                "borderWidth": 2,
+                "spacing": 1
+              }
+            ]
+          },
+          "options": {
+            "responsive": false,
+            "plugins": {
+              "legend": { "display": false },
+              "tooltip": { "enabled": false }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "Waterfall: Operating Profit Bridge",
+      "image": {
+        "type": "slide",
+        "slide": {
+          "layout": "waterfall",
+          "title": "FY2025 Operating Profit Bridge",
+          "subtitle": "YoY +$15M (+12.5%)",
+          "items": [
+            { "label": "FY2024\nOp. Profit", "value": 120, "isTotal": true },
+            { "label": "Revenue\nGrowth", "value": 35 },
+            { "label": "COGS\nImprovement", "value": 12 },
+            { "label": "Personnel\nCosts", "value": -18 },
+            { "label": "R&D\nInvestment", "value": -10 },
+            { "label": "FX\nImpact", "value": -4 },
+            { "label": "FY2025\nOp. Profit", "value": 135, "isTotal": true }
+          ],
+          "unit": "$M",
+          "callout": {
+            "text": "Revenue growth and COGS improvement drove profit growth, absorbing personnel and R&D investment increases",
+            "label": "Summary"
+          }
+        }
+      }
+    },
+    {
+      "text": "Stacked Bar: Regional Revenue Breakdown",
+      "image": {
+        "type": "chart",
+        "title": "Regional Revenue Breakdown (Stacked Bar)",
+        "chartData": {
+          "type": "bar",
+          "data": {
+            "labels": ["FY2021", "FY2022", "FY2023", "FY2024", "FY2025"],
+            "datasets": [
+              {
+                "label": "Japan",
+                "data": [400, 420, 450, 480, 530],
+                "backgroundColor": "#3B82F6"
+              },
+              {
+                "label": "Americas",
+                "data": [150, 180, 220, 260, 310],
+                "backgroundColor": "#10B981"
+              },
+              {
+                "label": "EMEA",
+                "data": [80, 100, 130, 160, 200],
+                "backgroundColor": "#F59E0B"
+              },
+              {
+                "label": "APAC",
+                "data": [50, 70, 90, 120, 160],
+                "backgroundColor": "#EF4444"
+              }
+            ]
+          },
+          "options": {
+            "scales": {
+              "x": { "stacked": true },
+              "y": { "stacked": true, "title": { "display": true, "text": "Revenue (億円)" } }
+            },
+            "plugins": {
+              "legend": { "position": "top" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "Bubble: Business Unit Positioning",
+      "image": {
+        "type": "chart",
+        "title": "Business Unit Positioning (Growth vs Margin)",
+        "chartData": {
+          "type": "bubble",
+          "data": {
+            "datasets": [
+              {
+                "label": "Cloud Services",
+                "data": [{ "x": 25, "y": 35, "r": 20 }],
+                "backgroundColor": "rgba(59, 130, 246, 0.6)"
+              },
+              {
+                "label": "Enterprise SW",
+                "data": [{ "x": 8, "y": 28, "r": 18 }],
+                "backgroundColor": "rgba(16, 185, 129, 0.6)"
+              },
+              {
+                "label": "Consumer Apps",
+                "data": [{ "x": 15, "y": 12, "r": 12 }],
+                "backgroundColor": "rgba(245, 158, 11, 0.6)"
+              },
+              {
+                "label": "Hardware",
+                "data": [{ "x": -2, "y": 5, "r": 8 }],
+                "backgroundColor": "rgba(239, 68, 68, 0.6)"
+              }
+            ]
+          },
+          "options": {
+            "scales": {
+              "x": { "title": { "display": true, "text": "Revenue Growth (%)" } },
+              "y": { "title": { "display": true, "text": "Operating Margin (%)" } }
+            },
+            "plugins": {
+              "legend": { "position": "right" }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/slide/layouts/index.ts
+++ b/src/slide/layouts/index.ts
@@ -10,6 +10,7 @@ import { layoutSplit } from "./split.js";
 import { layoutMatrix } from "./matrix.js";
 import { layoutTable } from "./table.js";
 import { layoutFunnel } from "./funnel.js";
+import { layoutWaterfall } from "./waterfall.js";
 import { escapeHtml } from "../utils.js";
 
 /** Render the inner content of a slide (without the wrapper div) */
@@ -37,6 +38,8 @@ export const renderSlideContent = (slide: SlideLayout): string => {
       return layoutTable(slide);
     case "funnel":
       return layoutFunnel(slide);
+    case "waterfall":
+      return layoutWaterfall(slide);
     default: {
       const _exhaustive: never = slide;
       return `<p class="text-white p-8">Unknown layout: ${escapeHtml(String((_exhaustive as { layout: string }).layout))}</p>`;

--- a/src/slide/layouts/waterfall.ts
+++ b/src/slide/layouts/waterfall.ts
@@ -1,0 +1,80 @@
+import type { WaterfallSlide } from "../schema.js";
+import { renderInlineMarkup, c, slideHeader, renderOptionalCallout } from "../utils.js";
+
+/** Height of the chart area as percentage of available space */
+const CHART_HEIGHT_PCT = 75;
+
+export const layoutWaterfall = (data: WaterfallSlide): string => {
+  const parts: string[] = [slideHeader(data)];
+  const items = data.items || [];
+
+  const positions = buildWaterfallPositions(items);
+  const globalMax = Math.max(...positions.map((p) => p.top));
+  const globalMin = Math.min(...positions.map((p) => p.bottom));
+  const range = globalMax - globalMin || 1;
+
+  parts.push(`<div class="flex gap-1 px-12 mt-4 flex-1" style="min-height: 0">`);
+
+  items.forEach((item, i) => {
+    const pos = positions[i];
+    const isTotal = item.isTotal ?? false;
+    const isPositive = item.value >= 0;
+    const color = resolveBarColor(item.color, isTotal, isPositive);
+
+    const bottomPct = ((pos.bottom - globalMin) / range) * CHART_HEIGHT_PCT;
+    const heightPct = Math.max(((pos.top - pos.bottom) / range) * CHART_HEIGHT_PCT, 1.5);
+    const topOfBar = bottomPct + heightPct;
+    const labelTopPct = 100 - topOfBar;
+    const formattedValue = formatValue(item.value, data.unit, isTotal);
+
+    parts.push(`<div class="flex-1 relative" style="height: 100%">`);
+    // Value label (above bar)
+    parts.push(
+      `  <p class="absolute w-full text-xs font-bold text-d-text font-body text-center" style="top: ${labelTopPct - 4}%">${renderInlineMarkup(formattedValue)}</p>`,
+    );
+    // Bar (absolute positioned from bottom)
+    parts.push(`  <div class="absolute left-1 right-1 bg-${c(color)} rounded-t" style="bottom: ${bottomPct}%; height: ${heightPct}%"></div>`);
+    // Bottom label
+    parts.push(
+      `  <p class="absolute bottom-0 w-full text-xs text-d-muted font-body text-center" style="transform: translateY(100%)">${renderInlineMarkup(item.label)}</p>`,
+    );
+    parts.push(`</div>`);
+  });
+
+  parts.push(`</div>`);
+  // Labels area
+  parts.push(`<div class="h-10 shrink-0"></div>`);
+  parts.push(renderOptionalCallout(data.callout));
+
+  return parts.join("\n");
+};
+
+type WaterfallPosition = { top: number; bottom: number };
+
+const buildWaterfallPositions = (items: WaterfallSlide["items"]): WaterfallPosition[] => {
+  let runningTotal = 0;
+  return items.map((item) => {
+    if (item.isTotal) {
+      runningTotal = item.value;
+      return { top: Math.max(item.value, 0), bottom: Math.min(item.value, 0) };
+    }
+    const prevTotal = runningTotal;
+    runningTotal += item.value;
+    if (item.value >= 0) {
+      return { top: runningTotal, bottom: prevTotal };
+    }
+    return { top: prevTotal, bottom: runningTotal };
+  });
+};
+
+const resolveBarColor = (itemColor: string | undefined, isTotal: boolean, isPositive: boolean): string => {
+  if (itemColor) return itemColor;
+  if (isTotal) return "primary";
+  return isPositive ? "success" : "danger";
+};
+
+const formatValue = (value: number, unit: string | undefined, isTotal: boolean): string => {
+  const prefix = !isTotal && value > 0 ? "+" : "";
+  const suffix = unit ? ` ${unit}` : "";
+  return `${prefix}${value}${suffix}`;
+};

--- a/src/slide/render.ts
+++ b/src/slide/render.ts
@@ -18,10 +18,13 @@ const isDarkBg = (hex: string): boolean => {
 
 /** Build CDN script tags for chart/mermaid when needed */
 const buildCdnScripts = (theme: SlideTheme, slide: SlideLayout): string => {
-  const { hasChart, hasMermaid } = detectBlockTypes(slide);
+  const { hasChart, hasMermaid, chartPlugins } = detectBlockTypes(slide);
   const scripts: string[] = [];
   if (hasChart) {
     scripts.push('<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>');
+    chartPlugins.forEach((cdn) => {
+      scripts.push(`<script src="${cdn}"></script>`);
+    });
   }
   if (hasMermaid) {
     const mermaidTheme = isDarkBg(theme.colors.bg) ? "dark" : "default";

--- a/src/slide/schema.ts
+++ b/src/slide/schema.ts
@@ -390,6 +390,25 @@ export const tableSlideSchema = z.object({
   callout: calloutBarSchema.optional(),
 });
 
+// ─── waterfall ───
+export const waterfallItemSchema = z.object({
+  label: z.string(),
+  value: z.number(),
+  isTotal: z.boolean().optional(),
+  color: accentColorKeySchema.optional(),
+});
+
+export const waterfallSlideSchema = z.object({
+  layout: z.literal("waterfall"),
+  ...slideBaseFields,
+  title: z.string(),
+  stepLabel: z.string().optional(),
+  subtitle: z.string().optional(),
+  items: z.array(waterfallItemSchema),
+  unit: z.string().optional(),
+  callout: calloutBarSchema.optional(),
+});
+
 // ─── funnel ───
 export const funnelStageSchema = z.object({
   label: z.string(),
@@ -460,6 +479,7 @@ export const slideLayoutSchema = z.discriminatedUnion("layout", [
   matrixSlideSchema,
   tableSlideSchema,
   funnelSlideSchema,
+  waterfallSlideSchema,
 ]);
 
 /** Media schema registered in mulmoImageAssetSchema */
@@ -518,6 +538,8 @@ export type TableCellValue = z.infer<typeof tableCellValueSchema>;
 export type TableSlide = z.infer<typeof tableSlideSchema>;
 export type FunnelStage = z.infer<typeof funnelStageSchema>;
 export type FunnelSlide = z.infer<typeof funnelSlideSchema>;
+export type WaterfallItem = z.infer<typeof waterfallItemSchema>;
+export type WaterfallSlide = z.infer<typeof waterfallSlideSchema>;
 export type SlideBrandingLogo = z.infer<typeof slideBrandingLogoSchema>;
 export type SlideBranding = z.infer<typeof slideBrandingSchema>;
 export type MulmoSlideMedia = z.infer<typeof mulmoSlideMediaSchema>;

--- a/src/slide/utils.ts
+++ b/src/slide/utils.ts
@@ -206,7 +206,13 @@ export const resetSlideIdCounter = (): void => {
 // Content block type detection
 // ═══════════════════════════════════════════════════════════
 
-type BlockTypeFlags = { hasChart: boolean; hasMermaid: boolean };
+/** Chart.js plugin CDN URLs keyed by chart type */
+const CHART_PLUGIN_CDNS: Record<string, string> = {
+  sankey: "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey",
+  treemap: "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3",
+};
+
+type BlockTypeFlags = { hasChart: boolean; hasMermaid: boolean; chartPlugins: string[] };
 
 /** Collect all content block arrays from a slide layout */
 const collectContentArrays = (slide: SlideLayout): ContentBlock[][] => {
@@ -236,22 +242,35 @@ const collectContentArrays = (slide: SlideLayout): ContentBlock[][] => {
   return arrays;
 };
 
+/** Collect chart type from a chart block */
+const collectChartPlugin = (block: ContentBlock, plugins: Set<string>): void => {
+  if (block.type === "chart") {
+    const chartType = block.chartData?.type as string | undefined;
+    if (chartType && CHART_PLUGIN_CDNS[chartType]) {
+      plugins.add(CHART_PLUGIN_CDNS[chartType]);
+    }
+  }
+};
+
 /** Detect whether chart or mermaid content blocks exist in a slide */
 export const detectBlockTypes = (slide: SlideLayout): BlockTypeFlags => {
   const arrays = collectContentArrays(slide);
   let hasChart = false;
   let hasMermaid = false;
+  const plugins = new Set<string>();
   arrays.forEach((blocks) => {
     blocks.forEach((block) => {
       if (block.type === "chart") hasChart = true;
       if (block.type === "mermaid") hasMermaid = true;
+      collectChartPlugin(block, plugins);
       if (block.type === "section" && block.content) {
         block.content.forEach((inner) => {
           if (inner.type === "chart") hasChart = true;
           if (inner.type === "mermaid") hasMermaid = true;
+          collectChartPlugin(inner, plugins);
         });
       }
     });
   });
-  return { hasChart, hasMermaid };
+  return { hasChart, hasMermaid, chartPlugins: [...plugins] };
 };

--- a/src/utils/html_render.ts
+++ b/src/utils/html_render.ts
@@ -97,9 +97,9 @@ const scaleContentToFit = async (page: puppeteer.Page, viewportWidth: number, vi
 
 /** Determine the appropriate waitUntil strategy based on HTML content */
 const resolveWaitUntil = (html: string): "networkidle0" | "load" | "domcontentloaded" => {
-  const hasExternalImages = html.includes("<img") && /src=["']https?:\/\//.test(html);
+  const hasExternalResources = (html.includes("<img") && /src=["']https?:\/\//.test(html)) || /script src=["']https?:\/\//.test(html);
   const hasLocalImages = html.includes("<img") && /src=["']file:\/\//.test(html);
-  if (hasExternalImages) return "networkidle0";
+  if (hasExternalResources) return "networkidle0";
   if (hasLocalImages) return "load";
   return "domcontentloaded";
 };
@@ -113,8 +113,9 @@ const resolveWaitUntil = (html: string): "networkidle0" | "load" | "domcontentlo
 const loadHtmlIntoPage = async (page: puppeteer.Page, html: string, timeout_ms: number): Promise<void> => {
   const waitUntil = resolveWaitUntil(html);
   const hasFileUrls = /file:\/\//.test(html);
+  const hasExternalScripts = /script src=["']https?:\/\//.test(html);
 
-  if (hasFileUrls) {
+  if (hasFileUrls || hasExternalScripts) {
     const tmpFile = nodePath.join(os.tmpdir(), `mulmocast_render_${crypto.randomUUID()}.html`);
     fs.writeFileSync(tmpFile, html);
     try {

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -5,15 +5,25 @@ import { parrotingImagePath, generateUniqueId } from "./utils.js";
 
 export const imageType = "chart";
 
+/** Chart.js plugin CDN URLs keyed by chart type */
+const CHART_PLUGIN_CDNS: Record<string, string> = {
+  sankey: "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey",
+  treemap: "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3",
+};
+
+/** Resolve CDN script tags for Chart.js plugins based on chart type */
+const resolveChartPlugins = (chartType: string): string => {
+  const cdn = CHART_PLUGIN_CDNS[chartType];
+  if (!cdn) return "";
+  return `<script src="${cdn}"></script>`;
+};
+
 const processChart = async (params: ImageProcessorParams) => {
   const { beat, imagePath, canvasSize, textSlideStyle } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
-  const isCircular =
-    beat.image.chartData.type === "pie" ||
-    beat.image.chartData.type === "doughnut" ||
-    beat.image.chartData.type === "polarArea" ||
-    beat.image.chartData.type === "radar";
+  const chartType = beat.image.chartData.type as string;
+  const isCircular = chartType === "pie" || chartType === "doughnut" || chartType === "polarArea" || chartType === "radar";
   const chart_width = isCircular ? Math.min(canvasSize.width, canvasSize.height) * 0.75 : canvasSize.width * 0.75;
   const template = getHTMLFile("chart");
   const htmlData = interpolate(template, {
@@ -21,6 +31,7 @@ const processChart = async (params: ImageProcessorParams) => {
     style: textSlideStyle,
     chart_width: chart_width.toString(),
     chart_data: JSON.stringify(beat.image.chartData),
+    chart_plugins: resolveChartPlugins(chartType),
   });
   await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height);
   return imagePath;


### PR DESCRIPTION
## Summary

- **Chart.js plugin support**: Auto-load `chartjs-chart-sankey` and `chartjs-chart-treemap` CDN based on chart type. JSON-friendly: `backgroundColor` arrays (treemap) and `colorFrom`/`colorTo` objects (sankey) are converted to scriptable functions at runtime.
- **Waterfall slide layout**: Dedicated Slide DSL layout for profit bridge / YoY change analysis with auto-colored bars (green=positive, red=negative, blue=total) and absolute-positioned running total bars.
- **Chart rendering improvements**: Container height (70vh), `maintainAspectRatio: false`, flexbox vertical centering, `chart.resize()`/`update()` for plugin compatibility, try-catch for graceful error handling.
- **External script loading fix**: Detect `<script src="https://...">` in HTML for `networkidle0` wait strategy and `file://` loading to avoid cross-origin blocking.
- **Sample script**: `test_ir_visualizations.json` with 5 chart types (sankey BS diagram, treemap, waterfall, stacked bar, bubble chart).

Closes #1303

## User Prompt

- 決算・IRでよく使われる可視化（サンキー、ツリーマップ、ウォーターフォール等）を機能として盛り込みたい
- サンプルのJSONを作ってPDF化
- サンキー図は貸借対照表(BS)スタイルで、column/priority/labelsで砂時計型レイアウト
- ウォーターフォールはSlide DSLレイアウトとして追加

## Implementation Details

### Chart.js Plugin Auto-Loading (`chart.ts`, `chart.html`)

| Chart Type | Plugin CDN | JSON Adaptations |
|---|---|---|
| `sankey` | `chartjs-chart-sankey` (latest) | `colorFrom`/`colorTo` objects → lookup functions |
| `treemap` | `chartjs-chart-treemap@3` | `backgroundColor` array → scriptable function |

Sankey supports `column` (explicit x-position), `priority` (vertical ordering), and `labels` (display names with `\n` for multi-line) via JSON dataset options.

### Waterfall Slide Layout (`src/slide/layouts/waterfall.ts`)

- Schema: `waterfallSlideSchema` with `items: [{label, value, isTotal?, color?}]` and optional `unit`
- Positioning: absolute CSS with percentage-based `bottom`/`height` from running total calculation
- Auto-coloring: `success` for positive, `danger` for negative, `primary` for totals

### HTML Rendering (`html_render.ts`)

- `resolveWaitUntil`: now detects external `<script src="https://...">` for `networkidle0` strategy
- `loadHtmlIntoPage`: uses `file://` temp file when external scripts are present (avoids cross-origin blocking in `setContent`)

## Test plan

- [x] `yarn build` and `yarn lint` pass
- [x] `yarn ci_test` passes
- [x] `yarn pdf scripts/test/test_ir_visualizations.json` generates PDF with all 5 chart types
- [x] Sankey: BS diagram with color-coded flows (gray=assets, red=liabilities, green=equity)
- [x] Treemap: colored rectangles with labels
- [x] Waterfall: correctly positioned bars with running totals
- [x] Stacked bar and bubble charts render normally (standard Chart.js)
- [x] Existing chart types (bar, line, pie, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a waterfall layout option for slide presentations.
  * Chart.js plugins (sankey and treemap) now auto-load by chart type.
  * Chart rendering updated to Chart.js v4 with improved responsive behavior.

* **Improvements**
  * More reliable external resource detection and page-loading logic.
  * HTML/CSS adjustments for full-height centering and chart container sizing.

* **Tests**
  * Added a comprehensive visualization test configuration covering Sankey, Treemap, Waterfall, Stacked Bar, and Bubble charts.

* **Documentation**
  * README updated to reflect layout and plugin changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->