### PR TITLE
feat(methods): expose getResolvedSlideTheme on MulmoPresentationStyleMethods

### DIFF
--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -5,7 +5,9 @@
  */
 
 import { isNull } from "graphai";
+import type { SlideTheme } from "@mulmocast/deck";
 import { userAssert } from "../utils/utils.js";
+import { slideThemes } from "../data/slideThemes.js";
 import {
   MulmoCanvasDimension,
   MulmoBeat,
@@ -72,6 +74,28 @@ export const MulmoPresentationStyleMethods = {
     const extraStyles = beat.textSlideParams?.cssStyles ?? [];
     // This code allows us to support both string and array of strings for cssStyles
     return [...defaultTextSlideStyles, ...[styles], ...[extraStyles]].flat().join("\n");
+  },
+  /**
+   * Resolve the effective theme for a slide-typed beat.
+   * Priority (high → low):
+   *   1. `beat.image.theme` — per-beat override
+   *   2. `presentationStyle.slideParams.theme` — deck-level default
+   *   3. `slideThemes.corporate` — built-in fallback
+   *
+   * Returns the corporate fallback (without throwing) when called on a
+   * non-slide beat, so callers driving the deck preview from a mixed
+   * script can hand any beat in without a special-case check.
+   *
+   * Exposed as a method so the editor (`@mulmocast/deck-web`) can
+   * import it via `mulmocast/browser` and surface the same priority
+   * its render-time slide.ts already enforces — closing the editor
+   * vs. PDF/movie theme mismatch reported on mulmoclaude#1622.
+   */
+  getResolvedSlideTheme(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat): SlideTheme {
+    if (beat.image?.type === "slide" && beat.image.theme) {
+      return beat.image.theme;
+    }
+    return presentationStyle.slideParams?.theme ?? slideThemes.corporate;
   },
   getDefaultSpeaker(presentationStyle: MulmoPresentationStyle) {
     const speakers = presentationStyle?.speechParams?.speakers ?? {};

--- a/src/utils/image_plugins/slide.ts
+++ b/src/utils/image_plugins/slide.ts
@@ -3,11 +3,11 @@ import { pathToFileURL } from "node:url";
 import { ImageProcessorParams } from "../../types/index.js";
 import { generateSlideHTML } from "@mulmocast/deck";
 import type { SlideLayout, SlideTheme, ContentBlock, MulmoSlideMedia, SlideBranding, ResolvedBranding } from "@mulmocast/deck";
-import { slideThemes } from "../../data/slideThemes.js";
 import { renderHTMLToImage } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 import { pathToDataUrl } from "../../methods/mulmo_media_source.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
+import { MulmoPresentationStyleMethods } from "../../methods/mulmo_presentation_style.js";
 import { imageAction, imageFileTarget, unknownMediaType } from "../error_cause.js";
 
 export const imageType = "slide";
@@ -99,9 +99,12 @@ const resolveTheme = (params: ImageProcessorParams): SlideTheme => {
   if (!beat.image || beat.image.type !== imageType) {
     throw new Error("resolveTheme called on non-slide beat");
   }
-  const defaultTheme = context.presentationStyle.slideParams?.theme;
-  const theme = beat.image.theme ?? defaultTheme ?? slideThemes.corporate;
-  return theme;
+  // Single source of truth for the priority — the same method is now
+  // exposed via `MulmoPresentationStyleMethods` for browser callers
+  // (editor preview) so the deck-web preview and the PDF/movie
+  // render reach the same theme. See the docblock there for the
+  // priority spelled out.
+  return MulmoPresentationStyleMethods.getResolvedSlideTheme(context.presentationStyle, beat);
 };
 
 const resolveSlide = (params: ImageProcessorParams, converter: (filePath: string) => string = pathToDataUrl): SlideLayout => {

--- a/test/methods/test_presentation_style.ts
+++ b/test/methods/test_presentation_style.ts
@@ -101,3 +101,50 @@ test("defaultSpeaker error no speaker", async () => {
     MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   });
 });
+
+// --- getResolvedSlideTheme (mulmoclaude#1622 follow-up) ---
+//
+// The priority surfaced here is the single source of truth that both
+// the renderer (`slide.ts`) and the editor (`@mulmocast/deck-web`)
+// will read from, so the tests below pin the contract loudly.
+
+const fakeTheme = (label: string) => ({
+  colors: { bg: label, bgCard: label, bgCardAlt: label, text: label, textMuted: label, textDim: label, primary: label, accent: label, success: label, warning: label, danger: label, info: label, highlight: label },
+  fonts: { title: "Georgia", body: "Helvetica", mono: "Menlo" },
+});
+
+test("getResolvedSlideTheme: per-beat theme wins over presentation-level", () => {
+  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
+  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" }, theme: fakeTheme("BEAT") } };
+  const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
+  assert.equal(result.colors.bg, "BEAT");
+});
+
+test("getResolvedSlideTheme: presentation-level theme used when beat lacks one", () => {
+  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
+  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" } } };
+  const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
+  assert.equal(result.colors.bg, "PRES");
+});
+
+test("getResolvedSlideTheme: slideThemes.corporate fallback when neither is set", () => {
+  const presentationStyle = {};
+  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" } } };
+  const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
+  // corporate's bg is "F8FAFC"; we just assert the call returns a
+  // theme-shaped object — checking the literal value would lock the
+  // test to the current default and make the fallback awkward to
+  // tweak upstream.
+  assert.ok(typeof result.colors.bg === "string" && result.colors.bg.length > 0);
+});
+
+test("getResolvedSlideTheme: non-slide beat falls through to fallback (no throw)", () => {
+  // Callers driving a deck preview from a mixed script need to be
+  // able to hand any beat in without first checking its image.type.
+  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
+  const beat = { image: { type: "textSlide" as const, slide: { title: "x" } } };
+  const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
+  // Falls through to the presentation-level theme since beat.image.theme
+  // doesn't apply (different image kind), instead of throwing.
+  assert.equal(result.colors.bg, "PRES");
+});

--- a/test/methods/test_presentation_style.ts
+++ b/test/methods/test_presentation_style.ts
@@ -109,7 +109,21 @@ test("defaultSpeaker error no speaker", async () => {
 // will read from, so the tests below pin the contract loudly.
 
 const fakeTheme = (label: string) => ({
-  colors: { bg: label, bgCard: label, bgCardAlt: label, text: label, textMuted: label, textDim: label, primary: label, accent: label, success: label, warning: label, danger: label, info: label, highlight: label },
+  colors: {
+    bg: label,
+    bgCard: label,
+    bgCardAlt: label,
+    text: label,
+    textMuted: label,
+    textDim: label,
+    primary: label,
+    accent: label,
+    success: label,
+    warning: label,
+    danger: label,
+    info: label,
+    highlight: label,
+  },
   fonts: { title: "Georgia", body: "Helvetica", mono: "Menlo" },
 });
 


### PR DESCRIPTION
## Summary

Expose the slide-theme priority that `slide.ts`'s private `resolveTheme` already encodes as a public method on `MulmoPresentationStyleMethods`, so browser callers (`@mulmocast/deck-web`) can call into the same resolver via the `mulmocast/browser` entry point.

Priority (high → low) — single source of truth across renderer + editor:

1. `beat.image.theme` — per-beat override
2. `presentationStyle.slideParams.theme` — deck-level default
3. `slideThemes.corporate` — built-in fallback

`slide.ts:resolveTheme` is now a thin delegation to the new method (no behaviour change for any existing CLI / renderer path).

## Why

Browser callers — specifically `@mulmocast/deck-web`'s `MulmoScriptDeckEditor` — have no way to reach the renderer's resolver today, so the editor re-implemented a different priority that misses `beat.image.theme` entirely. Users running through `mulmoclaude` see this as:

- **Editor**: cream Aurora fallback (deck-web's `defaultTheme`)
- **PDF / movie**: navy from `beat.image.theme` (renderer's `resolveTheme`)

…same SlideLayout DSL, two different fallbacks. Reported on [receptron/mulmoclaude#1622](https://github.com/receptron/mulmoclaude/issues/1622).

## Behavioural notes

- **Non-slide beat**: returns the presentation-level / corporate fallback instead of throwing. Deck-preview callers driving a mixed script can now hand any beat in without first checking `beat.image.type === "slide"`. The pre-existing throw in `slide.ts:resolveTheme` was there to catch internal mis-dispatch; that's not a useful guarantee at the public API boundary.
- `mulmocast/browser` already re-exports `MulmoPresentationStyleMethods` via `index.common.ts`, so deck-web can import the method without dragging Puppeteer / ffmpeg into a Vue bundle.

## Test plan

- [x] `yarn build` clean (TSC, both Node and browser entry points)
- [x] `yarn lint` — no new warnings (only the pre-existing complexity warnings unrelated to this change)
- [x] `yarn tsx --test test/methods/test_presentation_style.ts` → 9/9 (5 existing + 4 new pinning the priority)
- [ ] **Follow-up**: deck-web PR to import this method in `MulmoScriptDeckEditor`. Tracked separately.

## Related

- Downstream report: [receptron/mulmoclaude#1622](https://github.com/receptron/mulmoclaude/issues/1622)
- Editor package: `@mulmocast/deck-web` (target of the follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified slide theme resolution with clear precedence: per-beat theme overrides presentation-level theme, then a corporate fallback; fallback applied safely even when a beat isn't a slide.

* **Tests**
  * Added tests validating theme resolution precedence and fallback behavior across beat scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->