### PR TITLE
fix: chart.html const/let, CSS order fix, plugin feature tests

### DIFF
--- a/assets/html/chart.html
+++ b/assets/html/chart.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Simple Chart.js Bar Chart</title>
     <style>
-        ${style}
         html, body { height: 100%; margin: 0; }
         body { display: flex; flex-direction: column; align-items: center; justify-content: center; }
+        ${style}
         .chart-container {
             width: ${chart_width}px;
             height: 70vh;
@@ -27,9 +27,9 @@
     <script>
         function initChart() {
             if (!window.Chart) return false;
-            var ctx = document.getElementById('myChart');
+            const ctx = document.getElementById('myChart');
             if (!ctx) return false;
-            var chartData = ${chart_data};
+            const chartData = ${chart_data};
 
             // Disable animation for static image generation
             if (!chartData.options) chartData.options = {};
@@ -39,40 +39,38 @@
 
             // Treemap: convert backgroundColor array to scriptable function
             if (chartData.type === 'treemap') {
-                chartData.data.datasets.forEach(function(ds) {
+                chartData.data.datasets.forEach((ds) => {
                     if (Array.isArray(ds.backgroundColor)) {
-                        var colors = ds.backgroundColor;
-                        ds.backgroundColor = function(ctx) {
-                            return colors[ctx.dataIndex % colors.length];
-                        };
+                        const colors = ds.backgroundColor;
+                        ds.backgroundColor = (c) => colors[c.dataIndex % colors.length];
                     }
                 });
             }
 
             // Sankey: convert colorFrom/colorTo objects to lookup functions
             if (chartData.type === 'sankey') {
-                chartData.data.datasets.forEach(function(ds) {
+                chartData.data.datasets.forEach((ds) => {
                     if (ds.colorFrom && typeof ds.colorFrom === 'object') {
-                        var fromMap = ds.colorFrom;
-                        ds.colorFrom = function(c) { return fromMap[c.dataset.data[c.dataIndex].from] || '#999'; };
+                        const fromMap = ds.colorFrom;
+                        ds.colorFrom = (c) => fromMap[c.dataset.data[c.dataIndex].from] || '#999';
                     }
                     if (ds.colorTo && typeof ds.colorTo === 'object') {
-                        var toMap = ds.colorTo;
-                        ds.colorTo = function(c) { return toMap[c.dataset.data[c.dataIndex].to] || '#999'; };
+                        const toMap = ds.colorTo;
+                        ds.colorTo = (c) => toMap[c.dataset.data[c.dataIndex].to] || '#999';
                     }
                 });
             }
 
             try {
-                var chart = new Chart(ctx, chartData);
+                const chart = new Chart(ctx, chartData);
                 chart.resize();
                 chart.update();
             } catch (e) {
                 console.error('Chart init error:', e);
             }
 
-            requestAnimationFrame(function() {
-                requestAnimationFrame(function() {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
                     ctx.dataset.chartReady = "true";
                 });
             });
@@ -84,7 +82,7 @@
             setTimeout(waitForChart, 50);
         }
 
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', () => {
             waitForChart();
         });
     </script>

--- a/scripts/test/test_plugin_features.json
+++ b/scripts/test/test_plugin_features.json
@@ -1,0 +1,142 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "title": "Plugin Feature Tests",
+  "lang": "en",
+  "canvasSize": { "width": 1280, "height": 720 },
+  "imageParams": {
+    "images": {
+      "bg_gradient": {
+        "type": "image",
+        "source": { "kind": "url", "url": "https://images.unsplash.com/photo-1557682250-33bd709cbe85?w=1280&h=720&fit=crop" }
+      }
+    }
+  },
+  "beats": [
+    {
+      "text": "Chart with backgroundImage (URL string)",
+      "image": {
+        "type": "chart",
+        "title": "Revenue by Quarter",
+        "backgroundImage": "https://images.unsplash.com/photo-1557682250-33bd709cbe85?w=1280&h=720&fit=crop",
+        "chartData": {
+          "type": "bar",
+          "data": {
+            "labels": ["Q1", "Q2", "Q3", "Q4"],
+            "datasets": [{
+              "label": "Revenue ($M)",
+              "data": [120, 150, 180, 210],
+              "backgroundColor": "rgba(59, 130, 246, 0.8)"
+            }]
+          },
+          "options": {
+            "plugins": {
+              "legend": { "labels": { "color": "white" } },
+              "title": { "display": false }
+            },
+            "scales": {
+              "x": { "ticks": { "color": "white" }, "grid": { "color": "rgba(255,255,255,0.1)" } },
+              "y": { "ticks": { "color": "white" }, "grid": { "color": "rgba(255,255,255,0.1)" } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "Chart with backgroundImage (source object with opacity)",
+      "image": {
+        "type": "chart",
+        "title": "Market Share",
+        "backgroundImage": {
+          "source": { "kind": "url", "url": "https://images.unsplash.com/photo-1557682250-33bd709cbe85?w=1280&h=720&fit=crop" },
+          "size": "cover",
+          "opacity": 0.3
+        },
+        "chartData": {
+          "type": "doughnut",
+          "data": {
+            "labels": ["Product A", "Product B", "Product C", "Other"],
+            "datasets": [{
+              "data": [35, 25, 20, 20],
+              "backgroundColor": ["#3B82F6", "#10B981", "#F59E0B", "#94A3B8"]
+            }]
+          }
+        }
+      }
+    },
+    {
+      "text": "Chart with custom style",
+      "image": {
+        "type": "chart",
+        "title": "Growth Trend",
+        "style": "body { background: linear-gradient(135deg, #1a1a2e, #16213e, #0f3460); } h1 { color: #e94560; }",
+        "chartData": {
+          "type": "line",
+          "data": {
+            "labels": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"],
+            "datasets": [{
+              "label": "Users (K)",
+              "data": [10, 15, 25, 35, 50, 72],
+              "borderColor": "#e94560",
+              "backgroundColor": "rgba(233, 69, 96, 0.2)",
+              "fill": true,
+              "tension": 0.4
+            }]
+          },
+          "options": {
+            "plugins": { "legend": { "labels": { "color": "white" } } },
+            "scales": {
+              "x": { "ticks": { "color": "#ccc" }, "grid": { "color": "rgba(255,255,255,0.1)" } },
+              "y": { "ticks": { "color": "#ccc" }, "grid": { "color": "rgba(255,255,255,0.1)" } }
+            }
+          }
+        }
+      }
+    },
+    {
+      "text": "Mermaid with backgroundImage (image:name ref)",
+      "image": {
+        "type": "mermaid",
+        "title": "System Architecture",
+        "code": { "kind": "text", "text": "graph TD\n  A[Client] --> B[API Gateway]\n  B --> C[Auth Service]\n  B --> D[Data Service]\n  C --> E[(Database)]\n  D --> E" },
+        "backgroundImage": {
+          "source": { "kind": "url", "url": "https://images.unsplash.com/photo-1557682250-33bd709cbe85?w=1280&h=720&fit=crop" },
+          "size": "cover",
+          "opacity": 0.15
+        }
+      }
+    },
+    {
+      "text": "Chart with backgroundImage + style combined",
+      "image": {
+        "type": "chart",
+        "title": "",
+        "style": "h1 { display: none; }",
+        "backgroundImage": {
+          "source": { "kind": "url", "url": "https://images.unsplash.com/photo-1557682250-33bd709cbe85?w=1280&h=720&fit=crop" },
+          "size": "cover",
+          "opacity": 0.2
+        },
+        "chartData": {
+          "type": "radar",
+          "data": {
+            "labels": ["Speed", "Reliability", "Cost", "Security", "Scalability", "UX"],
+            "datasets": [
+              {
+                "label": "Product A",
+                "data": [85, 90, 60, 80, 75, 70],
+                "borderColor": "#3B82F6",
+                "backgroundColor": "rgba(59, 130, 246, 0.2)"
+              },
+              {
+                "label": "Product B",
+                "data": [70, 65, 90, 75, 85, 80],
+                "borderColor": "#10B981",
+                "backgroundColor": "rgba(16, 185, 129, 0.2)"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace `var` with `const`/`let` and `function()` with arrow functions in `chart.html`
- Fix CSS cascade order: base styles before `${style}` so custom styles can override
- Add `test_plugin_features.json` with 5 beats testing:
  - Chart + backgroundImage (URL string)
  - Chart + backgroundImage (source object with opacity)
  - Chart + custom style (CSS gradient)
  - Mermaid + backgroundImage (with opacity)
  - Chart + backgroundImage + style combined

Ref #1305

## Test plan

- [x] `yarn build`, `yarn lint`, `yarn ci_test` pass
- [x] `yarn pdf scripts/test/test_plugin_features.json` generates all 5 pages correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced chart rendering configuration for improved responsiveness and aspect ratio handling.

* **Tests**
  * Added comprehensive test fixtures for various visualization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->