### PR TITLE
docs: split Veo Replicate rows to show lastFrame param accurately

### DIFF
--- a/docs/movie_reference_images.md
+++ b/docs/movie_reference_images.md
@@ -125,7 +125,8 @@ For videos **longer than 8 seconds**, Veo 3.1 uses video extension (generating a
 | **kling-v1.6/2.1/2.1-master** | ✅ | ❌ | — | ❌ | — |
 | **kling-v3-video/v3-omni-video** | ✅ | ✅ | `end_image` | optional | `generate_audio` |
 | **veo-2 (Replicate)** | ✅ | ❌ | — | ❌ | — |
-| **veo-3/3.1/3.1-fast/3-fast** | ✅ | varies | — | optional | `generate_audio` |
+| **veo-3/3-fast** | ✅ | ❌ | — | optional | `generate_audio` |
+| **veo-3.1/3.1-fast** | ✅ | ✅ | `last_frame_image` | optional | `generate_audio` |
 | **veo-3.1-lite** | ✅ | ✅ | `last_frame` | ❌ | — |
 | **minimax/video-01** | ✅ | ❌ | — | ❌ | — |
 | **xai/grok-imagine-r2v** | ❌ | ❌ | — | ❌ | — |


### PR DESCRIPTION
## 概要

CodeRabbit レビュー指摘への対応。

Replicate モデル表で `veo-3/3.1/3.1-fast/3-fast` を1行にまとめていたが、lastFrame の対応状況が `varies` + param が `—` となっており、対応モデルのパラメータ名が欠落していた。

## 変更内容

`provider2agent.ts` の実データに基づき行を分割:

| モデル | lastFrame | lastFrame param |
|--------|:---:|---|
| **veo-3/3-fast** | ❌ | — |
| **veo-3.1/3.1-fast** | ✅ | `last_frame_image` |

## 関連

- PR #1352 (generateAudio サポート) の CodeRabbit レビューコメント

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Replicate Model Support Matrix to clarify feature support for different Veo model versions, separating veo-3/3-fast and veo-3.1/3.1-fast into distinct configuration rows with updated specifications.
  * Specified lastFrame parameter support and optional audio generation capabilities distinctly for each model version, providing clear developer guidance on available features and supported parameters for implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->