### PR TITLE
chore(deps): bump @google/genai 1.50.1 → 2.0.1 and @tavily/core 0.5.14 → 0.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "homepage": "https://github.com/receptron/mulmocast-cli#readme",
   "dependencies": {
     "@google-cloud/text-to-speech": "^6.4.1",
-    "@google/genai": "^1.50.1",
+    "@google/genai": "^2.0.1",
     "@graphai/anthropic_agent": "^2.0.12",
     "@graphai/browserless_agent": "^2.0.2",
     "@graphai/gemini_agent": "^2.0.5",
@@ -103,7 +103,7 @@
     "@inquirer/select": "^5.1.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
-    "@tavily/core": "^0.5.11",
+    "@tavily/core": "^0.7.3",
     "archiver": "^7.0.1",
     "clipboardy": "^5.3.1",
     "dotenv": "^17.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,10 +300,20 @@
   dependencies:
     google-gax "^5.0.0"
 
-"@google/genai@^1.38.0", "@google/genai@^1.50.1":
+"@google/genai@^1.38.0":
   version "1.50.1"
   resolved "https://registry.yarnpkg.com/@google/genai/-/genai-1.50.1.tgz#c63dffa193ecc18facc325f71d931c203d5cab77"
   integrity sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==
+  dependencies:
+    google-auth-library "^10.3.0"
+    p-retry "^4.6.2"
+    protobufjs "^7.5.4"
+    ws "^8.18.0"
+
+"@google/genai@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@google/genai/-/genai-2.0.1.tgz#c98c6eaaf173b1b1f280a6d618d73e2ac28480dc"
+  integrity sha512-trxxbVePM9J8Cuni5x7+xvApoqb2y6Zk27/wugjT2cuwHOT78nFGdf/Ni29MkDxzWwrj90OQpno1Ana6dm3D2A==
   dependencies:
     google-auth-library "^10.3.0"
     p-retry "^4.6.2"
@@ -667,10 +677,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@tavily/core@^0.5.11":
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/@tavily/core/-/core-0.5.14.tgz#9ffc1a849413e6e8afb0f9927699683dbca2e561"
-  integrity sha512-4TO9J8Yyn/908aeVI0IdGP2VTg1XPXylVp2kVpAJbtr0P6Ftou1qChHLSK1oG/splhw+boQ0c8LpUoynVMRXpA==
+"@tavily/core@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@tavily/core/-/core-0.7.3.tgz#eafbffbc626941720c5c9da72178262bdbf8c044"
+  integrity sha512-KEXw8xIifY8Rfjq2Wstm8LvlvsNAj4drtpytEmg7BQUtKDcgMmWXm7CB/Mr0nxrcKwnpdTgOt8Ien1iJIUd1yQ==
   dependencies:
     axios "^1.7.7"
     https-proxy-agent "^7.0.6"


### PR DESCRIPTION
## Summary

両ライブラリの major bump。changelog/commit log を確認した上で、本リポでの使用範囲は影響を受けない範囲のみ。

### @google/genai 1.50.1 → 2.0.1

- 2.0.0 の breaking changes は **Interactions API のみ** (`GenerateContent` usage is unaffected) → 我々の用途は \`generateContent\` / \`generateImages\` / \`generateVideos\` / \`operations\` / \`files\` のみで影響なし
- 2.0.1 は \`response_format\` のフィールド名を snake_case に修正したのみ (Interactions 周辺)
- ref: https://ai.google.dev/gemini-api/docs/interactions-breaking-changes-may-2026

### @tavily/core 0.5.14 → 0.7.3

- 0.6.0 〜 0.7.3 は **additive のみ**: \`exact_match\`, \`human_id\`, \`session_id\`, \`client_name\`, \`projectId\`, basic/advanced \`include_answer\`
- \`include_answer\` の型拡張時に \`fix: allow true to prevent breaking changes\` を入れて後方互換を維持 (commit: 22ecbc3)
- 我々の使用は \`tvly.search(query, options)\` のみで影響なし

## Verification

- ✅ \`yarn build\` 通過
- ✅ \`yarn lint\` 通過
- ✅ \`yarn ci_test\`: 1108 tests pass, 0 fail
- ✅ @google/genai 2.0.1 で実機 image 生成成功 (\`gemini-2.5-flash-image\` 経由)

## Items to Confirm / Review

- @tavily/core はライブ API テストは TAVILY_API_KEY が無く未実施。TS 型チェック (\`tvly.search\` のシグネチャ) は通過しているので互換性問題はない見込み
- archiver 7 → 8 は ESM 化で TS 型周りに影響の可能性があるため本 PR には含めず別途検討