### PR TITLE
fix: reject deprecated DALL-E 2/3 models with migration hint

### DIFF
--- a/scripts/test/test_images.json
+++ b/scripts/test/test_images.json
@@ -21,10 +21,10 @@
       }
     },
     {
-      "text": "Image with Dall-E 3",
+      "text": "Image with OpenAI gpt-image-1-mini",
       "imagePrompt": "Blue sky, a flock of birds",
       "imageParams": {
-        "model": "dall-e-3",
+        "model": "gpt-image-1-mini",
         "style": "anime-style",
         "provider": "openai"
       }

--- a/scripts/test/test_images_dalle_deprecated.json
+++ b/scripts/test/test_images_dalle_deprecated.json
@@ -10,14 +10,14 @@
   },
   "beats": [
     {
-      "text": "Deprecated model dall-e-2 should fail",
+      "text": "Compatibility probe: dall-e-2 (no longer available on OpenAI; expects model_not_found from API)",
       "imagePrompt": "Blue sky, a flock of birds",
       "imageParams": {
         "model": "dall-e-2"
       }
     },
     {
-      "text": "Deprecated model dall-e-3 should fail",
+      "text": "Compatibility probe: dall-e-3 (no longer available on OpenAI; expects model_not_found from API)",
       "imagePrompt": "Blue sky, a flock of birds",
       "imageParams": {
         "model": "dall-e-3"

--- a/scripts/test/test_images_dalle_deprecated.json
+++ b/scripts/test/test_images_dalle_deprecated.json
@@ -1,0 +1,27 @@
+{
+  "$mulmocast": {
+    "version": "1.1"
+  },
+  "lang": "en",
+  "title": "Test Deprecated OpenAI Image Models",
+  "imageParams": {
+    "provider": "openai",
+    "style": "Photorealistic-style"
+  },
+  "beats": [
+    {
+      "text": "Deprecated model dall-e-2 should fail",
+      "imagePrompt": "Blue sky, a flock of birds",
+      "imageParams": {
+        "model": "dall-e-2"
+      }
+    },
+    {
+      "text": "Deprecated model dall-e-3 should fail",
+      "imagePrompt": "Blue sky, a flock of birds",
+      "imageParams": {
+        "model": "dall-e-3"
+      }
+    }
+  ]
+}

--- a/scripts/test/test_images_dalle_deprecated.json
+++ b/scripts/test/test_images_dalle_deprecated.json
@@ -10,14 +10,14 @@
   },
   "beats": [
     {
-      "text": "Compatibility probe: dall-e-2 (no longer available on OpenAI; expects model_not_found from API)",
+      "text": "dall-e-2 is deprecated; mulmocast rejects this with a migration hint before calling OpenAI",
       "imagePrompt": "Blue sky, a flock of birds",
       "imageParams": {
         "model": "dall-e-2"
       }
     },
     {
-      "text": "Compatibility probe: dall-e-3 (no longer available on OpenAI; expects model_not_found from API)",
+      "text": "dall-e-3 is deprecated; mulmocast rejects this with a migration hint before calling OpenAI",
       "imagePrompt": "Blue sky, a flock of birds",
       "imageParams": {
         "model": "dall-e-3"

--- a/scripts/test/test_movie.json
+++ b/scripts/test/test_movie.json
@@ -12,7 +12,7 @@
   },
   "imageParams": {
     "provider": "openai",
-    "model": "dall-e-3",
+    "model": "gpt-image-1-mini",
     "style": "Photo realistic, cinematic style.",
     "images": {
       "optimus": {

--- a/scripts/test/test_movie_dalle_deprecated.json
+++ b/scripts/test/test_movie_dalle_deprecated.json
@@ -17,7 +17,7 @@
   },
   "beats": [
     {
-      "text": "Deprecated model on movie flow should fail",
+      "text": "Compatibility probe: deprecated dall-e-3 on movie flow (expects model_not_found from OpenAI API)",
       "imagePrompt": "A rocket on the launch pad at dusk.",
       "moviePrompt": "Rocket lifts off.",
       "duration": 5

--- a/scripts/test/test_movie_dalle_deprecated.json
+++ b/scripts/test/test_movie_dalle_deprecated.json
@@ -1,0 +1,26 @@
+{
+  "$mulmocast": {
+    "version": "1.1"
+  },
+  "lang": "en",
+  "movieParams": {
+    "provider": "google"
+  },
+  "canvasSize": {
+    "width": 720,
+    "height": 1280
+  },
+  "imageParams": {
+    "provider": "openai",
+    "model": "dall-e-3",
+    "style": "Photo realistic, cinematic style."
+  },
+  "beats": [
+    {
+      "text": "Deprecated model on movie flow should fail",
+      "imagePrompt": "A rocket on the launch pad at dusk.",
+      "moviePrompt": "Rocket lifts off.",
+      "duration": 5
+    }
+  ]
+}

--- a/scripts/test/test_movie_dalle_deprecated.json
+++ b/scripts/test/test_movie_dalle_deprecated.json
@@ -17,7 +17,7 @@
   },
   "beats": [
     {
-      "text": "Compatibility probe: deprecated dall-e-3 on movie flow (expects model_not_found from OpenAI API)",
+      "text": "dall-e-3 on movie flow is deprecated; mulmocast rejects upfront with a migration hint",
       "imagePrompt": "A rocket on the launch pad at dusk.",
       "moviePrompt": "Rocket lifts off.",
       "duration": 5

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -16,6 +16,11 @@ import {
 } from "../utils/error_cause.js";
 import type { AgentBufferResult, OpenAIImageOptions, OpenAIImageAgentParams, OpenAIImageAgentInputs, OpenAIImageAgentConfig } from "../types/agent.js";
 
+const deprecatedModelHints: Record<string, string> = {
+  "dall-e-2": "Use 'gpt-image-1' or another supported model.",
+  "dall-e-3": "Use 'gpt-image-1' or another supported model.",
+};
+
 // https://platform.openai.com/docs/guides/image-generation
 export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBufferResult, OpenAIImageAgentInputs, OpenAIImageAgentConfig> = async ({
   namedInputs,
@@ -83,6 +88,11 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
       }
     } catch (error) {
       GraphAILogger.info("Failed to generate image:", (error as Error).message);
+      if (deprecatedModelHints[model]) {
+        throw new Error(`OpenAI image model "${model}" is no longer available. ${deprecatedModelHints[model]}`, {
+          cause: error,
+        });
+      }
       if (error instanceof AuthenticationError) {
         throw new Error("Failed to generate image: 401 Incorrect API key provided with OpenAI", {
           cause: agentIncorrectAPIKeyError("imageOpenaiAgent", imageAction, imageFileTarget),

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -13,17 +13,22 @@ import {
   agentInvalidResponseError,
   imageAction,
   imageFileTarget,
+  unsupportedModelTarget,
 } from "../utils/error_cause.js";
 import type { AgentBufferResult, OpenAIImageOptions, OpenAIImageAgentParams, OpenAIImageAgentInputs, OpenAIImageAgentConfig } from "../types/agent.js";
 
-const deprecatedModelHints: Record<string, string> = {
+type DeprecatedModel = "dall-e-2" | "dall-e-3";
+
+const deprecatedModelHints: Record<DeprecatedModel, string> = {
   "dall-e-2": "Use 'gpt-image-1' or another supported model.",
   "dall-e-3": "Use 'gpt-image-1' or another supported model.",
 };
 
+const isDeprecatedModel = (model: string): model is DeprecatedModel => model in deprecatedModelHints;
+
 export const buildDeprecatedModelMessage = (model: string): string | null => {
-  const hint = deprecatedModelHints[model];
-  return hint ? `OpenAI image model "${model}" is no longer available. ${hint}` : null;
+  if (!isDeprecatedModel(model)) return null;
+  return `OpenAI image model "${model}" is no longer available. ${deprecatedModelHints[model]}`;
 };
 
 // https://platform.openai.com/docs/guides/image-generation
@@ -43,7 +48,9 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
   const model = params.model ?? provider2ImageAgent["openai"].defaultModel;
   const deprecatedMessage = buildDeprecatedModelMessage(model);
   if (deprecatedMessage) {
-    throw new Error(deprecatedMessage);
+    throw new Error(deprecatedMessage, {
+      cause: agentGenerationError("imageOpenaiAgent", imageAction, unsupportedModelTarget),
+    });
   }
   const openai = createOpenAIClient({ apiKey, baseURL, apiVersion });
   const size = (() => {

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -128,7 +128,7 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
     return { buffer: Buffer.from(image_base64, "base64") };
   }
 
-  // For dall-e-3
+  // URL response handling (legacy OpenAI image API response format)
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`, {

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -41,6 +41,10 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
     });
   }
   const model = params.model ?? provider2ImageAgent["openai"].defaultModel;
+  const deprecatedMessage = buildDeprecatedModelMessage(model);
+  if (deprecatedMessage) {
+    throw new Error(deprecatedMessage);
+  }
   const openai = createOpenAIClient({ apiKey, baseURL, apiVersion });
   const size = (() => {
     if (gptImages.includes(model)) {
@@ -104,12 +108,6 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
         });
       }
       if (error instanceof APIError) {
-        if (error.code === "model_not_found") {
-          const deprecatedMessage = buildDeprecatedModelMessage(model);
-          if (deprecatedMessage) {
-            throw new Error(deprecatedMessage, { cause: error });
-          }
-        }
         if (error.code && error.type) {
           throw new Error("Failed to generate image with OpenAI", {
             cause: openAIAgentGenerationError("imageOpenaiAgent", imageAction, error.code, error.type),

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -21,6 +21,11 @@ const deprecatedModelHints: Record<string, string> = {
   "dall-e-3": "Use 'gpt-image-1' or another supported model.",
 };
 
+export const buildDeprecatedModelMessage = (model: string): string | null => {
+  const hint = deprecatedModelHints[model];
+  return hint ? `OpenAI image model "${model}" is no longer available. ${hint}` : null;
+};
+
 // https://platform.openai.com/docs/guides/image-generation
 export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBufferResult, OpenAIImageAgentInputs, OpenAIImageAgentConfig> = async ({
   namedInputs,
@@ -88,11 +93,6 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
       }
     } catch (error) {
       GraphAILogger.info("Failed to generate image:", (error as Error).message);
-      if (deprecatedModelHints[model]) {
-        throw new Error(`OpenAI image model "${model}" is no longer available. ${deprecatedModelHints[model]}`, {
-          cause: error,
-        });
-      }
       if (error instanceof AuthenticationError) {
         throw new Error("Failed to generate image: 401 Incorrect API key provided with OpenAI", {
           cause: agentIncorrectAPIKeyError("imageOpenaiAgent", imageAction, imageFileTarget),
@@ -104,6 +104,12 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
         });
       }
       if (error instanceof APIError) {
+        if (error.code === "model_not_found") {
+          const deprecatedMessage = buildDeprecatedModelMessage(model);
+          if (deprecatedMessage) {
+            throw new Error(deprecatedMessage, { cause: error });
+          }
+        }
         if (error.code && error.type) {
           throw new Error("Failed to generate image with OpenAI", {
             cause: openAIAgentGenerationError("imageOpenaiAgent", imageAction, error.code, error.type),

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -3,7 +3,7 @@ import path from "path";
 import { AgentFunction, AgentFunctionInfo, GraphAILogger } from "graphai";
 import { toFile, AuthenticationError, RateLimitError, APIError } from "openai";
 import { createOpenAIClient } from "../utils/openai_client.js";
-import { provider2ImageAgent, gptImages } from "../types/provider2agent.js";
+import { provider2ImageAgent, gptImages, deprecatedOpenAIImageModelHints, type DeprecatedOpenAIImageModel } from "../types/provider2agent.js";
 import {
   apiKeyMissingError,
   agentGenerationError,
@@ -17,18 +17,11 @@ import {
 } from "../utils/error_cause.js";
 import type { AgentBufferResult, OpenAIImageOptions, OpenAIImageAgentParams, OpenAIImageAgentInputs, OpenAIImageAgentConfig } from "../types/agent.js";
 
-type DeprecatedModel = "dall-e-2" | "dall-e-3";
-
-const deprecatedModelHints: Record<DeprecatedModel, string> = {
-  "dall-e-2": "Use 'gpt-image-1' or another supported model.",
-  "dall-e-3": "Use 'gpt-image-1' or another supported model.",
-};
-
-const isDeprecatedModel = (model: string): model is DeprecatedModel => model in deprecatedModelHints;
+const isDeprecatedOpenAIImageModel = (model: string): model is DeprecatedOpenAIImageModel => model in deprecatedOpenAIImageModelHints;
 
 export const buildDeprecatedModelMessage = (model: string): string | null => {
-  if (!isDeprecatedModel(model)) return null;
-  return `OpenAI image model "${model}" is no longer available. ${deprecatedModelHints[model]}`;
+  if (!isDeprecatedOpenAIImageModel(model)) return null;
+  return `OpenAI image model "${model}" is no longer available. ${deprecatedOpenAIImageModelHints[model]}`;
 };
 
 // https://platform.openai.com/docs/guides/image-generation

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -52,7 +52,6 @@ const defaultTextSlideStyles = [
   "td, th { padding: 8px }",
   "tr:nth-child(even) { background-color: #eee }",
 ];
-const unsupportedOpenAIImageModels = new Set(["dall-e-2", "dall-e-3"]);
 
 export const MulmoPresentationStyleMethods = {
   getCanvasSize(presentationStyle: MulmoPresentationStyle): MulmoCanvasDimension {
@@ -125,15 +124,10 @@ export const MulmoPresentationStyleMethods = {
       provider,
       model: agentInfo.defaultModel,
     };
-    const mergedImageParams: MulmoImageParams = { ...defaultImageParams, ...imageParams };
-    userAssert(
-      !(mergedImageParams.provider === "openai" && unsupportedOpenAIImageModels.has(mergedImageParams.model ?? "")),
-      `Unsupported image model: ${mergedImageParams.model}. OpenAI image models 'dall-e-2' and 'dall-e-3' are no longer available. Please use one of: ${provider2ImageAgent.openai.models.join(", ")}`,
-    );
 
     return {
       agent: agentInfo.agentName,
-      imageParams: mergedImageParams,
+      imageParams: { ...defaultImageParams, ...imageParams },
       keyName: agentInfo.keyName,
     };
   },

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -52,6 +52,7 @@ const defaultTextSlideStyles = [
   "td, th { padding: 8px }",
   "tr:nth-child(even) { background-color: #eee }",
 ];
+const unsupportedOpenAIImageModels = new Set(["dall-e-2", "dall-e-3"]);
 
 export const MulmoPresentationStyleMethods = {
   getCanvasSize(presentationStyle: MulmoPresentationStyle): MulmoCanvasDimension {
@@ -119,15 +120,20 @@ export const MulmoPresentationStyleMethods = {
       (MulmoPresentationStyleMethods.getText2ImageProvider(imageParams?.provider) as keyof typeof provider2ImageAgent) ?? defaultProviders.text2image;
     const agentInfo = provider2ImageAgent[provider];
 
-    // The default text2image model is gpt-image-1 from OpenAI, and to use it you must have an OpenAI account and have verified your identity. If this is not possible, please specify dall-e-3 as the model.
+    // The default text2image model is gpt-image-1 from OpenAI.
     const defaultImageParams: MulmoImageParams = {
       provider,
       model: agentInfo.defaultModel,
     };
+    const mergedImageParams: MulmoImageParams = { ...defaultImageParams, ...imageParams };
+    userAssert(
+      !(mergedImageParams.provider === "openai" && unsupportedOpenAIImageModels.has(mergedImageParams.model ?? "")),
+      `Unsupported image model: ${mergedImageParams.model}. OpenAI image models 'dall-e-2' and 'dall-e-3' are no longer available. Please use one of: ${provider2ImageAgent.openai.models.join(", ")}`,
+    );
 
     return {
       agent: agentInfo.agentName,
-      imageParams: { ...defaultImageParams, ...imageParams },
+      imageParams: mergedImageParams,
       keyName: agentInfo.keyName,
     };
   },
@@ -172,8 +178,7 @@ export const MulmoPresentationStyleMethods = {
     const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(presentationStyle);
     if (imageAgentInfo.imageParams.provider === "openai") {
       // NOTE: Here are the rate limits of OpenAI's text2image API (1token = 32x32 patch).
-      // dall-e-3: 7,500 RPM、15 images per minute (4 images for max resolution)
-      // gpt-image-1：3,000,000 TPM、150 images per minute
+      // gpt-image-1: 3,000,000 TPM, 150 images per minute
       if (imageAgentInfo.imageParams.model === provider2ImageAgent.openai.defaultModel) {
         return 16;
       }

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -52,7 +52,7 @@ export const provider2ImageAgent = {
   openai: {
     agentName: "imageOpenaiAgent",
     defaultModel: "gpt-image-1",
-    models: ["dall-e-3", ...gptImages],
+    models: [...gptImages],
     keyName: "OPENAI_API_KEY",
     baseURLKeyName: "OPENAI_BASE_URL",
   },

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -48,6 +48,15 @@ export const provider2TTSAgent = {
 
 export const gptImages = ["gpt-image-2", "gpt-image-1.5", "gpt-image-1", "gpt-image-1-mini"];
 
+const supportedOpenAIImageReplacementHint = "Use 'gpt-image-1' or another supported model.";
+
+export const deprecatedOpenAIImageModelHints = {
+  "dall-e-2": supportedOpenAIImageReplacementHint,
+  "dall-e-3": supportedOpenAIImageReplacementHint,
+} as const satisfies Record<string, string>;
+
+export type DeprecatedOpenAIImageModel = keyof typeof deprecatedOpenAIImageModelHints;
+
 export const provider2ImageAgent = {
   openai: {
     agentName: "imageOpenaiAgent",

--- a/test/actions/test_image_preprocess_agent.ts
+++ b/test/actions/test_image_preprocess_agent.ts
@@ -29,7 +29,7 @@ test("imagePreprocessAgent - basic functionality", async () => {
     prompt: "generate image appropriate for the text. text: Test beat text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -45,7 +45,7 @@ test("imagePreprocessAgent - basic functionality", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -76,7 +76,7 @@ test("imagePreprocessAgent - with movie prompt and text", async () => {
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -111,7 +111,7 @@ test("imagePreprocessAgent - movie prompt only (no image prompt)", async () => {
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -170,7 +170,7 @@ test("imagePreprocessAgent - with imageNames", async () => {
     prompt: "generate image appropriate for the text. text: Test beat text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -186,7 +186,7 @@ test("imagePreprocessAgent - with imageNames", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -219,7 +219,7 @@ test("imagePreprocessAgent - without imageNames (uses all imageRefs)", async () 
     prompt: "generate image appropriate for the text. text: Test beat text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -235,7 +235,7 @@ test("imagePreprocessAgent - without imageNames (uses all imageRefs)", async () 
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -269,7 +269,7 @@ test("imagePreprocessAgent - filters undefined image references", async () => {
     prompt: "generate image appropriate for the text. text: Test beat text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -285,7 +285,7 @@ test("imagePreprocessAgent - filters undefined image references", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -318,7 +318,7 @@ test("imagePreprocessAgent - merges beat and imageAgentInfo imageParams", async 
     prompt: "generate image appropriate for the text. text: Test beat text\nvivid",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3", // From imageAgentInfo
+      model: "gpt-image-1", // From imageAgentInfo
       style: "vivid", // From beat (override)
       moderation: "auto", // From beat (override)
     },
@@ -334,7 +334,7 @@ test("imagePreprocessAgent - merges beat and imageAgentInfo imageParams", async 
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "vivid",
@@ -362,7 +362,7 @@ test("imagePreprocessAgent - empty imageRefs", async () => {
     prompt: "generate image appropriate for the text. text: Test beat text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -378,7 +378,7 @@ test("imagePreprocessAgent - empty imageRefs", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -413,7 +413,7 @@ test("imagePreprocessAgent - with real sample data", async () => {
       prompt: "Blue sky, a flock of birds\n<style>sumie-style",
       imageParams: {
         provider: "openai",
-        model: "dall-e-3", // From imageAgentInfo
+        model: "gpt-image-1", // From imageAgentInfo
         style: "<style>sumie-style", // From beat override
         moderation: "auto", // From imageAgentInfo
       },
@@ -429,7 +429,7 @@ test("imagePreprocessAgent - with real sample data", async () => {
         agent: "imageOpenaiAgent",
         keyName: "OPENAI_API_KEY",
         imageParams: {
-          model: "dall-e-3",
+          model: "gpt-image-1",
           moderation: "auto",
           provider: "openai",
           style: "<style>sumie-style",
@@ -462,7 +462,7 @@ test("imagePreprocessAgent - text only", async () => {
     prompt: "generate image appropriate for the text. text: Only text content\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -478,7 +478,7 @@ test("imagePreprocessAgent - text only", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -510,7 +510,7 @@ test("imagePreprocessAgent - imagePrompt only", async () => {
     prompt: "Only image prompt\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -526,7 +526,7 @@ test("imagePreprocessAgent - imagePrompt only", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -555,7 +555,7 @@ test("imagePreprocessAgent - moviePrompt only", async () => {
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -593,7 +593,7 @@ test("imagePreprocessAgent - text + moviePrompt (no imagePrompt)", async () => {
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -632,7 +632,7 @@ test("imagePreprocessAgent - imagePrompt + moviePrompt (no text)", async () => {
     prompt: "Image prompt\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -648,7 +648,7 @@ test("imagePreprocessAgent - imagePrompt + moviePrompt (no text)", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -680,7 +680,7 @@ test("imagePreprocessAgent - text + imagePrompt + moviePrompt (all three)", asyn
     prompt: "Image prompt\nnatural", // imagePrompt takes precedence over text
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -696,7 +696,7 @@ test("imagePreprocessAgent - text + imagePrompt + moviePrompt (all three)", asyn
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -727,7 +727,7 @@ test("imagePreprocessAgent - no text, no imagePrompt, no moviePrompt", async () 
     prompt: "generate image appropriate for the text. text: undefined\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -743,7 +743,7 @@ test("imagePreprocessAgent - no text, no imagePrompt, no moviePrompt", async () 
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -774,7 +774,7 @@ test("imagePreprocessAgent - with both text and imagePrompt", async () => {
     prompt: "Custom image prompt\nnatural", // imagePrompt takes precedence
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -790,7 +790,7 @@ test("imagePreprocessAgent - with both text and imagePrompt", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -801,7 +801,7 @@ test("imagePreprocessAgent - with both text and imagePrompt", async () => {
   assert.deepStrictEqual(result, expected);
 });
 
-test("imagePreprocessAgent - with imageParams override", async () => {
+test("imagePreprocessAgent - rejects unsupported OpenAI image model", async () => {
   const context = createMockContext();
   const beat = createMockBeat({
     imagePrompt: "A beautiful sunset",
@@ -812,44 +812,15 @@ test("imagePreprocessAgent - with imageParams override", async () => {
     },
   });
 
-  const result = await imagePreprocessAgent({
-    context,
-    beat,
-    index: 21,
-    imageRefs: {},
-  });
-
-  const expected = {
-    imagePath: "/test/images/test_studio/21p.png",
-    referenceImageForMovie: "/test/images/test_studio/21p.png",
-    prompt: "A beautiful sunset\nphotorealistic",
-    beatDuration: undefined,
-    imageAgentInfo: {
-      agent: "imageOpenaiAgent",
-      keyName: "OPENAI_API_KEY",
-      imageParams: {
-        provider: "openai",
-        style: "photorealistic",
-        model: "dall-e-2",
-        moderation: "auto",
-      },
-    },
-    imageParams: {
-      provider: "openai",
-      model: "dall-e-2", // From beat override
-      style: "photorealistic", // From beat override
-      moderation: "auto",
-    },
-    movieFile: undefined,
-    movieAgentInfo: {
-      agent: "movieReplicateAgent",
-      keyName: "REPLICATE_API_TOKEN",
-      movieParams: {},
-    },
-    referenceImages: [],
-  };
-
-  assert.deepStrictEqual(result, expected);
+  await assert.rejects(
+    imagePreprocessAgent({
+      context,
+      beat,
+      index: 21,
+      imageRefs: {},
+    }),
+    /Unsupported image model: dall-e-2/,
+  );
 });
 
 // soundEffectPrompt parameter tests(no movie)
@@ -873,7 +844,7 @@ test("imagePreprocessAgent - with soundEffectPrompt only", async () => {
     prompt: "generate image appropriate for the text. text: Test text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -890,7 +861,7 @@ test("imagePreprocessAgent - with soundEffectPrompt only", async () => {
       keyName: "OPENAI_API_KEY",
 
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -923,7 +894,7 @@ test("imagePreprocessAgent - soundEffectPrompt + imagePrompt", async () => {
     prompt: "A forest scene\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -939,7 +910,7 @@ test("imagePreprocessAgent - soundEffectPrompt + imagePrompt", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -968,7 +939,7 @@ test("imagePreprocessAgent - soundEffectPrompt + moviePrompt (no imagePrompt)", 
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1022,7 +993,7 @@ test("imagePreprocessAgent - soundEffectPrompt + imagePrompt + moviePrompt", asy
     prompt: "A peaceful forest\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1052,7 +1023,7 @@ test("imagePreprocessAgent - soundEffectPrompt + imagePrompt + moviePrompt", asy
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1085,7 +1056,7 @@ test("imagePreprocessAgent - with enableLipSync true", async () => {
     prompt: "generate image appropriate for the text. text: Test text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1104,7 +1075,7 @@ test("imagePreprocessAgent - with enableLipSync true", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1137,7 +1108,7 @@ test("imagePreprocessAgent - enableLipSync + imagePrompt", async () => {
     prompt: "Portrait of a person speaking\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1158,7 +1129,7 @@ test("imagePreprocessAgent - enableLipSync + imagePrompt", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1187,7 +1158,7 @@ test("imagePreprocessAgent - enableLipSync + moviePrompt (no imagePrompt)", asyn
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1231,7 +1202,7 @@ test("imagePreprocessAgent - enableLipSync + imagePrompt + moviePrompt", async (
     prompt: "Close-up of person's face\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1251,7 +1222,7 @@ test("imagePreprocessAgent - enableLipSync + imagePrompt + moviePrompt", async (
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1284,7 +1255,7 @@ test("imagePreprocessAgent - soundEffectPrompt + enableLipSync", async () => {
     prompt: "generate image appropriate for the text. text: Test text\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1304,7 +1275,7 @@ test("imagePreprocessAgent - soundEffectPrompt + enableLipSync", async () => {
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1338,7 +1309,7 @@ test("imagePreprocessAgent - soundEffectPrompt + enableLipSync + imagePrompt", a
     prompt: "Singer performing on stage\nnatural",
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1358,7 +1329,7 @@ test("imagePreprocessAgent - soundEffectPrompt + enableLipSync + imagePrompt", a
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",
@@ -1388,7 +1359,7 @@ test("imagePreprocessAgent - soundEffectPrompt + enableLipSync + moviePrompt (no
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1444,7 +1415,7 @@ test("imagePreprocessAgent - all parameters: soundEffectPrompt + enableLipSync +
   const expected = {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -1474,7 +1445,7 @@ test("imagePreprocessAgent - all parameters: soundEffectPrompt + enableLipSync +
       agent: "imageOpenaiAgent",
       keyName: "OPENAI_API_KEY",
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
         moderation: "auto",
         provider: "openai",
         style: "natural",

--- a/test/actions/test_image_preprocess_agent.ts
+++ b/test/actions/test_image_preprocess_agent.ts
@@ -801,26 +801,55 @@ test("imagePreprocessAgent - with both text and imagePrompt", async () => {
   assert.deepStrictEqual(result, expected);
 });
 
-test("imagePreprocessAgent - rejects unsupported OpenAI image model", async () => {
+test("imagePreprocessAgent - with imageParams override", async () => {
   const context = createMockContext();
   const beat = createMockBeat({
     imagePrompt: "A beautiful sunset",
     imageParams: {
       provider: "openai",
       style: "photorealistic",
-      model: "dall-e-2",
+      model: "gpt-image-1-mini",
     },
   });
 
-  await assert.rejects(
-    imagePreprocessAgent({
-      context,
-      beat,
-      index: 21,
-      imageRefs: {},
-    }),
-    /Unsupported image model: dall-e-2/,
-  );
+  const result = await imagePreprocessAgent({
+    context,
+    beat,
+    index: 21,
+    imageRefs: {},
+  });
+
+  const expected = {
+    imagePath: "/test/images/test_studio/21p.png",
+    referenceImageForMovie: "/test/images/test_studio/21p.png",
+    prompt: "A beautiful sunset\nphotorealistic",
+    beatDuration: undefined,
+    imageAgentInfo: {
+      agent: "imageOpenaiAgent",
+      keyName: "OPENAI_API_KEY",
+      imageParams: {
+        provider: "openai",
+        style: "photorealistic",
+        model: "gpt-image-1-mini",
+        moderation: "auto",
+      },
+    },
+    imageParams: {
+      provider: "openai",
+      model: "gpt-image-1-mini", // From beat override
+      style: "photorealistic", // From beat override
+      moderation: "auto",
+    },
+    movieFile: undefined,
+    movieAgentInfo: {
+      agent: "movieReplicateAgent",
+      keyName: "REPLICATE_API_TOKEN",
+      movieParams: {},
+    },
+    referenceImages: [],
+  };
+
+  assert.deepStrictEqual(result, expected);
 });
 
 // soundEffectPrompt parameter tests(no movie)

--- a/test/actions/test_image_preprocess_agent_plugin.ts
+++ b/test/actions/test_image_preprocess_agent_plugin.ts
@@ -31,7 +31,7 @@ test("imagePreprocessAgent - movie plugin", async () => {
     imageFromMovie: true,
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -84,7 +84,7 @@ test("imagePreprocessAgent - with image plugin (textSlide)", async () => {
     imageFromMovie: false,
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -119,7 +119,7 @@ test("imagePreprocessAgent - with image plugin (markdown)", async () => {
     imageFromMovie: false,
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -177,7 +177,7 @@ test("imagePreprocessAgent - with image plugin (chart)", async () => {
     imageFromMovie: false,
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },
@@ -265,7 +265,7 @@ test("imagePreprocessAgent - with image plugin (mermaid)", async () => {
     imageFromMovie: false,
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },

--- a/test/actions/utils.ts
+++ b/test/actions/utils.ts
@@ -28,7 +28,7 @@ export const createMockContext = (): MulmoStudioContext => ({
   presentationStyle: {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },

--- a/test/actions/utils2.ts
+++ b/test/actions/utils2.ts
@@ -36,7 +36,7 @@ export const createMockContext = (): MulmoStudioContext => ({
   presentationStyle: {
     imageParams: {
       provider: "openai",
-      model: "dall-e-3",
+      model: "gpt-image-1",
       style: "natural",
       moderation: "auto",
     },

--- a/test/agents/test_image_openai_agent.ts
+++ b/test/agents/test_image_openai_agent.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert";
+import { buildDeprecatedModelMessage } from "../../src/agents/image_openai_agent.js";
+
+test("buildDeprecatedModelMessage returns migration hint for dall-e-2", () => {
+  const message = buildDeprecatedModelMessage("dall-e-2");
+  assert.ok(message);
+  assert.match(message, /dall-e-2.*no longer available/);
+  assert.match(message, /gpt-image-1/);
+});
+
+test("buildDeprecatedModelMessage returns migration hint for dall-e-3", () => {
+  const message = buildDeprecatedModelMessage("dall-e-3");
+  assert.ok(message);
+  assert.match(message, /dall-e-3.*no longer available/);
+  assert.match(message, /gpt-image-1/);
+});
+
+test("buildDeprecatedModelMessage returns null for currently supported model", () => {
+  assert.strictEqual(buildDeprecatedModelMessage("gpt-image-1"), null);
+  assert.strictEqual(buildDeprecatedModelMessage("gpt-image-1-mini"), null);
+});
+
+test("buildDeprecatedModelMessage returns null for unknown / future model names", () => {
+  assert.strictEqual(buildDeprecatedModelMessage("gpt-image-99"), null);
+  assert.strictEqual(buildDeprecatedModelMessage("typo-model"), null);
+  assert.strictEqual(buildDeprecatedModelMessage(""), null);
+});

--- a/test/agents/test_image_openai_agent.ts
+++ b/test/agents/test_image_openai_agent.ts
@@ -1,6 +1,21 @@
 import test from "node:test";
 import assert from "node:assert";
-import { buildDeprecatedModelMessage } from "../../src/agents/image_openai_agent.js";
+import type { GraphAI } from "graphai";
+import { imageOpenaiAgent, buildDeprecatedModelMessage } from "../../src/agents/image_openai_agent.js";
+
+const baseParams = {
+  config: { apiKey: "fake-key-not-used" },
+  filterParams: {},
+  debugInfo: {
+    verbose: false,
+    nodeId: "",
+    state: "",
+    retry: 0,
+    subGraphs: new Map<string, GraphAI>(),
+  },
+};
+
+const canvasSize = { width: 1024, height: 1024 };
 
 test("buildDeprecatedModelMessage returns migration hint for dall-e-2", () => {
   const message = buildDeprecatedModelMessage("dall-e-2");
@@ -25,4 +40,30 @@ test("buildDeprecatedModelMessage returns null for unknown / future model names"
   assert.strictEqual(buildDeprecatedModelMessage("gpt-image-99"), null);
   assert.strictEqual(buildDeprecatedModelMessage("typo-model"), null);
   assert.strictEqual(buildDeprecatedModelMessage(""), null);
+});
+
+test("imageOpenaiAgent rejects deprecated dall-e-2 before calling the API", async () => {
+  await assert.rejects(
+    () =>
+      imageOpenaiAgent({
+        ...baseParams,
+        namedInputs: { prompt: "test prompt", referenceImages: [] },
+        params: { model: "dall-e-2", canvasSize, moderation: "auto" },
+      }),
+    (err: Error) => /dall-e-2.*no longer available/.test(err.message) && /gpt-image-1/.test(err.message),
+    "expected upfront deprecation rejection without an API call",
+  );
+});
+
+test("imageOpenaiAgent rejects deprecated dall-e-3 before calling the API", async () => {
+  await assert.rejects(
+    () =>
+      imageOpenaiAgent({
+        ...baseParams,
+        namedInputs: { prompt: "test prompt", referenceImages: [] },
+        params: { model: "dall-e-3", canvasSize, moderation: "auto" },
+      }),
+    (err: Error) => /dall-e-3.*no longer available/.test(err.message) && /gpt-image-1/.test(err.message),
+    "expected upfront deprecation rejection without an API call",
+  );
 });

--- a/test/agents/test_validate_schema_agent.ts
+++ b/test/agents/test_validate_schema_agent.ts
@@ -25,7 +25,7 @@ const validMulmoScriptJson = JSON.stringify({
         },
       },
       imageParams: {
-        model: "dall-e-3",
+        model: "gpt-image-1",
       },
       speechOptions: {
         speed: 1.0,
@@ -50,7 +50,7 @@ const validMulmoScriptJson = JSON.stringify({
     },
   },
   imageParams: {
-    model: "dall-e-3",
+    model: "gpt-image-1",
     provider: "openai",
     style: "natural",
   },

--- a/test/tools/test_complete_script.ts
+++ b/test/tools/test_complete_script.ts
@@ -22,7 +22,7 @@ test("mergeScripts - merges base with override (override takes precedence)", () 
   const base = {
     title: "Base Title",
     lang: "en",
-    imageParams: { provider: "openai", model: "dall-e-3" },
+    imageParams: { provider: "openai", model: "gpt-image-1" },
     beats: [],
   };
 


### PR DESCRIPTION
## Summary

- OpenAI で廃止された DALL-E 2 / DALL-E 3 を mulmocast 側でも利用不可とし、指定された場合は API 呼び出し前に migration hint 付きエラーで早期拒否する
- スキーマの `provider2ImageAgent.openai.models` から `dall-e-3` を除外
- 既存スクリプト / テストの参照モデルを `gpt-image-1` に更新

## Items to Confirm / Review

- [ ] **設計判断 (重要)**: deprecation チェックを `image_openai_agent.ts` の API 呼び出し前に置いている。当初は「OpenAI API が source of truth」として catch 内で `error.code === "model_not_found"` を判別する形を試したが、実機で OpenAI が `model_not_found` ではなく `invalid_value` (size validation) を先に返してくることが判明したため、API 呼び出し前のクライアント側チェックに変更した
- [ ] `deprecatedModelHints` の Record をハードコードしている。今後別の OpenAI image モデルが廃止されたらここに追記する運用
- [ ] Replicate / Google 側の image agent には同等のチェックは入れていない (DALL-E は OpenAI 固有のため)
- [ ] `imageOpenaiAgent` を直接呼ぶ既存テストがなかったため `test/agents/test_image_openai_agent.ts` を新規追加

## User Prompt

- DALL-E 2 / DALL-E 3 が OpenAI で使えなくなったので mulmocast から外したい
- 実装後、廃止モデル動作確認スクリプトを実行したら分かりにくいエラーになる (「なんかエラー出たぞ、何が悪いんだ」) → 原因調査・修正

## 実装の概要

### 1. allow-list の更新

- `src/types/provider2agent.ts`: `provider2ImageAgent.openai.models` から `dall-e-3` を除外し `gptImages` のみに

### 2. 廃止モデルの早期拒否

- `src/agents/image_openai_agent.ts`:
  - `deprecatedModelHints` Record と `buildDeprecatedModelMessage(model)` ヘルパーを追加
  - エージェント先頭 (API 呼び出し前) で、廃止モデルなら migration hint 付きで throw
- `src/methods/mulmo_presentation_style.ts`: 当初の検討で置いた deny-list 検証は撤去 (集約場所を agent 層に統一)

### 3. テスト

- `test/agents/test_image_openai_agent.ts` (新規): `buildDeprecatedModelMessage` の単体テスト + agent 直接呼び出しでの upfront 拒否確認 (合計 6 ケース)
- 既存テストの `dall-e-3` モデル参照を `gpt-image-1` に置換
- 廃止モデル動作確認用スクリプトを新設: `scripts/test/test_images_dalle_deprecated.json`, `scripts/test/test_movie_dalle_deprecated.json`

## 動作確認

`yarn run images scripts/test/test_images_dalle_deprecated.json` で API 呼び出しなしに即時エラーが返ることを確認:

```
Error: OpenAI image model "dall-e-2" is no longer available. Use 'gpt-image-1' or another supported model.
```

## ローカルチェック

- `yarn format`: 全 unchanged
- `yarn lint`: 0 errors / 5 warnings (すべて pre-existing の cognitive complexity 警告)
- `yarn build`: 成功
- `yarn ci_test`: 1059 pass / 0 fail / 4 skipped

## レビュー履歴

- Codex によるクロスレビューを 2 iterations 実施し最終 verdict は ACCEPT (no new blocking findings)
- iteration 1 の 4 findings のうち 3 件 (must-fix 2 + question 1) を本 PR で対処、1 件 (`src/agents/image_replicate_agent.ts:93` の agent 名 typo) は本 PR のスコープ外として別 PR で対処予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deprecation gate for OpenAI DALL-E models (dall-e-2, dall-e-3) with migration guidance messages.
  * Introduced new default image generation model (gpt-image-1/gpt-image-1-mini).

* **Documentation**
  * Updated comments to reflect new default image model and rate limits.

* **Tests**
  * Added test fixtures for deprecated DALL-E model scenarios.
  * Updated test expectations across all test files to use new image model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->