### PR TITLE
feat: add gpt-image-2 model support

### DIFF
--- a/scripts/test/README.md
+++ b/scripts/test/README.md
@@ -106,7 +106,7 @@ Language setting tests
 Provider-specific feature tests
 
 - [**test_hello_google.json**](./test_hello_google.json) - Google TTS専用テスト / Google TTS specific test
-- [**gpt.json**](./gpt.json) - GPTモデルテスト / GPT model test
+- [**test_gpt_image.json**](./test_gpt_image.json) - GPT image model test
 - [**mulmo_story.json**](./mulmo_story.json) - ストーリー形式テスト / Story format test
 - [**nano_banana.json**](./nano_banana.json) - カスタムサンプル / Custom sample
 

--- a/scripts/test/test_gpt_image.json
+++ b/scripts/test/test_gpt_image.json
@@ -24,6 +24,14 @@
     {
       "speaker": "Host",
       "text": "How are you?",
+      "imagePrompt": "A witch in Harajuku",
+      "imageParams": {
+        "model": "gpt-image-2"
+      }
+    },
+    {
+      "speaker": "Host",
+      "text": "How are you?",
       "imagePrompt": "A witch in Harajuku"
     },
     {

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -46,7 +46,7 @@ export const provider2TTSAgent = {
   },
 };
 
-export const gptImages = ["gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini"];
+export const gptImages = ["gpt-image-2", "gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini"];
 
 export const provider2ImageAgent = {
   openai: {

--- a/test/actions/test_create_video.ts
+++ b/test/actions/test_create_video.ts
@@ -94,14 +94,15 @@ test("test createVideo filterComplex structure", async () => {
   ]);
 });
 
-test("test createVideo with gpt.json", async () => {
-  const script = getMulmoScript("test/gpt.json");
+test("test createVideo with test_gpt_image.json", async () => {
+  const script = getMulmoScript("test/test_gpt_image.json");
   const context = createContextFromScript(script);
   const result = await createVideo("/dummy/audio.mp3", "/dummy/output.mp4", context, true);
   assert.deepStrictEqual(result, [
     "[0:v]loop=loop=-1:size=1:start=0,fps=30,trim=end_frame=150,setpts=PTS-STARTPTS,scale=w=1280:h=720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,format=yuv420p[v0]",
     "[1:v]loop=loop=-1:size=1:start=0,fps=30,trim=end_frame=150,setpts=PTS-STARTPTS,scale=w=1280:h=720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,format=yuv420p[v1]",
-    "[v0][v1]concat=n=2:v=1:a=0[concat_video]",
+    "[2:v]loop=loop=-1:size=1:start=0,fps=30,trim=end_frame=150,setpts=PTS-STARTPTS,scale=w=1280:h=720:force_original_aspect_ratio=decrease,pad=1280:720:(ow-iw)/2:(oh-ih)/2:color=black,setsar=1,format=yuv420p[v2]",
+    "[v0][v1][v2]concat=n=3:v=1:a=0[concat_video]",
   ]);
 });
 


### PR DESCRIPTION
## 概要

OpenAI の新しい画像生成モデル `gpt-image-2` をサポート。


https://github.com/user-attachments/assets/3ce0cf73-a962-4a87-be38-edb00de3f11c



## 変更内容

- `gptImages` 配列に `gpt-image-2` を追加（既存の gpt-image-1 系と同じコードパスで動作）
- テストファイル `gpt.json` → `test_gpt_image.json` にリネーム（命名規則統一）
- `test_gpt_image.json` に gpt-image-2 のテストビートを追加
- テストコード・README の参照を更新

## テスト

- `yarn ci_test` 全件パス
- `yarn movie scripts/test/test_gpt_image.json` で動画生成を実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new GPT image generation model with advanced image synthesis capabilities.

* **Tests**
  * Updated test data and validation to ensure proper functionality of the new image generation model.

* **Documentation**
  * Updated test documentation to reflect the new model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->