### PR TITLE
default background color of textSlide

### DIFF
--- a/docs/plans/plan_textslide_default_background.md
+++ b/docs/plans/plan_textslide_default_background.md
@@ -1,0 +1,28 @@
+# Plan: Add default background-color to textSlide styles
+
+## Problem
+
+The default CSS for textSlide sets `color: #333` (dark grey) on the body but does **not** set a `background-color`. Puppeteer defaults to a white background, so slides render correctly within the MulmoCast CLI pipeline. However, when an external app uses this module as a library and renders the generated HTML in a different context (e.g., a dark-themed WebView, an embedded browser with a black default background), the dark grey text becomes nearly invisible against the dark inherited background.
+
+## Root Cause
+
+In `src/methods/mulmo_presentation_style.ts`, the `defaultTextSlideStyles` array defines:
+
+```css
+body { margin: 60px; margin-top: 40px; color:#333; font-size: 30px; font-family: Arial, sans-serif; box-sizing: border-box; height: 100vh }
+```
+
+No `background-color` is specified. The rendering relies on the implicit white background of Puppeteer's Chromium instance, which is not guaranteed in other environments.
+
+## Fix
+
+Add `background-color: #fff` to the default `body` rule so that textSlide always has an explicit white background regardless of the rendering environment.
+
+## Affected Files
+
+- `src/methods/mulmo_presentation_style.ts` (line 43) — add `background-color: #fff` to the body style string
+
+## Notes
+
+- Users can still override this via `textSlideParams.cssStyles` at the presentation or beat level, since those styles are appended after the defaults.
+- The `backgroundImage` feature (via `bg_image_util.ts`) also sets its own `body` styles, which will naturally override this default when a background image is specified.

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -40,7 +40,7 @@ import {
 
 const defaultTextSlideStyles = [
   '*,*::before,*::after{box-sizing:border-box}body,h1,h2,h3,h4,p,figure,blockquote,dl,dd{margin:0}ul[role="list"],ol[role="list"]{list-style:none}html:focus-within{scroll-behavior:smooth}body{min-height:100vh;text-rendering:optimizeSpeed;line-height:1.5}a:not([class]){text-decoration-skip-ink:auto}img,picture{max-width:100%;display:block}input,button,textarea,select{font:inherit}@media(prefers-reduced-motion:reduce){html:focus-within{scroll-behavior:auto}*,*::before,*::after{animation-duration:.01ms !important;animation-iteration-count:1 !important;transition-duration:.01ms !important;scroll-behavior:auto !important}}',
-  "body { margin: 60px; margin-top: 40px; color:#333; font-size: 30px; font-family: Arial, sans-serif; box-sizing: border-box; height: 100vh }",
+  "body { margin: 60px; margin-top: 40px; color:#333; background-color:#fff; font-size: 30px; font-family: Arial, sans-serif; box-sizing: border-box; height: 100vh }",
   "h1 { font-size: 56px; margin-bottom: 20px; text-align: center }",
   "h2 { font-size: 48px; text-align: center }",
   "h3 { font-size: 36px }",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added plan documentation describing text slide default background styling and how it interacts with existing CSS override and background image features.

* **Bug Fixes**
  * Text slides now include an explicit white background color in their default styles for consistent rendering across all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->