### PR TITLE
feat: add MulmoErrorFormatter injection point for schema validation errors

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -16,6 +16,20 @@ import { loadMulmoConfig, mergeConfigWithScript } from "./mulmo_config.js";
 
 export const silentMp3 = "https://github.com/receptron/mulmocast-cli/raw/refs/heads/main/assets/audio/silent300.mp3";
 
+// Optional error formatter injected by the host application. When set, it is invoked
+// with the raw error before logging; if it returns a non-null string, that string is
+// logged instead of the default `${error}` interpolation. Default behavior (returning
+// null or leaving this unset) keeps the original verbose output.
+export type MulmoErrorFormatter = (error: unknown) => string | null;
+let mulmoErrorFormatter: MulmoErrorFormatter | null = null;
+export const setMulmoErrorFormatter = (formatter: MulmoErrorFormatter | null): void => {
+  mulmoErrorFormatter = formatter;
+};
+const formatMulmoError = (error: unknown): string => {
+  const formatted = mulmoErrorFormatter?.(error);
+  return formatted ?? `${error}`;
+};
+
 const mulmoCredit = (speaker: string, isPortrait: boolean) => {
   return {
     id: "mulmo_credit",
@@ -181,7 +195,7 @@ export const initializeContextFromFiles = async (
       lang: targetLang ?? studio.script.lang, // This lang is target Language. studio.lang is default Language
     };
   } catch (error) {
-    GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${error}`);
+    GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${formatMulmoError(error)}`);
     if (raiseError) {
       throw error;
     }


### PR DESCRIPTION
## Summary

\`initializeContextFromFiles\` logs validation failures with \`\${error}\` directly. For ZodError that produces a verbose multiline JSON dump:

\`\`\`
Error: invalid MulmoScript Schema: /path/to/script.json
 [
  {
    "code": "invalid_value",
    "values": ["openai", "google", "gemini", ...],
    "path": ["speechParams", "speakers", "Presenter", "lang", "ja", "provider"],
    "message": "Invalid option: expected one of \"openai\"|\"google\"|..."
  },
  ...
]
\`\`\`

The host app can't currently shorten this because the log call is inside the library. This PR exposes \`setMulmoErrorFormatter\` so the app can register a formatter that turns the error into something readable before it reaches the log line, e.g.:

\`\`\`
Error: invalid MulmoScript Schema: /path/to/script.json
   - speechParams.speakers.Presenter.lang.ja.provider: Invalid option: expected one of ...
   - speechParams.speakers.Announcer.provider: Invalid option: expected one of ...
\`\`\`

## API

\`\`\`ts
export type MulmoErrorFormatter = (error: unknown) => string | null;
export const setMulmoErrorFormatter = (formatter: MulmoErrorFormatter | null): void;
\`\`\`

## Default behavior is unchanged

- If no formatter is registered (default), \`\${error}\` is used as before.
- If the registered formatter returns \`null\` for a given error, \`\${error}\` is used as before.

Only when the host explicitly opts in by registering a formatter that returns a string is the output different.

## Changes

- \`src/utils/context.ts\`:
  - Add \`MulmoErrorFormatter\` type, module-level \`mulmoErrorFormatter\` slot, and \`setMulmoErrorFormatter\` setter
  - Replace \`\${error}\` interpolation in the \`initializeContextFromFiles\` catch with \`formatMulmoError(error)\` helper that uses the injected formatter when available
- These are re-exported automatically via \`index.node.ts\`'s \`export * from "./utils/context.js"\`

## Test plan

- [x] \`yarn build\` pass
- [x] \`yarn lint\` 0 errors
- [ ] Smoke: without \`setMulmoErrorFormatter\`, log output for an invalid script is identical to before
- [ ] Smoke: with a formatter installed, log output uses the formatter's string

## User Prompt

> zod のerrorもformatedなものにして、よみやすくしてほしい
> mulmocast ライブラリで、整形関数をinjection できるとよい？../mulmocast-cliにあるから。そっちでなおそうよ
> 整形できるようなoption、もしくは関数のinjectionを。基本的な動作はかえないでね

🤖 Generated with [Claude Code](https://claude.com/claude-code)