### PR TITLE
mulmocast@2.6.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.6.13](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.13) (2026-05-11)
+
+- **`setMulmoErrorFormatter` injection point**: Host apps can now register a formatter that turns the schema validation error into a readable summary before `initializeContextFromFiles` logs it (default behavior unchanged when no formatter is registered or the formatter returns `null`)
+
+📦 **npm**: [`mulmocast@2.6.13`](https://www.npmjs.com/package/mulmocast/v/2.6.13)
+
 ## [2.6.12](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.12) (2026-05-11)
 
 - **fluent-ffmpeg → @modernized/fluent-ffmpeg**: Migrated to a TypeScript-native fork with bundled type definitions. Verified e2e across 7 movie scenarios (BGM trim, audio mixing, ducking, animation, movie embed, voice over, spillover)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "description": "",
   "type": "module",
   "main": "lib/index.node.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/types",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "description": "Type definitions for MulmoCast",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Release version bump for `mulmocast@2.6.13` and `@mulmocast/types@2.6.13`.

## Changes since 2.6.12

- **`setMulmoErrorFormatter` injection point** (#1373): Host apps can now register a formatter that turns the schema validation error into a readable summary before `initializeContextFromFiles` logs it (default behavior unchanged when no formatter is registered or the formatter returns `null`)

## Files

- `package.json`: 2.6.12 → 2.6.13
- `types/package.json`: 2.6.12 → 2.6.13
- `CHANGELOG.md`: add 2.6.13 entry

## Test plan

- [x] `yarn install` pass
- [x] `yarn lint` 0 errors
- [x] `yarn build` pass

After merge: publish to npm, tag `2.6.13`, create GitHub release with `--latest=false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `setMulmoErrorFormatter` injection point to customize schema validation error formatting.

* **Chores**
  * Version bumped to 2.6.13.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmocast-cli/pull/1374)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->