### PR TITLE
feat(replicate): add hailuo-2.3, happyhorse-1.0, pixverse-v5 movie models

### DIFF
--- a/scripts/test/test_replicate_new_movies.json
+++ b/scripts/test/test_replicate_new_movies.json
@@ -32,13 +32,6 @@
       "movieParams": { "model": "minimax/hailuo-2.3" }
     },
     {
-      "id": "hailuo-23-fast",
-      "text": "minimax/hailuo-2.3-fast",
-      "duration": 6,
-      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
-      "movieParams": { "model": "minimax/hailuo-2.3-fast" }
-    },
-    {
       "id": "pixverse-v5",
       "text": "pixverse/pixverse-v5",
       "duration": 5,

--- a/scripts/test/test_replicate_new_movies.json
+++ b/scripts/test/test_replicate_new_movies.json
@@ -1,0 +1,49 @@
+{
+  "$mulmocast": { "version": "1.1" },
+  "movieParams": {
+    "provider": "replicate"
+  },
+  "audioParams": { "bgmVolume": 0 },
+  "captionParams": { "lang": "en" },
+  "lang": "en",
+  "title": "Replicate New Movie Models Showcase",
+  "beats": [
+    {
+      "text": "PROMPT: a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "image": {
+        "type": "textSlide",
+        "slide": {
+          "title": "PROMPT: a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses"
+        }
+      }
+    },
+    {
+      "id": "alibaba-happyhorse",
+      "text": "alibaba/happyhorse-1.0",
+      "duration": 5,
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "movieParams": { "model": "alibaba/happyhorse-1.0" }
+    },
+    {
+      "id": "hailuo-23",
+      "text": "minimax/hailuo-2.3",
+      "duration": 6,
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "movieParams": { "model": "minimax/hailuo-2.3" }
+    },
+    {
+      "id": "hailuo-23-fast",
+      "text": "minimax/hailuo-2.3-fast",
+      "duration": 6,
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "movieParams": { "model": "minimax/hailuo-2.3-fast" }
+    },
+    {
+      "id": "pixverse-v5",
+      "text": "pixverse/pixverse-v5",
+      "duration": 5,
+      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
+      "movieParams": { "model": "pixverse/pixverse-v5" }
+    }
+  ]
+}

--- a/scripts/test/test_replicate_new_movies.json
+++ b/scripts/test/test_replicate_new_movies.json
@@ -37,6 +37,14 @@
       "duration": 5,
       "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
       "movieParams": { "model": "pixverse/pixverse-v5" }
+    },
+    {
+      "id": "hailuo-23-fast",
+      "text": "minimax/hailuo-2.3-fast (i2v: starts from a generated still image)",
+      "duration": 6,
+      "imagePrompt": "a woman wearing dark sunglasses standing on a busy Tokyo street at night, neon reflections, cinematic still",
+      "moviePrompt": "the woman starts walking forward, neon reflections shimmer on the wet pavement",
+      "movieParams": { "model": "minimax/hailuo-2.3-fast" }
     }
   ]
 }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -162,6 +162,11 @@ export const movieReplicateAgent: AgentFunction<ReplicateMovieAgentParams, Agent
       cause: agentGenerationError("movieReplicateAgent", imageAction, unsupportedModelTarget),
     });
   }
