### PR TITLE
mulmocast@2.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.6.20](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.20) (2026-06-09)
+
+- **e2e CI parallelized**: split the monolithic `e2e` job into 16 shards × `[22.x, 24.x]` matrix so each script runs on its own runner; target wall-clock ~10 min vs ~30 min before (#1404)
+- **`@mulmocast/types` version aligned**: 2.6.18 → 2.6.20 to match `mulmocast` (catches up types changes since `@mulmocast/types@2.4.0`)
+- **Dependency updates**: `graphai` ^2.0.17 → ^2.0.18
+
+📦 **npm**: [`mulmocast@2.6.20`](https://www.npmjs.com/package/mulmocast/v/2.6.20) · [`@mulmocast/types@2.6.20`](https://www.npmjs.com/package/@mulmocast/types/v/2.6.20)
+
 ## [2.6.19](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.19) (2026-06-06)
 
 - **`getResolvedSlideTheme` method**: new `MulmoPresentationStyleMethods.getResolvedSlideTheme` exposes the merged slide theme (script + presentation style + defaults) so callers can read the effective theme without re-deriving it (#1402)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast",
-  "version": "2.6.19",
+  "version": "2.6.20",
   "description": "",
   "type": "module",
   "main": "lib/index.node.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/types",
-  "version": "2.6.18",
+  "version": "2.6.20",
   "description": "Type definitions for MulmoCast",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Release **mulmocast@2.6.20** and **@mulmocast/types@2.6.20** (versions aligned).

Already published to npm:
- 📦 [\`mulmocast@2.6.20\`](https://www.npmjs.com/package/mulmocast/v/2.6.20)
- 📦 [\`@mulmocast/types@2.6.20\`](https://www.npmjs.com/package/@mulmocast/types/v/2.6.20)

## Highlights

- **e2e CI parallelized**: 16 shards × \`[22.x, 24.x]\` matrix, ~10 min target wall-clock (#1404)
- **\`@mulmocast/types\` version aligned**: 2.6.18 → 2.6.20 to match \`mulmocast\`
- **Dependency updates**: \`graphai\` ^2.0.17 → ^2.0.18

See \`CHANGELOG.md\` for full notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.6.20 with synchronized type package updates and dependency improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->