### PR TITLE
fix(translate): preserve original error instead of masking it as a generic apiError

### DIFF
--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -300,8 +300,12 @@ export const translateBeat = async (index: number, context: MulmoStudioContext, 
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to translate", {
-      cause: agentGenerationError("translateBeat", translateAction, multiLingualFileTarget),
+    // Preserve the original error. Without this, a non-structured failure (e.g.
+    // a GraphAI assertion such as "mapAgent: Concurrency is too low") would be
+    // masked as a generic apiError with no diagnostic detail.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to translate: ${message}`, {
+      cause: { ...agentGenerationError("translateBeat", translateAction, multiLingualFileTarget), originalError: error },
     });
   }
 };
@@ -338,11 +342,16 @@ export const translate = async (context: MulmoStudioContext, args?: PublicAPIArg
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", false, true);
   } catch (error) {
     MulmoStudioContextMethods.setSessionState(context, "multiLingual", false, false);
+    GraphAILogger.log(error);
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to translate", {
-      cause: agentGenerationError("translateBeat", translateAction, multiLingualFileTarget),
+    // Preserve the original error. Without this, a non-structured failure (e.g.
+    // a GraphAI assertion such as "mapAgent: Concurrency is too low") would be
+    // masked as a generic apiError with no diagnostic detail.
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to translate: ${message}`, {
+      cause: { ...agentGenerationError("translateBeat", translateAction, multiLingualFileTarget), originalError: error },
     });
   }
   return context;

--- a/src/actions/translate.ts
+++ b/src/actions/translate.ts
@@ -351,7 +351,7 @@ export const translate = async (context: MulmoStudioContext, args?: PublicAPIArg
     // masked as a generic apiError with no diagnostic detail.
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to translate: ${message}`, {
-      cause: { ...agentGenerationError("translateBeat", translateAction, multiLingualFileTarget), originalError: error },
+      cause: { ...agentGenerationError("translate", translateAction, multiLingualFileTarget), originalError: error },
     });
   }
   return context;


### PR DESCRIPTION
## Summary

The two `catch` blocks in `src/actions/translate.ts` replaced any error **without** a `.cause` with a generic `"Failed to translate"` / `apiError`, discarding the original message and stack:

```ts
if (hasCause(error) && error.cause) {
  throw error;
}
throw new Error("Failed to translate", {
  cause: agentGenerationError("translateBeat", translateAction, multiLingualFileTarget),
});
```

This masked real failures. In particular a GraphAI assertion — `mapAgent: Concurrency is too low` (a regression from per-label concurrency, receptron/graphai#1314, fixed in receptron/graphai#1326) — has no `.cause`, so it fell into this branch and surfaced in CI ([failing run](https://github.com/receptron/mulmocast-cli/actions/runs/27046673532/job/79833907508)) only as:

```
An unexpected error occurred: Error: Failed to translate
  [cause]: { type: 'apiError', action: 'translate', target: 'multiLingualFile', agentName: 'translateBeat' }
```

…with the actual root cause nowhere in the log.

## Change

- Include the original error message in the thrown message: `Failed to translate: <original message>`.
- Attach the original error to the structured cause as `originalError`, keeping the existing i18n-friendly cause shape (consumers read `type`/`action`/etc.; the extra field is additive).
- Log the error in the **outer** catch too (the inner one already did).

This is a diagnosability fix only; the structured `apiError` cause is still produced for the GUI/i18n path. No test pins the `"Failed to translate"` string.

`npx tsc --noEmit` and `yarn lint` clean (only pre-existing warnings).

> Note: the underlying CI failure is fixed upstream by receptron/graphai#1326. This PR ensures a future masked error is actually diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for translation failures by including detailed information about the underlying cause, helping users better understand what went wrong.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->