### PR TITLE
Add Seedance 2.0 models, tests, and pricing updates

### DIFF
--- a/scripts/test/test_seedance.json
+++ b/scripts/test/test_seedance.json
@@ -1,0 +1,61 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "movieParams": {
+    "provider": "replicate",
+    "model": "bytedance/seedance-2.0"
+  },
+  "audioParams": {
+    "bgmVolume": 0
+  },
+  "captionParams": {
+    "lang": "en"
+  },
+  "lang": "en",
+  "beats": [
+    {
+      "text": "Comparing the bytedance seedance series with a fast-cut dance prompt",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "PROMPT: high-energy dance montage, quick cuts synced to the beat, neon-lit urban street"
+        }
+      }
+    },
+    {
+      "id": "seedance-1-lite",
+      "text": "bytedance/seedance-1-lite",
+      "duration": 5,
+      "moviePrompt": "A high-energy 5-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-1-lite"
+      }
+    },
+    {
+      "id": "seedance-1-pro",
+      "text": "bytedance/seedance-1-pro",
+      "duration": 5,
+      "moviePrompt": "A high-energy 5-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-1-pro"
+      }
+    },
+    {
+      "id": "seedance-2.0",
+      "text": "bytedance/seedance-2.0",
+      "duration": 10,
+      "moviePrompt": "A high-energy 10-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-2.0"
+      }
+    },
+    {
+      "id": "seedance-2.0-fast",
+      "text": "bytedance/seedance-2.0-fast",
+      "duration": 8,
+      "moviePrompt": "A high-energy 8-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-2.0-fast"
+      }
+    }
+  ]
+}

--- a/scripts/test/test_seedance2_only.json
+++ b/scripts/test/test_seedance2_only.json
@@ -25,7 +25,7 @@
       "id": "seedance-2.0",
       "text": "bytedance/seedance-2.0",
       "duration": 5,
-      "moviePrompt": "A high-energy 10-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "moviePrompt": "A high-energy 5-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
       "movieParams": {
         "model": "bytedance/seedance-2.0"
       }
@@ -34,7 +34,7 @@
       "id": "seedance-2.0-fast",
       "text": "bytedance/seedance-2.0-fast",
       "duration": 5,
-      "moviePrompt": "A high-energy 8-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "moviePrompt": "A high-energy 5-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
       "movieParams": {
         "model": "bytedance/seedance-2.0-fast"
       }

--- a/scripts/test/test_seedance2_only.json
+++ b/scripts/test/test_seedance2_only.json
@@ -1,0 +1,43 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "movieParams": {
+    "provider": "replicate",
+    "model": "bytedance/seedance-2.0"
+  },
+  "audioParams": {
+    "bgmVolume": 0
+  },
+  "captionParams": {
+    "lang": "en"
+  },
+  "lang": "en",
+  "beats": [
+    {
+      "text": "Comparing the bytedance seedance series with a fast-cut dance prompt",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "PROMPT: high-energy dance montage, quick cuts synced to the beat, neon-lit urban street"
+        }
+      }
+    },
+    {
+      "id": "seedance-2.0",
+      "text": "bytedance/seedance-2.0",
+      "duration": 5,
+      "moviePrompt": "A high-energy 10-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-2.0"
+      }
+    },
+    {
+      "id": "seedance-2.0-fast",
+      "text": "bytedance/seedance-2.0-fast",
+      "duration": 5,
+      "moviePrompt": "A high-energy 8-second dance video, photorealistic, vibrant lighting. Fast-paced montage with quick cuts synchronized to the beat: energetic dancer performing sharp hip-hop moves in an urban street at night, neon lights reflecting on wet pavement, quick close-ups on footwork and hand gestures, dynamic full-body shots with camera orbiting smoothly, realistic body physics and fabric movement, original choreography, no copyrighted elements.",
+      "movieParams": {
+        "model": "bytedance/seedance-2.0-fast"
+      }
+    }
+  ]
+}

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -133,13 +133,13 @@ export const provider2MovieAgent = {
         durations: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",
         last_image: "last_frame_image",
-        price_per_sec: 0.14,
+        price_per_sec: 0.29,
       },
       "bytedance/seedance-2.0-fast": {
         durations: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",
         last_image: "last_frame_image",
-        price_per_sec: 0.081,
+        price_per_sec: 0.22,
       },
       "kwaivgi/kling-v1.6-pro": {
         durations: [5, 10],

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -266,7 +266,7 @@ export const provider2MovieAgent = {
       "veo-3.1-lite-generate-preview": {
         durations: [4, 6, 8],
         supportsDuration: true,
-        supportsLastFrame: false,
+        supportsLastFrame: true,
         supportsReferenceImages: false,
         supportsPersonGeneration: false,
       },

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -93,6 +93,8 @@ export const provider2MovieAgent = {
     models: [
       "bytedance/seedance-1-lite",
       "bytedance/seedance-1-pro",
+      "bytedance/seedance-2.0",
+      "bytedance/seedance-2.0-fast",
       "kwaivgi/kling-v1.6-pro",
       "kwaivgi/kling-v2.1",
       "kwaivgi/kling-v2.1-master",
@@ -126,6 +128,18 @@ export const provider2MovieAgent = {
         start_image: "image",
         last_image: "last_frame_image",
         price_per_sec: 0.15,
+      },
+      "bytedance/seedance-2.0": {
+        durations: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        start_image: "image",
+        last_image: "last_frame_image",
+        price_per_sec: 0.14,
+      },
+      "bytedance/seedance-2.0-fast": {
+        durations: [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        start_image: "image",
+        last_image: "last_frame_image",
+        price_per_sec: 0.081,
       },
       "kwaivgi/kling-v1.6-pro": {
         durations: [5, 10],
@@ -252,7 +266,7 @@ export const provider2MovieAgent = {
       "veo-3.1-lite-generate-preview": {
         durations: [4, 6, 8],
         supportsDuration: true,
-        supportsLastFrame: true,
+        supportsLastFrame: false,
         supportsReferenceImages: false,
         supportsPersonGeneration: false,
       },


### PR DESCRIPTION
Seedance 2
https://replicate.com/bytedance/seedance-2.0
が使えるようになったので、その変更です。

ただ、Seedance 2 は同じプロンプトでも成功したり、失敗したりするようです。
test script（json）も何度か実行しないと全て成功しない可能性があります。

replicate 側の error 内容
```
Prediction failed
Error: Prediction failed: Async prediction failed: ModelError: The input or output was flagged as sensitive. Please try again with different inputs. (E005) (uIJ6l3ruRD)
```

Seedance 2 の beat 10 sec

https://github.com/user-attachments/assets/3e4032d5-a5fb-457d-b413-acf9c5179840

Seedance 2 + Seedance 2 fast の 5secずつ

https://github.com/user-attachments/assets/51cad351-b18e-4ed3-b2c6-98ae3c841fa4

## 概要
- `provider2MovieAgent.replicate.models` に `bytedance/seedance-2.0` と `bytedance/seedance-2.0-fast` を追加
- 上記2モデルの `modelParams`（対応秒数、先頭/末尾フレーム指定）を追加
- Seedance 2.0 系モデルの `price_per_sec` を修正
- テスト用シナリオJSONを追加
  - `scripts/test/test_seedance.json`
  - `scripts/test/test_seedance2_only.json`


## 確認
- 追加JSONの構文チェック
- `yarn -s tsc --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new Bytedance Seedance video generation models: Seedance 2.0 and Seedance 2.0-Fast, enabling high-energy dance montage video creation with varying performance and cost options.

* **Tests**
  * Added test configurations validating the new Seedance models' functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->