+  if (provider2MovieAgent.replicate.modelParams[model].start_image_required && !imagePath) {
+    throw new Error(`Model ${model} requires a start image (image-to-video only)`, {
+      cause: agentGenerationError("movieReplicateAgent", imageAction, unsupportedModelTarget),
+    });
+  }
   const duration = getModelDuration("replicate", model, params.duration);
 
   if (duration === undefined || !provider2MovieAgent.replicate.modelParams[model].durations.includes(duration)) {

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -301,6 +301,10 @@ export const provider2MovieAgent = {
         audio: { mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
         price_per_sec: 0.3,
       },
+      // TODO: price_per_sec for the models below is a coarse approximation.
+      // Actual Replicate pricing varies by resolution / duration / quality and
+      // cannot be expressed as a single per-second number. Verify each model at
+      // https://replicate.com/<owner>/<model> when this field starts being consumed.
       "alibaba/happyhorse-1.0": {
         durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -91,6 +91,7 @@ type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_M
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
+  start_image_required?: boolean;
   last_image?: string;
   reference_images_param?: string;
   audio: MovieAudioSpec;
@@ -315,6 +316,7 @@ export const provider2MovieAgent = {
       "minimax/hailuo-2.3-fast": {
         durations: [6, 10],
         start_image: "first_frame_image",
+        start_image_required: true,
         audio: { mode: AUDIO_MODE_NEVER },
         price_per_sec: 0.06,
       },

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -135,6 +135,10 @@ export const provider2MovieAgent = {
       "runwayml/gen-4.5",
       "kwaivgi/kling-v3-omni-video",
       "kwaivgi/kling-v3-video",
+      "alibaba/happyhorse-1.0",
+      "minimax/hailuo-2.3",
+      "minimax/hailuo-2.3-fast",
+      "pixverse/pixverse-v5",
     ],
     modelParams: {
       "bytedance/seedance-1-lite": {
@@ -295,6 +299,31 @@ export const provider2MovieAgent = {
         reference_images_param: "reference_images",
         audio: { mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
         price_per_sec: 0.3,
+      },
+      "alibaba/happyhorse-1.0": {
+        durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        start_image: "image",
+        audio: { mode: AUDIO_MODE_NEVER },
+        price_per_sec: 0.05,
+      },
+      "minimax/hailuo-2.3": {
+        durations: [6, 10],
+        start_image: "first_frame_image",
+        audio: { mode: AUDIO_MODE_NEVER },
+        price_per_sec: 0.1,
+      },
+      "minimax/hailuo-2.3-fast": {
+        durations: [6, 10],
+        start_image: "first_frame_image",
+        audio: { mode: AUDIO_MODE_NEVER },
+        price_per_sec: 0.06,
+      },
+      "pixverse/pixverse-v5": {
+        durations: [5, 8],
+        start_image: "image",
+        last_image: "last_frame_image",
+        audio: { mode: AUDIO_MODE_NEVER },
+        price_per_sec: 0.12,
       },
     } as Record<ReplicateModel, ReplicateMovieModelParams>,
   },

--- a/test/agents/test_movie_replicate_agent.ts
+++ b/test/agents/test_movie_replicate_agent.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert";
+import type { GraphAI } from "graphai";
+import { movieReplicateAgent } from "../../src/agents/movie_replicate_agent.js";
+
+const baseParams = {
+  config: { apiKey: "fake-key-not-used" },
+  filterParams: {},
+  debugInfo: {
+    verbose: false,
+    nodeId: "",
+    state: "",
+    retry: 0,
+    subGraphs: new Map<string, GraphAI>(),
+  },
+};
+
+const canvasSize = { width: 1024, height: 1024 };
+
+test("movieReplicateAgent throws when start_image_required model is called without imagePath", async () => {
+  await assert.rejects(
+    () =>
+      movieReplicateAgent({
+        ...baseParams,
+        namedInputs: { prompt: "test prompt", movieFile: "unused-movie-file.mp4" },
+        params: { model: "minimax/hailuo-2.3-fast", canvasSize, duration: 6 },
+      }),
+    (err: Error) => err.message.includes("requires a start image"),
+    "expected i2v-only validation error",
+  );
+});
+
+test("movieReplicateAgent passes the start_image_required gate when imagePath is provided", async () => {
+  // Same i2v-only model, but with an imagePath supplied. The gate must let
+  // execution proceed; readFileSync then fails on the bogus path, which proves
+  // we got past the gate without hitting the Replicate API.
+  await assert.rejects(
+    () =>
+      movieReplicateAgent({
+        ...baseParams,
+        namedInputs: {
+          prompt: "test prompt",
+          imagePath: "./nonexistent-test-image.png",
+          movieFile: "unused-movie-file.mp4",
+        },
+        params: { model: "minimax/hailuo-2.3-fast", canvasSize, duration: 6 },
+      }),
+    (err: Error) => !err.message.includes("requires a start image"),
+    "gate should pass when imagePath is provided; agent fails for an unrelated reason",
+  );
+});


### PR DESCRIPTION
## Summary

Replicate movie provider に新規モデル4つを追加。既存 agent contract (\`prompt + duration + start_image + aspect_ratio\`) にそのまま乗るため、\`provider2MovieAgent.replicate.modelParams\` のエントリ追加のみ。

| モデル | durations (sec) | start_image | last_image | audio | 単価/sec | t2v | i2v |
|---|---|---|---|---|---|---|---|
| \`alibaba/happyhorse-1.0\` | 3-15 | \`image\` | – | NEVER | $0.05 | ✅ | ✅ |
| \`minimax/hailuo-2.3\` | 6, 10 | \`first_frame_image\` | – | NEVER | $0.10 | ✅ | ✅ |
| \`minimax/hailuo-2.3-fast\` | 6, 10 | \`first_frame_image\` | – | NEVER | $0.06 | ❌ | ✅ |
| \`pixverse/pixverse-v5\` | 5, 8 | \`image\` | \`last_frame_image\` | NEVER | $0.12 | ✅ | ✅ |

## Sample

\`scripts/test/test_replicate_new_movies.json\` — 4 ビートで上記モデルを比較できる showcase script (注: hailuo-2.3-fast は i2v 専用なので moviePrompt のみだと 422 エラーになる。サンプル内の hailuo-2.3-fast は first frame image 付きでテスト想定)

実は最終サンプルでは hailuo-2.3-fast を t2v として書いてしまっています。次のreviewで修正するか、user 側で実行時に first frame image を追加する想定です。

## Verification

- ✅ \`minimax/hailuo-2.3\` t2v: 1.4MB MP4 出力 (122秒)
- ✅ \`alibaba/happyhorse-1.0\` t2v + \`pixverse/pixverse-v5\` t2v 並列実行: 合算 2.6MB MP4 出力 (194秒)
- ⚠️ \`minimax/hailuo-2.3-fast\` は i2v 専用 (\`first_frame_image\` required) なので t2v テストはスキップ。同じ agent コードパスを通るため動くはず

## Items to Confirm / Review

- 単価は Replicate ページから読み取った推定値。正確な値を確認するか、いっそ price_per_sec を null 許容にするか
- \`hailuo-2.3-fast\` は実質 i2v 専用。schema 上 \`required: [prompt, first_frame_image]\`。modelParams に「first_frame_image required」フラグを足して agent 側で warn を出すべきか?
- サンプル内 hailuo-2.3-fast を t2v として記述しているのは矛盾しているので、別 PR でそこも整理予定 (もしくは本 PR で修正)