### PR TITLE
Replicate movie: i2v gate, tests, and sample fixes (#1364 followups)

### DIFF
--- a/scripts/test/test_replicate_new_movies.json
+++ b/scripts/test/test_replicate_new_movies.json
@@ -32,13 +32,6 @@
       "movieParams": { "model": "minimax/hailuo-2.3" }
     },
     {
-      "id": "hailuo-23-fast",
-      "text": "minimax/hailuo-2.3-fast",
-      "duration": 6,
-      "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
-      "movieParams": { "model": "minimax/hailuo-2.3-fast" }
-    },
-    {
       "id": "pixverse-v5",
       "text": "pixverse/pixverse-v5",
       "duration": 5,

--- a/scripts/test/test_replicate_new_movies.json
+++ b/scripts/test/test_replicate_new_movies.json
@@ -37,6 +37,14 @@
       "duration": 5,
       "moviePrompt": "a woman is walking through a busy Tokyo street at night, she is wearing dark sunglasses",
       "movieParams": { "model": "pixverse/pixverse-v5" }
+    },
+    {
+      "id": "hailuo-23-fast",
+      "text": "minimax/hailuo-2.3-fast (i2v: starts from a generated still image)",
+      "duration": 6,
+      "imagePrompt": "a woman wearing dark sunglasses standing on a busy Tokyo street at night, neon reflections, cinematic still",
+      "moviePrompt": "the woman starts walking forward, neon reflections shimmer on the wet pavement",
+      "movieParams": { "model": "minimax/hailuo-2.3-fast" }
     }
   ]
 }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -162,6 +162,11 @@ export const movieReplicateAgent: AgentFunction<ReplicateMovieAgentParams, Agent
       cause: agentGenerationError("movieReplicateAgent", imageAction, unsupportedModelTarget),
     });
   }
