### PR TITLE
feat: zero-dependency `file://` HTML viewer command (#1385)

### DIFF
--- a/plans/feat-file-viewer.md
+++ b/plans/feat-file-viewer.md
@@ -1,0 +1,222 @@
+# feat: zero-dependency `file://` HTML viewer command (#1385)
+
+## User Prompt
+
+> #1385 で要望されている、`mulmocast viewer <script>` で **依存ゼロ・サーバー不要・`file://` で開ける単一 HTML** を吐くコマンドを追加してほしい。
+>
+> 動画は一旦考えない。beats を image として書き出して、それを HTML に埋め込む（base64）。左右キーでスライドを移動できる、シンプルなビューワーで OK。
+>
+> フルスクリーンのスライドモードでも **スクロールせず左右キーだけで移動できる** UX にしてほしい。
+>
+> 既存パターン（`src/actions/html.ts`, `src/cli/commands/bundle/`）に倣ってキレイに作ってほしい。
+
+## Goal
+
+新しい CLI コマンド `mulmocast viewer <script>` を追加し、`output/` に **`<filename>_viewer.html`** を書き出す。
+
+- **完全自己完結**: 外部 `<script src>` / `<link href>` 一切なし。画像も base64 data URI として埋め込み
+- **サーバー不要**: `file:///path/to/<filename>_viewer.html` を直接ブラウザで開いて動く
+- **オフライン動作**: ネット切断・エアギャップ環境でも問題なし
+- **キーボードナビ**: ← → / Space / Home / End / `f` (fullscreen) / `Esc` (exit fullscreen)
+- **「スライドモード」固定レイアウト**: `body { overflow: hidden; }` + 各スライド絶対配置で、フルスクリーン時も通常時も **スクロールしない**。 left/right キーだけで明示的に進める
+- **スライドカウンター**: 画面右下に `current / total`
+
+## 非ゴール（今回スコープ外）
+
+- 動画 (`movieFile` / `lipSyncFile`) の埋め込み — 画像のみ
+- 音声再生 — テキスト/画像だけ
+- アニメーション / トランジション — 静的なスライド送りのみ
+- 多言語切り替え UI — `--lang` で書き出し時に言語固定
+- BGM
+- スライドサムネイル一覧、スピーカーノート
+
+将来的に「フル版 viewer」を別途出す余地として残す。今回は **オフライン安全な静的スライド配布** に特化。
+
+## レイアウト方針（最重要）
+
+スクロールしない・キーだけで送れるための CSS 設計:
+
+```css
+html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #000; }
+
+#deck { position: relative; width: 100vw; height: 100vh; }
+
+section.slide {
+  position: absolute;
+  inset: 0;                              /* 全スライドが同じ位置に重なる */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  visibility: hidden;                    /* 非アクティブは非表示 */
+  padding: 24px;
+  box-sizing: border-box;
+}
+
+section.slide.active { visibility: visible; }
+
+section.slide img {
+  max-width: 100%;
+  max-height: 80vh;                      /* キャプション分だけ残す */
+  object-fit: contain;
+  user-select: none;
+}
+
+section.slide p.caption {
+  color: #eee;
+  margin-top: 16px;
+  text-align: center;
+  font-family: system-ui, sans-serif;
+  max-width: 80ch;
+  max-height: 15vh;
+  overflow: hidden;
+}
+
+#counter {
+  position: fixed;
+  right: 16px;
+  bottom: 12px;
+  color: #aaa;
+  font-family: system-ui, sans-serif;
+  font-size: 14px;
+  user-select: none;
+}
+```
+
+要点:
+- `overflow: hidden` を `html, body` 両方に効かせて、画像が viewport より大きくてもスクロールバーは出ない
+- 各スライドは `position: absolute; inset: 0;` で全画面・全重なり、`visibility` で切替（`display: none` だと画像の再レンダリングが入るので `visibility` の方が滑らか）
+- 画像は `object-fit: contain` で常に viewport 内に収まる
+- フルスクリーン (`requestFullscreen`) でも非フルスクリーンでも同じ動作
+
+## 実装
+
+### ファイル構成
+
+```
+src/actions/viewer.ts                          (新規, ~120 行)
+src/cli/commands/viewer/
+  ├─ index.ts                                  (新規, ~5 行)
+  ├─ builder.ts                                (新規, ~15 行)
+  └─ handler.ts                                (新規, ~15 行)
+src/actions/index.ts                           (export 1 行追加)
+src/cli/bin.ts                                 (command 1 行追加)
+test/actions/test_viewer.ts                    (新規, ~40 行)
+plans/feat-file-viewer.md                      (本ドキュメント)
+```
+
+### `src/actions/viewer.ts`
+
+`html.ts` の `generateHtml` パターンを踏襲:
+
+```typescript
+export const viewer = async (context: MulmoStudioContext): Promise<void> => {
+  MulmoStudioContextMethods.setSessionState(context, "viewer", true);
+  try {
+    const outputPath = viewerFilePath(context);
+    const htmlContent = generateViewerHtml(context);
+    fs.writeFileSync(outputPath, htmlContent, "utf8");
+    writingMessage(outputPath);
+    MulmoStudioContextMethods.setSessionState(context, "viewer", false, true);
+  } catch (error) {
+    MulmoStudioContextMethods.setSessionState(context, "viewer", false, false);
+    throw error;
+  }
+};
+```
+
+主要ロジック:
+
+1. `context.studio.beats[i]` を順に走査
+2. `imageFile` または `htmlImageFile` を読み、`fs.readFileSync` → base64 → `data:image/<ext>;base64,...`
+3. キャプションは `localizedText(beat, multiLingual?.[i], lang)`（既存パターン）
+4. 画像が存在しない beat はスキップ
+5. HTML テンプレートは `<section class="slide">` リスト + 上記 `<style>` + 下記ナビ `<script>`
+
+### ナビ JS（インライン, ~30 行）
+
+```javascript
+(function () {
+  const slides = document.querySelectorAll("section.slide");
+  const counter = document.getElementById("counter");
+  if (slides.length === 0) return;
+  let current = 0;
+  const show = (i) => {
+    slides[current].classList.remove("active");
+    current = Math.max(0, Math.min(slides.length - 1, i));
+    slides[current].classList.add("active");
+    counter.textContent = `${current + 1} / ${slides.length}`;
+  };
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowRight" || e.key === " " || e.key === "PageDown") {
+      e.preventDefault();
+      show(current + 1);
+    } else if (e.key === "ArrowLeft" || e.key === "PageUp") {
+      e.preventDefault();
+      show(current - 1);
+    } else if (e.key === "Home") show(0);
+    else if (e.key === "End") show(slides.length - 1);
+    else if (e.key === "f" || e.key === "F") document.documentElement.requestFullscreen?.();
+    else if (e.key === "Escape") document.exitFullscreen?.();
+  });
+  // Optional: click anywhere to advance (presentation-friendly fallback).
+  document.addEventListener("click", () => show(current + 1));
+  show(0);
+})();
+```
+
+`e.preventDefault()` で Space / PageDown のデフォルトスクロールも抑止（`overflow: hidden` で見た目には出ないが、フォーカスやアクセシビリティのため）。
+
+### `src/cli/commands/viewer/handler.ts`
+
+`bundle/handler.ts` をなぞる:
+
+```typescript
+export const handler = async (argv) => {
+  const context = await initializeContext(argv);
+  if (!context) process.exit(1);
+  await runTranslateIfNeeded(context);
+  await images(context);
+  await viewer(context);
+};
+```
+
+### `builder.ts`
+
+`image/builder.ts` 等を参考に、共通フラグだけ継承:
+- `-o, --outdir`
+- `-i, --imagedir`
+- `-l, --lang`
+
+独自フラグは今回追加しない（KISS）。
+
+### エスケープ
+
+タイトル・キャプションは `escapeHtml()` で `& < > " '` をエスケープして XSS を回避。
+
+## 後方互換
+
+- 新規コマンドのみ追加。既存 `html`, `pdf`, `bundle` の挙動は不変
+- 既存テストへの影響なし
+
+## バリデーション
+
+- `yarn format`
+- `yarn lint`
+- `yarn build`
+- `yarn ci_test`
+
+## エッジケース
+
+- 画像が大量 / 大きい場合: 出力ファイルサイズが base64 で ~33% 膨張。生成後に `writingMessage` でサイズを併記
+- `imageFile` が存在しない beat はスキップ（既存 `html.ts` と同じ振る舞い）
+- `htmlImageFile` も走査対象に含める（既存 `html.ts` がそうしているため整合）
+
+## Out of scope（followup 候補）
+
+- 動画 (`movieFile`) の埋め込み
+- 音声トラックの埋め込み・再生
+- BGM ループ再生
+- 多言語切り替え UI
+- スライドサムネイル一覧
+- スピーカーノート表示

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -8,4 +8,5 @@ export * from "./pdf.js";
 export * from "./translate.js";
 export * from "./markdown.js";
 export * from "./html.js";
+export * from "./viewer.js";
 export * from "./bundle.js";

--- a/src/actions/viewer.ts
+++ b/src/actions/viewer.ts
@@ -1,0 +1,182 @@
+import fs from "fs";
+import path from "path";
+import { MulmoStudioContext } from "../types/index.js";
+import { localizedText } from "../utils/utils.js";
+import { writingMessage } from "../utils/file.js";
+import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
+import { escapeHtml } from "../slide/utils.js";
+
+const imageMimeTypes: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+};
+
+const imageToDataUri = (filePath: string): string | null => {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  const ext = path.extname(filePath).slice(1).toLowerCase();
+  const mime = imageMimeTypes[ext] ?? "image/png";
+  const base64 = fs.readFileSync(filePath).toString("base64");
+  return `data:${mime};base64,${base64}`;
+};
+
+type Slide = { dataUri: string; caption: string };
+
+const collectSlides = (context: MulmoStudioContext): Slide[] => {
+  const { studio, multiLingual, lang = "en" } = context;
+  const slides: Slide[] = [];
+  studio.script.beats.forEach((beat, index) => {
+    const studioBeat = studio.beats[index];
+    const source = studioBeat?.imageFile ?? studioBeat?.htmlImageFile;
+    if (!source) return;
+    const dataUri = imageToDataUri(source);
+    if (!dataUri) return;
+    slides.push({
+      dataUri,
+      caption: localizedText(beat, multiLingual?.[index], lang),
+    });
+  });
+  return slides;
+};
+
+const viewerStyles = `
+  html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #000; }
+  #deck { position: relative; width: 100vw; height: 100vh; }
+  section.slide {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    visibility: hidden;
+    padding: 24px;
+    box-sizing: border-box;
+  }
+  section.slide.active { visibility: visible; }
+  section.slide img {
+    max-width: 100%;
+    max-height: 80vh;
+    object-fit: contain;
+    user-select: none;
+  }
+  section.slide p.caption {
+    color: #eee;
+    margin-top: 16px;
+    text-align: center;
+    font-family: system-ui, -apple-system, sans-serif;
+    max-width: 80ch;
+    max-height: 15vh;
+    overflow: hidden;
+  }
+  #counter {
+    position: fixed;
+    right: 16px;
+    bottom: 12px;
+    color: #aaa;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 14px;
+    user-select: none;
+    pointer-events: none;
+  }
+`;
+
+const viewerScript = `
+  (function () {
+    const slides = document.querySelectorAll("section.slide");
+    const counter = document.getElementById("counter");
+    if (slides.length === 0) return;
+    let current = 0;
+    const show = (i) => {
+      slides[current].classList.remove("active");
+      current = Math.max(0, Math.min(slides.length - 1, i));
+      slides[current].classList.add("active");
+      counter.textContent = (current + 1) + " / " + slides.length;
+    };
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowRight" || e.key === " " || e.key === "PageDown") {
+        e.preventDefault();
+        show(current + 1);
+      } else if (e.key === "ArrowLeft" || e.key === "PageUp") {
+        e.preventDefault();
+        show(current - 1);
+      } else if (e.key === "Home") {
+        e.preventDefault();
+        show(0);
+      } else if (e.key === "End") {
+        e.preventDefault();
+        show(slides.length - 1);
+      } else if (e.key === "f" || e.key === "F") {
+        if (!document.fullscreenElement) {
+          document.documentElement.requestFullscreen && document.documentElement.requestFullscreen();
+        } else {
+          document.exitFullscreen && document.exitFullscreen();
+        }
+      } else if (e.key === "Escape") {
+        document.exitFullscreen && document.exitFullscreen();
+      }
+    });
+    document.addEventListener("click", () => show(current + 1));
+    show(0);
+  })();
+`;
+
+const generateViewerHtml = (context: MulmoStudioContext): string => {
+  const title = context.studio.script.title || "MulmoCast Viewer";
+  const slides = collectSlides(context);
+  const slidesHtml = slides
+    .map((s, i) => {
+      const captionHtml = s.caption.trim() ? `<p class="caption">${escapeHtml(s.caption)}</p>` : "";
+      const cls = i === 0 ? "slide active" : "slide";
+      return `      <section class="${cls}"><img src="${s.dataUri}" alt="Slide ${i + 1}" />${captionHtml}</section>`;
+    })
+    .join("\n");
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${escapeHtml(title)}</title>
+    <style>${viewerStyles}</style>
+  </head>
+  <body>
+    <div id="deck">
+${slidesHtml}
+    </div>
+    <div id="counter"></div>
+    <script>${viewerScript}</script>
+  </body>
+</html>
+`;
+};
+
+export const viewerFilePath = (context: MulmoStudioContext): string => {
+  const { studio, fileDirs, lang = "en" } = context;
+  const langSuffix = studio.script.lang !== lang ? `_${lang}` : "";
+  const filename = `${studio.filename}${langSuffix}_viewer.html`;
+  return path.join(fileDirs.outDirPath, filename);
+};
+
+const generateViewer = (context: MulmoStudioContext): void => {
+  const outputPath = viewerFilePath(context);
+  const htmlContent = generateViewerHtml(context);
+  fs.writeFileSync(outputPath, htmlContent, "utf8");
+  writingMessage(outputPath);
+};
+
+export const viewer = async (context: MulmoStudioContext): Promise<void> => {
+  try {
+    MulmoStudioContextMethods.setSessionState(context, "viewer", true);
+    generateViewer(context);
+    MulmoStudioContextMethods.setSessionState(context, "viewer", false, true);
+  } catch (error) {
+    MulmoStudioContextMethods.setSessionState(context, "viewer", false, false);
+    throw error;
+  }
+};

--- a/src/actions/viewer.ts
+++ b/src/actions/viewer.ts
@@ -32,7 +32,8 @@ const collectSlides = (context: MulmoStudioContext): Slide[] => {
   const slides: Slide[] = [];
   studio.script.beats.forEach((beat, index) => {
     const studioBeat = studio.beats[index];
-    const source = studioBeat?.imageFile ?? studioBeat?.htmlImageFile;
+    // Prefer the HTML-rendered frame over the source image, matching pdf.ts / movie.ts.
+    const source = studioBeat?.htmlImageFile ?? studioBeat?.imageFile;
     if (!source) return;
     const dataUri = imageToDataUri(source);
     if (!dataUri) return;

--- a/src/cli/commands/viewer/builder.ts
+++ b/src/cli/commands/viewer/builder.ts
@@ -1,0 +1,9 @@
+import type { Argv } from "yargs";
+import { commonOptions } from "../../common.js";
+
+export const builder = (yargs: Argv) =>
+  commonOptions(yargs).option("i", {
+    alias: "imagedir",
+    describe: "Image output directory",
+    type: "string",
+  });

--- a/src/cli/commands/viewer/handler.ts
+++ b/src/cli/commands/viewer/handler.ts
@@ -1,0 +1,13 @@
+import { images, viewer } from "../../../actions/index.js";
+import { CliArgs } from "../../../types/cli_types.js";
+import { initializeContext, runTranslateIfNeeded } from "../../helpers.js";
+
+export const handler = async (argv: CliArgs<{ i?: string }>) => {
+  const context = await initializeContext(argv);
+  if (!context) {
+    process.exit(1);
+  }
+  await runTranslateIfNeeded(context);
+  await images(context);
+  await viewer(context);
+};

--- a/src/cli/commands/viewer/index.ts
+++ b/src/cli/commands/viewer/index.ts
@@ -1,0 +1,4 @@
+export const command = "viewer <file>";
+export const desc = "Generate a zero-dependency, single-file HTML slideshow viewer (openable via file://)";
+export { builder } from "./builder.js";
+export { handler } from "./handler.js";

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -12,6 +12,7 @@ import * as pdfCmd from "./commands/pdf/index.js";
 import * as markdownCmd from "./commands/markdown/index.js";
 import * as bundleCmd from "./commands/bundle/index.js";
 import * as htmlCmd from "./commands/html/index.js";
+import * as viewerCmd from "./commands/viewer/index.js";
 import * as toolCmd from "./commands/tool/index.js";
 import { GraphAILogger } from "graphai";
 
@@ -45,6 +46,7 @@ export const cliMain = async () => {
     .command(markdownCmd)
     .command(bundleCmd)
     .command(htmlCmd)
+    .command(viewerCmd)
     .command(toolCmd)
     .demandCommand()
     .strict()

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -760,6 +760,7 @@ export const mulmoSessionStateSchema = z.object({
     pdf: z.boolean(),
     markdown: z.boolean(),
     html: z.boolean(),
+    viewer: z.boolean(),
   }),
   inBeatSession: z.object({
     audio: z.record(z.string(), z.boolean()),

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -176,7 +176,7 @@ export type BeatMediaType = "movie" | "image";
 
 export type StoryToScriptGenerateMode = (typeof storyToScriptGenerateMode)[keyof typeof storyToScriptGenerateMode];
 
-export type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "pdf" | "markdown" | "html";
+export type SessionType = "audio" | "image" | "video" | "multiLingual" | "caption" | "pdf" | "markdown" | "html" | "viewer";
 export type BeatSessionType = "audio" | "image" | "multiLingual" | "caption" | "movie" | "html" | "imageReference" | "soundEffect" | "lipSync";
 
 export type SessionProgressEvent =

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -65,6 +65,7 @@ const initSessionState = () => {
       pdf: false,
       markdown: false,
       html: false,
+      viewer: false,
     },
     inBeatSession: {
       audio: {},

--- a/test/actions/test_viewer.ts
+++ b/test/actions/test_viewer.ts
@@ -144,6 +144,30 @@ test("viewer produces a usable output even when no beats have images", async () 
   }
 });
 
+test("viewer prefers htmlImageFile over imageFile (matches pdf.ts / movie.ts)", async () => {
+  // Two visually distinct 1x1 PNGs so their base64 differs and we can assert which one was embedded.
+  const redPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
+  const bluePngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYPj/HwADAgH/5ncLrgAAAABJRU5ErkJggg==";
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
+  try {
+    const imageFile = path.join(tmpDir, "source.png");
+    const htmlImageFile = path.join(tmpDir, "rendered.png");
+    fs.writeFileSync(imageFile, Buffer.from(redPngBase64, "base64"));
+    fs.writeFileSync(htmlImageFile, Buffer.from(bluePngBase64, "base64"));
+
+    const context = buildContext(tmpDir, [imageFile]);
+    // Beat has BOTH: the HTML-rendered frame must win.
+    context.studio.beats[0].htmlImageFile = htmlImageFile;
+    await viewer(context);
+
+    const html = fs.readFileSync(viewerFilePath(context), "utf8");
+    assert.ok(html.includes(bluePngBase64), "htmlImageFile (rendered frame) should be embedded");
+    assert.ok(!html.includes(redPngBase64), "imageFile (source) must not be embedded when htmlImageFile exists");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test("viewer escapes HTML in title and caption", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
   try {

--- a/test/actions/test_viewer.ts
+++ b/test/actions/test_viewer.ts
@@ -3,17 +3,20 @@ import assert from "node:assert";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { fileURLToPath } from "url";
 
 import { viewer, viewerFilePath } from "../../src/actions/viewer.js";
 import { createStudioData } from "../../src/utils/context.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const repoRoot = path.resolve(__dirname, "..", "..");
-const sampleImage1 = path.resolve(repoRoot, "scripts/test/img_higgs.png");
-const sampleImage2 = path.resolve(repoRoot, "scripts/test/img_detector.png");
+// Minimal valid 1x1 transparent PNG (base64). Self-contained so the test does
+// not depend on any image file being checked into the repo.
+const minimalPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+
+const writeSamplePng = (dir: string, name: string): string => {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, Buffer.from(minimalPngBase64, "base64"));
+  return filePath;
+};
 
 const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): MulmoStudioContext => {
   const mulmoScript = {
@@ -73,7 +76,9 @@ const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): M
 test("viewer writes a self-contained HTML file with embedded base64 images", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
   try {
-    const context = buildContext(tmpDir, [sampleImage1, sampleImage2]);
+    const img1 = writeSamplePng(tmpDir, "sample1.png");
+    const img2 = writeSamplePng(tmpDir, "sample2.png");
+    const context = buildContext(tmpDir, [img1, img2]);
     await viewer(context);
 
     const outPath = viewerFilePath(context);
@@ -110,8 +115,10 @@ test("viewer writes a self-contained HTML file with embedded base64 images", asy
 test("viewer skips beats whose imageFile is missing on disk", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
   try {
+    const img1 = writeSamplePng(tmpDir, "sample1.png");
+    const img2 = writeSamplePng(tmpDir, "sample2.png");
     const missing = path.join(tmpDir, "does-not-exist.png");
-    const context = buildContext(tmpDir, [sampleImage1, missing, sampleImage2]);
+    const context = buildContext(tmpDir, [img1, missing, img2]);
     await viewer(context);
 
     const html = fs.readFileSync(viewerFilePath(context), "utf8");
@@ -152,7 +159,7 @@ test("viewer escapes HTML in title and caption", async () => {
       ],
     };
     const studio = createStudioData(mulmoScript, "viewer_test");
-    studio.beats[0].imageFile = sampleImage1;
+    studio.beats[0].imageFile = writeSamplePng(tmpDir, "sample.png");
     const context = {
       studio,
       fileDirs: { baseDirPath: tmpDir, outDirPath: tmpDir, imageDirPath: tmpDir, audioDirPath: tmpDir, grouped: false },

--- a/test/actions/test_viewer.ts
+++ b/test/actions/test_viewer.ts
@@ -1,0 +1,175 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import { viewer, viewerFilePath } from "../../src/actions/viewer.js";
+import { createStudioData } from "../../src/utils/context.js";
+import type { MulmoStudioContext } from "../../src/types/index.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..");
+const sampleImage1 = path.resolve(repoRoot, "scripts/test/img_higgs.png");
+const sampleImage2 = path.resolve(repoRoot, "scripts/test/img_detector.png");
+
+const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): MulmoStudioContext => {
+  const mulmoScript = {
+    $mulmocast: { version: "1.0", credit: "closing" },
+    title: "Viewer Test Deck",
+    description: "",
+    beats: beatImageFiles.map((_, i) => ({
+      text: `Caption ${i + 1}`,
+      image: { type: "textSlide" as const, slide: { title: `Slide ${i + 1}` } },
+    })),
+  };
+  const studio = createStudioData(mulmoScript, "viewer_test");
+  // Inject pre-rendered image paths for each beat so the viewer can pick them up.
+  beatImageFiles.forEach((file, i) => {
+    if (file && studio.beats[i]) {
+      studio.beats[i].imageFile = file;
+    }
+  });
+  return {
+    studio,
+    fileDirs: {
+      baseDirPath: tmpDir,
+      outDirPath: tmpDir,
+      imageDirPath: tmpDir,
+      audioDirPath: tmpDir,
+      grouped: false,
+    },
+    force: false,
+    sessionState: {
+      inSession: {
+        audio: false,
+        image: false,
+        video: false,
+        multiLingual: false,
+        caption: false,
+        pdf: false,
+        markdown: false,
+        html: false,
+        viewer: false,
+      },
+      inBeatSession: {
+        audio: {},
+        image: {},
+        movie: {},
+        multiLingual: {},
+        caption: {},
+        html: {},
+        imageReference: {},
+        soundEffect: {},
+        lipSync: {},
+      },
+    },
+    presentationStyle: studio.script,
+  } as unknown as MulmoStudioContext;
+};
+
+test("viewer writes a self-contained HTML file with embedded base64 images", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
+  try {
+    const context = buildContext(tmpDir, [sampleImage1, sampleImage2]);
+    await viewer(context);
+
+    const outPath = viewerFilePath(context);
+    assert.ok(fs.existsSync(outPath), "viewer html should exist at the computed path");
+
+    const html = fs.readFileSync(outPath, "utf8");
+
+    // The file is self-contained: no external scripts/styles.
+    assert.ok(!html.includes("<script src="), "must not have external <script src=>");
+    assert.ok(!html.includes("<link "), "must not have external <link> tag");
+    assert.ok(!html.includes("cdn."), "must not reference any cdn.* URL");
+
+    // Title appears (escaped) in the document.
+    assert.ok(html.includes("Viewer Test Deck"), "title should appear");
+
+    // Both images are embedded as data URIs (base64).
+    const dataUriCount = (html.match(/src="data:image\//g) || []).length;
+    assert.equal(dataUriCount, 2, "both images should be embedded as data URIs");
+
+    // Keyboard navigation is wired up.
+    assert.ok(html.includes("ArrowRight"), "keyboard handler should bind ArrowRight");
+    assert.ok(html.includes("ArrowLeft"), "keyboard handler should bind ArrowLeft");
+
+    // Slide layout prevents scrolling.
+    assert.ok(html.includes("overflow: hidden"), "body should have overflow: hidden");
+
+    // The first slide is marked active so it shows on file:// open.
+    assert.ok(/<section class="slide active"/.test(html), "first slide must start active");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("viewer skips beats whose imageFile is missing on disk", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
+  try {
+    const missing = path.join(tmpDir, "does-not-exist.png");
+    const context = buildContext(tmpDir, [sampleImage1, missing, sampleImage2]);
+    await viewer(context);
+
+    const html = fs.readFileSync(viewerFilePath(context), "utf8");
+    const dataUriCount = (html.match(/src="data:image\//g) || []).length;
+    assert.equal(dataUriCount, 2, "missing image file should be silently skipped");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("viewer produces a usable output even when no beats have images", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
+  try {
+    const context = buildContext(tmpDir, [undefined, undefined]);
+    await viewer(context);
+
+    const html = fs.readFileSync(viewerFilePath(context), "utf8");
+    // Still a valid HTML doc; just no <section.slide> entries.
+    assert.ok(html.includes("<!doctype html>"));
+    assert.ok(!html.includes('<section class="slide'));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("viewer escapes HTML in title and caption", async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
+  try {
+    const mulmoScript = {
+      $mulmocast: { version: "1.0", credit: "closing" },
+      title: "<script>alert(1)</script>",
+      description: "",
+      beats: [
+        {
+          text: 'Caption with <b>bold</b> & special "chars"',
+          image: { type: "textSlide" as const, slide: { title: "T" } },
+        },
+      ],
+    };
+    const studio = createStudioData(mulmoScript, "viewer_test");
+    studio.beats[0].imageFile = sampleImage1;
+    const context = {
+      studio,
+      fileDirs: { baseDirPath: tmpDir, outDirPath: tmpDir, imageDirPath: tmpDir, audioDirPath: tmpDir, grouped: false },
+      force: false,
+      sessionState: {
+        inSession: { audio: false, image: false, video: false, multiLingual: false, caption: false, pdf: false, markdown: false, html: false, viewer: false },
+        inBeatSession: { audio: {}, image: {}, movie: {}, multiLingual: {}, caption: {}, html: {}, imageReference: {}, soundEffect: {}, lipSync: {} },
+      },
+      presentationStyle: studio.script,
+    } as unknown as MulmoStudioContext;
+
+    await viewer(context);
+    const html = fs.readFileSync(viewerFilePath(context), "utf8");
+    assert.ok(!html.includes("<script>alert(1)</script>"), "raw <script> tag from title must not survive");
+    assert.ok(html.includes("&lt;script&gt;"), "title special chars must be escaped");
+    assert.ok(html.includes("&lt;b&gt;bold&lt;/b&gt;"), "caption special chars must be escaped");
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #1385

## Summary

Adds a new CLI subcommand `mulmocast viewer <script>` that emits a single self-contained HTML file (`<filename>_viewer.html`) under `output/`, openable directly via `file://` without any local server, npm dependency, or CDN.

- **All assets inlined**: images become `data:image/<ext>;base64,...`, CSS/JS are inline literals, zero `<script src>` or `<link href>`.
- **Slide-mode layout**: `body { overflow: hidden; }` + absolute-positioned `<section>` slides, so neither fullscreen nor normal mode scrolls. The user advances strictly with the keyboard.
- **Keyboard nav**: ← → / Space / PageDn / PageUp / Home / End / `f` (fullscreen) / `Esc`. Click also advances as a presenter-friendly fallback.

## Items to Confirm / Review

1. **Scope is intentionally narrow** — images only (no `movieFile` / `lipSyncFile` / audio / BGM). Per the issue, this addresses the primary "ship a confidential deck offline" use case and keeps the bundle small and predictable. Follow-up tickets can extend.
2. **`htmlImageFile` fallback** — when `imageFile` is missing, the viewer falls back to `htmlImageFile`, mirroring what `src/actions/html.ts` already does. Flag if you'd rather treat the two distinctly.
3. **Click-to-advance** — added as a presenter-friendly affordance; can be removed if it conflicts with anything later (e.g. embedded interactive content). Easy revert.
4. **`viewer` added to `SessionType`** — touches `types/type.ts`, `types/schema.ts`, and `utils/context.ts`. Same shape `markdown` and `html` already follow.
5. **`escapeHtml` reused** from `src/slide/utils.ts`. Test verifies a `<script>` in the title is rendered inert.

## User Prompt

> #1385 で要望されている、`mulmocast viewer <script>` で **依存ゼロ・サーバー不要・`file://` で開ける単一 HTML** を吐くコマンドを追加してほしい。
>
> 動画は一旦考えない。beats を image として書き出して、それを HTML に埋め込む（base64）。左右キーでスライドを移動できる、シンプルなビューワーで OK。
>
> フルスクリーンのスライドモードでも **スクロールせず左右キーだけで移動できる** UX にしてほしい。
>
> 既存パターン（`src/actions/html.ts`, `src/cli/commands/bundle/`）に倣ってキレイに作ってほしい。

## Implementation

### Files

| File | Change |
|---|---|
| `src/actions/viewer.ts` | **New.** ~180 lines. Walks `studio.beats`, base64-encodes each image, emits self-contained HTML. |
| `src/cli/commands/viewer/{index,builder,handler}.ts` | **New.** Follows the existing `html/` and `bundle/` command shape. Handler runs `runTranslateIfNeeded` → `images` → `viewer`. |
| `src/cli/main.ts` | Register `viewerCmd`. |
| `src/actions/index.ts` | Export `viewer.js`. |
| `src/types/type.ts` | `SessionType` gains `"viewer"`. |
| `src/types/schema.ts` | `mulmoSessionStateSchema.inSession.viewer: z.boolean()`. |
| `src/utils/context.ts` | `initSessionState().inSession.viewer = false`. |
| `test/actions/test_viewer.ts` | **New.** 4 unit tests. |
| `plans/feat-file-viewer.md` | **New.** Design doc per the repo convention. |

### Layout for "no-scroll slide mode"

```css
html, body { margin: 0; padding: 0; height: 100vh; overflow: hidden; background: #000; }
section.slide { position: absolute; inset: 0; visibility: hidden; ... }
section.slide.active { visibility: visible; }
section.slide img { max-width: 100%; max-height: 80vh; object-fit: contain; }
```

`visibility` is preferred over `display: none` so the browser keeps the decoded image in memory (snappier slide changes), and `object-fit: contain` plus `max-height: 80vh` keep the image inside the viewport regardless of aspect ratio. Same behaviour in fullscreen and windowed modes.

### Keyboard handler (inline)

`document.addEventListener("keydown", ...)` covering ArrowLeft/Right, Space, PageUp/Down, Home, End, `f`, Escape. `preventDefault()` on Space / PageDown so the default browser scroll never fires (defensive — `overflow: hidden` already suppresses the visual scroll).

### XSS

`escapeHtml()` runs on title and caption strings before interpolation. Verified by a test:

```ts
title: "<script>alert(1)</script>"
// ↓
html.includes("&lt;script&gt;") === true
html.includes("<script>alert(1)</script>") === false
```

## Validation

- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors (5 pre-existing cognitive-complexity warnings in unrelated files)
- [x] `yarn build` — clean
- [x] `yarn ci_test` — 1108 pass / **0 fail** (added 4 new tests)
- [x] Smoke test: ran `viewer` against a 2-beat context using `scripts/test/img_higgs.png` & `img_detector.png` → 4.8KB self-contained HTML written

## Test plan

- [ ] CI passes
- [ ] Manual: `mulmocast viewer scripts/test/<some-deck>.json`, open the resulting `_viewer.html` directly with `file://`, confirm:
  - Keyboard nav works in normal and fullscreen modes
  - No scrollbar appears in either mode
  - Disconnect network → reload → still works (true offline)

## Out of scope (follow-up candidates)

- Video / lipSync embedding
- Audio / BGM playback
- Runtime multilingual switch UI
- Thumbnail navigator / speaker notes panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New viewer command that generates a single self-contained HTML slideshow for offline file:// viewing with keyboard navigation, fullscreen, and slide counter; images embedded for zero external dependencies.

* **Behavioral Improvements**
  * Skips beats without images, prefers explicit image overrides, and escapes HTML in titles/captions to ensure safe output.

* **Tests**
  * Added integration tests validating self-contained output, navigation bindings, layout, and edge cases.

* **Documentation**
  * Added design/usage notes for the viewer feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/receptron/mulmocast-cli/pull/1386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->