### PR TITLE
fix(genai): clarify auth error and warn on gemini-3-pro-image-preview region

### DIFF
--- a/src/agents/image_genai_agent.ts
+++ b/src/agents/image_genai_agent.ts
@@ -80,16 +80,23 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
   const apiKey = config?.apiKey;
 
   const ai = params.vertexai_project
-    ? new GoogleGenAI({
-        vertexai: true,
-        project: params.vertexai_project,
-        location: params.vertexai_location ?? "us-central1",
-      })
+    ? (() => {
+        const location = params.vertexai_location ?? "us-central1";
+        if (model === "gemini-3-pro-image-preview" && location !== "global") {
+          GraphAILogger.warn(
+            `imageGenAIAgent: model "${model}" on Vertex AI is only available in location "global", but got "${location}". Set imageParams.vertexai_location to "global".`,
+          );
+        }
+        return new GoogleGenAI({ vertexai: true, project: params.vertexai_project, location });
+      })()
     : (() => {
         if (!apiKey) {
-          throw new Error("Google GenAI API key is required (GEMINI_API_KEY)", {
-            cause: apiKeyMissingError("imageGenAIAgent", imageAction, "GEMINI_API_KEY"),
-          });
+          throw new Error(
+            "Google GenAI authentication is required. Either set GEMINI_API_KEY (Gemini API) or specify imageParams.vertexai_project (Vertex AI). See docs/vertexai_en.md or docs/vertexai_ja.md.",
+            {
+              cause: apiKeyMissingError("imageGenAIAgent", imageAction, "GEMINI_API_KEY"),
+            },
+          );
         }
         return new GoogleGenAI({ apiKey });
       })();

--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -262,9 +262,12 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
         })
       : (() => {
           if (!apiKey) {
-            throw new Error("Google GenAI API key is required (GEMINI_API_KEY)", {
-              cause: apiKeyMissingError("movieGenAIAgent", imageAction, "GEMINI_API_KEY"),
-            });
+            throw new Error(
+              "Google GenAI authentication is required. Either set GEMINI_API_KEY (Gemini API) or specify movieParams.vertexai_project (Vertex AI). See docs/vertexai_en.md or docs/vertexai_ja.md.",
+              {
+                cause: apiKeyMissingError("movieGenAIAgent", imageAction, "GEMINI_API_KEY"),
+              },
+            );
           }
           return new GoogleGenAI({ apiKey });
         })();


### PR DESCRIPTION
## Summary

Vertex AI 利用時のつまずきポイント2点を改善。

1. **#2 認証エラーメッセージの改善** (`image_genai_agent.ts` / `movie_genai_agent.ts`)
   - 現状: \`vertexai_project\` 未指定 + \`GEMINI_API_KEY\` 未設定で \"Google GenAI API key is required (GEMINI_API_KEY)\" のみ
   - 変更後: Vertex AI 経路の存在も明記し、docs/vertexai_*.md への誘導を追加
2. **#3 \`gemini-3-pro-image-preview\` の region 制約 warn** (`image_genai_agent.ts`)
   - Vertex AI 経由で同モデルは \`global\` リージョンのみ対応（[GCP docs 2026-02-04 時点](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/3-pro-image)）
   - \`vertexai_location\` がデフォルトの \`us-central1\` のままだと失敗するため、warn を出して \`global\` への切替を促す

## Items to Confirm / Review

- 認証エラーメッセージ文言: 英語のみで OK か（他のエラーは英語のみが揃っているので合わせた）
- region warn: 対象モデルを \`gemini-3-pro-image-preview\` だけに絞っている。他の Gemini 画像モデル (\`gemini-2.5-flash-image\`, \`gemini-3.1-flash-image-preview\`) も \`global\` 限定になる可能性があるが、現時点の docs では明記されていないので一旦保留
- 実際に Vertex AI で再現テストはしていない（手元に GCP プロジェクトないため）。動作検証していただけると安心です
- Movie 側 (\`movie_genai_agent.ts\`) には region warn を入れていない（Veo は \`us-central1\` 等で動く前提）。必要なら追加します