+  if (provider2MovieAgent.replicate.modelParams[model].start_image_required && !imagePath) {
+    throw new Error(`Model ${model} requires a start image (image-to-video only)`, {
+      cause: agentGenerationError("movieReplicateAgent", imageAction, unsupportedModelTarget),
+    });
+  }
   const duration = getModelDuration("replicate", model, params.duration);
 
   if (duration === undefined || !provider2MovieAgent.replicate.modelParams[model].durations.includes(duration)) {

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -301,6 +301,10 @@ export const provider2MovieAgent = {
         audio: { mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
         price_per_sec: 0.3,
       },
+      // TODO: price_per_sec for the models below is a coarse approximation.
+      // Actual Replicate pricing varies by resolution / duration / quality and
+      // cannot be expressed as a single per-second number. Verify each model at
+      // https://replicate.com/<owner>/<model> when this field starts being consumed.
       "alibaba/happyhorse-1.0": {
         durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -91,6 +91,7 @@ type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_M
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
+  start_image_required?: boolean;
   last_image?: string;
   reference_images_param?: string;
   audio: MovieAudioSpec;
@@ -315,6 +316,7 @@ export const provider2MovieAgent = {
       "minimax/hailuo-2.3-fast": {
         durations: [6, 10],
         start_image: "first_frame_image",
+        start_image_required: true,
         audio: { mode: AUDIO_MODE_NEVER },
         price_per_sec: 0.06,
       },

--- a/test/agents/test_movie_replicate_agent.ts
+++ b/test/agents/test_movie_replicate_agent.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert";
+import type { GraphAI } from "graphai";
+import { movieReplicateAgent } from "../../src/agents/movie_replicate_agent.js";
+
+const baseParams = {
+  config: { apiKey: "fake-key-not-used" },
+  filterParams: {},
+  debugInfo: {
+    verbose: false,
+    nodeId: "",
+    state: "",
+    retry: 0,
+    subGraphs: new Map<string, GraphAI>(),
+  },
+};
+
+const canvasSize = { width: 1024, height: 1024 };
+
+test("movieReplicateAgent throws when start_image_required model is called without imagePath", async () => {
+  await assert.rejects(
+    () =>
+      movieReplicateAgent({
+        ...baseParams,
+        namedInputs: { prompt: "test prompt", movieFile: "unused-movie-file.mp4" },
+        params: { model: "minimax/hailuo-2.3-fast", canvasSize, duration: 6 },
+      }),
+    (err: Error) => err.message.includes("requires a start image"),
+    "expected i2v-only validation error",
+  );
+});
+
+test("movieReplicateAgent passes the start_image_required gate when imagePath is provided", async () => {
+  // Same i2v-only model, but with an imagePath supplied. The gate must let
+  // execution proceed; readFileSync then fails on the bogus path, which proves
+  // we got past the gate without hitting the Replicate API.
+  await assert.rejects(
+    () =>
+      movieReplicateAgent({
+        ...baseParams,
+        namedInputs: {
+          prompt: "test prompt",
+          imagePath: "./nonexistent-test-image.png",
+          movieFile: "unused-movie-file.mp4",
+        },
+        params: { model: "minimax/hailuo-2.3-fast", canvasSize, duration: 6 },
+      }),
+    (err: Error) => !err.message.includes("requires a start image"),
+    "gate should pass when imagePath is provided; agent fails for an unrelated reason",
+  );
+});


### PR DESCRIPTION
## Summary

PR #1364 のレビュー中に判明した、Replicate 動画モデルのうち i2v 専用モデル (`minimax/hailuo-2.3-fast`) の取り扱い周りを整える follow-up PR。

- `ReplicateMovieModelParams` に `start_image_required` フラグを追加し、`movieReplicateAgent` 冒頭で早期バリデーション
- 該当モデル (`minimax/hailuo-2.3-fast`) に `start_image_required: true` を設定
- ユニットテスト追加（実 API を呼ばずに検証ロジックを保証）
- showcase script を修正（t2v として書かれていたバグ → `imagePrompt` から生成した still を start frame に使う i2v 構成に置換）
- `price_per_sec` が粗近似値であることを TODO コメントで明記

## Items to Confirm / Review

- フィールド名 `start_image_required` と置き場所 (`ReplicateMovieModelParams` 内) で問題ないか
- バリデーションのエラーメッセージ `Model X requires a start image (image-to-video only)` は適切か
- `price_per_sec` の TODO は別 issue 化するなら本 PR から外すべきか（実態は解像度別・duration 別・quality 別で PR 値と大きく乖離している。詳細はコミット \`934432ed\` 参照）
- showcase の i2v ビートで使っている imagePrompt / moviePrompt の内容（夜の東京シーン）が妥当か

## User Prompt

PR #1364 のレビュー＆テスト過程で判明した複数の改善点を 1 つの PR にまとめたもの:

- showcase script で i2v 専用モデルが t2v ビートとして書かれており実行すると 422 エラーになる → 削除
- i2v 必須を型/コードレベルで表現したい → \`start_image_required\` を追加し agent でバリデート
- \`price_per_sec\` の正確値が解像度・duration によって変動するため単一 number で表現困難 → TODO コメントで明記
- i2v 動作の回帰防止用ユニットテストと、i2v 動作デモ用 showcase ビートの両方が欲しい

## Implementation Details

5 コミットに分割:

1. \`bfb21f61\` \`fix(scripts): remove hailuo-2.3-fast t2v beat from sample\`
2. \`fe30cfd2\` \`feat(replicate): enforce start_image_required for i2v-only movie models\`
3. \`934432ed\` \`docs(replicate): note price_per_sec is a coarse approximation\`
4. \`33f85737\` \`test(replicate): cover start_image_required validation in movie agent\` — \`test/agents/test_movie_replicate_agent.ts\` 新規。i2v 専用モデルの検証 2 ケース（API 通信なし）
5. \`a2a48b7c\` \`docs(scripts): demonstrate hailuo-2.3-fast i2v flow in showcase\` — \`imagePrompt\` から still 生成 → \`moviePrompt\` で i2v 動画化する beat を追加

## Verification

- \`yarn lint\` / \`yarn build\`: 0 errors（既存 warning のみ、本 PR は追加なし）
- \`yarn ci_test\`: 1053 tests / 1049 pass / 0 fail。\`test_movie_replicate_agent.ts\` カバレッジ 100%
- e2e: \`yarn run movie scripts/test/test_replicate_new_movies.json\`
  - 4 ビート (3 t2v + 1 i2v) 全部成功、最終 MP4 合成 OK
  - hailuo-2.3-fast の i2v 出力: 1152×768, 5.875s, h264

🤖 Generated with [Claude Code](https://claude.com/claude-code)