### PR TITLE
feat: add google/veo-3.1-lite support (Replicate + GenAI)

### DIFF
--- a/scripts/test/test_veo31_lite.json
+++ b/scripts/test/test_veo31_lite.json
@@ -1,0 +1,39 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "title": "Veo 3.1 Lite Test",
+  "lang": "en",
+  "canvasSize": { "width": 1280, "height": 720 },
+  "beats": [
+    {
+      "id": "google_genai_lite",
+      "text": "Google GenAI veo-3.1-lite-generate-preview text-to-video",
+      "duration": 4,
+      "moviePrompt": "A calm ocean wave rolling onto a sandy beach at golden hour",
+      "movieParams": {
+        "provider": "google",
+        "model": "veo-3.1-lite-generate-preview"
+      }
+    },
+    {
+      "id": "replicate_lite",
+      "text": "Replicate google/veo-3.1-lite text-to-video",
+      "duration": 4,
+      "moviePrompt": "A calm ocean wave rolling onto a sandy beach at golden hour",
+      "movieParams": {
+        "provider": "replicate",
+        "model": "google/veo-3.1-lite"
+      }
+    },
+    {
+      "id": "replicate_lite_i2v",
+      "text": "Replicate google/veo-3.1-lite image-to-video",
+      "duration": 4,
+      "imagePrompt": "A beautiful ocean sunset with golden reflections on the water",
+      "moviePrompt": "The camera slowly pans across the ocean as waves gently roll in",
+      "movieParams": {
+        "provider": "replicate",
+        "model": "google/veo-3.1-lite"
+      }
+    }
+  ]
+}

--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -179,7 +179,7 @@ const generateStandardVideo = async (
     model,
     prompt,
     config: {
-      durationSeconds: capabilities?.supportsPersonGeneration === false ? undefined : duration,
+      durationSeconds: capabilities?.supportsDuration === false ? undefined : duration,
       aspectRatio,
       personGeneration: imagePath || !capabilities?.supportsPersonGeneration ? undefined : PersonGeneration.ALLOW_ALL,
     },

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -100,6 +100,7 @@ export const provider2MovieAgent = {
       "google/veo-3",
       "google/veo-3.1",
       "google/veo-3.1-fast",
+      "google/veo-3.1-lite",
       "google/veo-3-fast",
       "minimax/video-01",
       "minimax/hailuo-02",
@@ -163,6 +164,12 @@ export const provider2MovieAgent = {
         start_image: "image",
         last_image: "last_frame_image",
         price_per_sec: 0.4,
+      },
+      "google/veo-3.1-lite": {
+        durations: [4, 6, 8],
+        start_image: "image",
+        last_image: "last_frame",
+        price_per_sec: 0.05,
       },
       "google/veo-3-fast": {
         durations: [8],
@@ -239,28 +246,41 @@ export const provider2MovieAgent = {
   google: {
     agentName: "movieGenAIAgent",
     defaultModel: "veo-2.0-generate-001",
-    models: ["veo-2.0-generate-001", "veo-3.0-generate-001", "veo-3.1-generate-preview"],
+    models: ["veo-2.0-generate-001", "veo-3.0-generate-001", "veo-3.1-generate-preview", "veo-3.1-lite-generate-preview"],
     keyName: "GEMINI_API_KEY",
     modelParams: {
+      "veo-3.1-lite-generate-preview": {
+        durations: [4, 6, 8],
+        supportsDuration: true,
+        supportsLastFrame: true,
+        supportsReferenceImages: false,
+        supportsPersonGeneration: false,
+      },
       "veo-3.1-generate-preview": {
         durations: [4, 6, 8],
+        supportsDuration: true,
         supportsLastFrame: true,
         supportsReferenceImages: true,
         supportsPersonGeneration: false,
       },
       "veo-3.0-generate-001": {
-        durations: [4, 6, 8],
+        durations: [8],
+        supportsDuration: false, // Veo 3.0 always generates 8s
         supportsLastFrame: false,
         supportsReferenceImages: false,
         supportsPersonGeneration: false,
       },
       "veo-2.0-generate-001": {
-        durations: [5, 6, 7, 8],
+        durations: [5, 6, 8],
+        supportsDuration: true,
         supportsLastFrame: false, // Vertex AI only
         supportsReferenceImages: false,
         supportsPersonGeneration: true,
       },
-    } as Record<string, { durations: number[]; supportsLastFrame: boolean; supportsReferenceImages: boolean; supportsPersonGeneration: boolean }>,
+    } as Record<
+      string,
+      { durations: number[]; supportsDuration: boolean; supportsLastFrame: boolean; supportsReferenceImages: boolean; supportsPersonGeneration: boolean }
+    >,
   },
   mock: {
     agentName: "mediaMockAgent",


### PR DESCRIPTION
## Summary

Add `google/veo-3.1-lite` model support for both Replicate and Google GenAI providers. Also fix duration specs to match official Google documentation.

Closes partially #1312

## Changes

### New model: veo-3.1-lite

| Provider | Model ID | Durations | Last Frame | Ref Images | Price |
|---|---|---|---|---|---|
| Replicate | `google/veo-3.1-lite` | 4, 6, 8s | ✅ `last_frame` | ❌ | $0.05/sec |
| Google GenAI | `veo-3.1-lite-generate-preview` | 4, 6, 8s | ✅ | ❌ | — |

### Duration spec fixes (per Google documentation)

| Model | Before | After | Source |
|---|---|---|---|
| veo-2.0-generate-001 | `[5, 6, 7, 8]` | `[5, 6, 8]` | [Veo 2 docs](https://ai.google.dev/gemini-api/docs/models/veo-2-generate-preview): "5, 6, 8" |
| veo-3.0-generate-001 | `[4, 6, 8]` | `[8]` | [Veo 3 docs](https://ai.google.dev/gemini-api/docs/models/veo-3-generate-preview): "8 seconds only" |

### supportsDuration field

Added explicit `supportsDuration` boolean to all Google model params. Previously the code used `supportsPersonGeneration === false` as a proxy for "don't send durationSeconds", which was incorrect for veo-3.1-lite (no person generation support, but DOES support duration).

## Test plan

- [x] `yarn build`, `yarn lint` pass
- [ ] `yarn movie scripts/test/test_veo31_lite.json` — GenAI text-to-video
- [ ] Replicate text-to-video and image-to-video

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Veo 3.1 Lite model for video generation.

* **Improvements**
  * Enhanced video duration handling and capability detection for video models.
  * Updated model parameter configuration for improved video generation compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->