### PR TITLE
feat: add backgroundImage and style support to chart plugin

### DIFF
--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -224,6 +224,8 @@ export const mulmoChartMediaSchema = z
     type: z.literal("chart"),
     title: z.string(),
     chartData: z.record(z.string(), z.any()),
+    style: z.string().optional(),
+    backgroundImage: backgroundImageSchema,
   })
   .strict();
 

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -2,11 +2,12 @@ import { ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
+import { resolveCombinedStyle } from "./bg_image_util.js";
 
 export const imageType = "chart";
 
 const processChart = async (params: ImageProcessorParams) => {
-  const { beat, imagePath, canvasSize, textSlideStyle } = params;
+  const { beat, imagePath, canvasSize } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
   const isCircular =
@@ -15,10 +16,11 @@ const processChart = async (params: ImageProcessorParams) => {
     beat.image.chartData.type === "polarArea" ||
     beat.image.chartData.type === "radar";
   const chart_width = isCircular ? Math.min(canvasSize.width, canvasSize.height) * 0.75 : canvasSize.width * 0.75;
+  const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
   const template = getHTMLFile("chart");
   const htmlData = interpolate(template, {
     title: beat.image.title,
-    style: textSlideStyle,
+    style: combinedStyle,
     chart_width: chart_width.toString(),
     chart_data: JSON.stringify(beat.image.chartData),
   });


### PR DESCRIPTION
## Summary

- Add `backgroundImage` and `style` fields to `mulmoChartMediaSchema`
- Use `resolveCombinedStyle` in chart.ts (same pattern as markdown/mermaid/textSlide)

Ref #1305

## User Prompt

- chartでreferenceを使ったbg指定ができるようにしたい

## Test plan

- [ ] `yarn build` and `yarn lint` pass
- [ ] `yarn ci_test` passes
- [ ] Chart beats with `backgroundImage` render background correctly
- [ ] Chart beats with `style` apply custom CSS
- [ ] Existing charts without these fields work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charts now support custom styling and background image configuration options, enabling greater visual flexibility and customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->