### PR TITLE
feat: add image/movie refs support to mermaid plugin

### DIFF
--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -4,6 +4,7 @@ import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
+import { resolveImageRefs, resolveMovieRefs, resolveRelativeImagePaths } from "./html_tailwind.js";
 
 export const imageType = "mermaid";
 
@@ -30,11 +31,14 @@ const processMermaid = async (params: ImageProcessorParams) => {
   const diagram_code = await MulmoMediaSourceMethods.getText(beat.image.code, context);
   if (diagram_code) {
     const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
-    const htmlData = interpolate(template, {
+    const rawHtml = interpolate(template, {
       title: beat.image.title,
       style: combinedStyle,
       diagram_code: `${diagram_code}\n${beat.image.appendix?.join("\n") ?? ""}`,
     });
+    const resolvedImageRefs = resolveImageRefs(rawHtml, params.imageRefs ?? {});
+    const resolvedAllRefs = resolveMovieRefs(resolvedImageRefs, params.movieRefs ?? {});
+    const htmlData = resolveRelativeImagePaths(resolvedAllRefs, context.fileDirs.mulmoFileDirPath);
     await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height, true);
   }
   return imagePath;


### PR DESCRIPTION
## Summary

- Apply `resolveImageRefs`, `resolveMovieRefs`, `resolveRelativeImagePaths` to mermaid HTML before rendering
- Enables `image:name` and `movie:name` references in mermaid styles/backgrounds

Ref #1305

## Test plan

- [ ] `yarn build`, `yarn lint`, `yarn ci_test` pass
- [ ] Mermaid beats with `image:name` refs in style/background resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)