### PR TITLE
docs: add Upload-Post for publishing generated videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,6 +910,20 @@ Examples:
 
 
 
+## Publishing Your Videos
+
+Once your video is generated, publish it to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com):
+
+```bash
+curl -X POST https://api.upload-post.com/upload \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -F "video=@output/video.mp4" \
+  -F "title=Your MulmoCast Video" \
+  -F "platforms=tiktok,youtube,instagram"
+```
+
+Upload-Post provides a single API to publish videos across all major platforms. [Get your API key here](https://upload-post.com).
+
 ## Contributing
 
 For developers interested in contributing to this project, please see [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
This PR adds documentation for publishing generated videos to TikTok, YouTube Shorts, and Instagram Reels using [Upload-Post](https://upload-post.com).

## Changes
- Added 'Publishing Your Videos' section before Contributing
- Shows how to upload videos to multiple platforms with a single API call

## Why?
MulmoCast generates multi-modal content including videos, but users still need to manually upload to each platform. Upload-Post provides a single API to publish to TikTok, YouTube, and Instagram simultaneously.

## Example
```bash
curl -X POST https://api.upload-post.com/upload \
  -H "Authorization: Bearer YOUR_API_KEY" \
  -F "video=@output/video.mp4" \
  -F "platforms=tiktok,youtube,instagram"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added publishing guide explaining how to share generated videos to TikTok, YouTube Shorts, and Instagram Reels via the Upload-Post cross-platform publishing API, including API usage example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->