### PR TITLE
chore: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/generate_action_docs.yml
+++ b/.github/workflows/generate_action_docs.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'yarn'
 
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-24-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,12 +32,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
     - name: Cache Puppeteer
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
@@ -78,7 +78,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
@@ -111,12 +111,12 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: node_modules
         key: node-modules-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}
     - name: Cache Puppeteer
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/puppeteer
         key: puppeteer-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
## Summary
- **actions/cache v4 → v5**: Node.js 20 deprecation warning の解消

## Test plan
- [ ] CI で Node.js 20 deprecation warning が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)