### PR TITLE
feat: introduce UsageCollector and MulmoStudioContext.usageCollector

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./type.js";
 export * from "./schema.js";
 export * from "./viewer.js";
+export * from "./usage.js";

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,4 +1,5 @@
 import { type CallbackFunction } from "graphai";
+import type { UsageCollector } from "../utils/usage_collector.js";
 import {
   langSchema,
   localizedTextSchema,
@@ -132,6 +133,7 @@ export type MulmoStudioContext = {
   sessionState: MulmoSessionState;
   presentationStyle: MulmoPresentationStyle;
   multiLingual: MulmoStudioMultiLingualArray;
+  usageCollector?: UsageCollector;
 };
 
 export type ScriptingParams = {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,5 +1,5 @@
 import { type CallbackFunction } from "graphai";
-import type { UsageCollector } from "../utils/usage_collector.js";
+import type { UsageCollectorAPI } from "./usage.js";
 import {
   langSchema,
   localizedTextSchema,
@@ -133,7 +133,7 @@ export type MulmoStudioContext = {
   sessionState: MulmoSessionState;
   presentationStyle: MulmoPresentationStyle;
   multiLingual: MulmoStudioMultiLingualArray;
-  usageCollector?: UsageCollector;
+  usageCollector?: UsageCollectorAPI;
 };
 
 export type ScriptingParams = {

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -1,0 +1,22 @@
+export type UsageRecord = {
+  agent: string;
+  provider: string;
+  model: string;
+  beatIndex?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  predictSec?: number;
+  inputChars?: number;
+  cached: boolean;
+  retryAttempt?: number;
+  timestamp: string;
+};
+
+export type UsageCollectorAPI = {
+  add(record: Omit<UsageRecord, "timestamp"> & { timestamp?: string }): void;
+  snapshot(): UsageRecord[];
+  merge(other: UsageCollectorAPI): void;
+  clear(): void;
+  readonly size: number;
+};

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -13,6 +13,7 @@ import type {
 import { mulmoStudioSchema, mulmoCaptionParamsSchema, mulmoPresentationStyleSchema } from "../types/schema.js";
 import { MulmoPresentationStyleMethods, MulmoScriptMethods, MulmoStudioMultiLingualMethod } from "../methods/index.js";
 import { loadMulmoConfig, mergeConfigWithScript } from "./mulmo_config.js";
+import { UsageCollector } from "./usage_collector.js";
 
 export const silentMp3 = "https://github.com/receptron/mulmocast-cli/raw/refs/heads/main/assets/audio/silent300.mp3";
 
@@ -194,6 +195,7 @@ export const initializeContextFromFiles = async (
       force: Boolean(force),
       backup: Boolean(withBackup),
       lang: targetLang ?? studio.script.lang, // This lang is target Language. studio.lang is default Language
+      usageCollector: new UsageCollector(),
     };
   } catch (error) {
     GraphAILogger.info(`Error: invalid MulmoScript Schema: ${isHttpPath ? fileOrUrl : mulmoFilePath} \n ${formatMulmoError(error)}`);

--- a/src/utils/usage_collector.ts
+++ b/src/utils/usage_collector.ts
@@ -10,11 +10,11 @@ export class UsageCollector implements UsageCollectorAPI {
   }
 
   snapshot(): UsageRecord[] {
-    return this.records.slice();
+    return this.records.map((record) => ({ ...record }));
   }
 
   merge(other: UsageCollectorAPI): void {
-    other.snapshot().forEach((record) => this.records.push(record));
+    other.snapshot().forEach((record) => this.records.push({ ...record }));
   }
 
   clear(): void {

--- a/src/utils/usage_collector.ts
+++ b/src/utils/usage_collector.ts
@@ -1,19 +1,8 @@
-export type UsageRecord = {
-  agent: string;
-  provider: string;
-  model: string;
-  beatIndex?: number;
-  inputTokens?: number;
-  outputTokens?: number;
-  totalTokens?: number;
-  predictSec?: number;
-  inputChars?: number;
-  cached: boolean;
-  retryAttempt?: number;
-  timestamp: string;
-};
+import type { UsageRecord, UsageCollectorAPI } from "../types/usage.js";
 
-export class UsageCollector {
+export type { UsageRecord, UsageCollectorAPI } from "../types/usage.js";
+
+export class UsageCollector implements UsageCollectorAPI {
   private readonly records: UsageRecord[] = [];
 
   add(record: Omit<UsageRecord, "timestamp"> & { timestamp?: string }): void {
@@ -24,7 +13,7 @@ export class UsageCollector {
     return this.records.slice();
   }
 
-  merge(other: UsageCollector): void {
+  merge(other: UsageCollectorAPI): void {
     other.snapshot().forEach((record) => this.records.push(record));
   }
 

--- a/src/utils/usage_collector.ts
+++ b/src/utils/usage_collector.ts
@@ -1,0 +1,38 @@
+export type UsageRecord = {
+  agent: string;
+  provider: string;
+  model: string;
+  beatIndex?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  predictSec?: number;
+  inputChars?: number;
+  cached: boolean;
+  retryAttempt?: number;
+  timestamp: string;
+};
+
+export class UsageCollector {
+  private readonly records: UsageRecord[] = [];
+
+  add(record: Omit<UsageRecord, "timestamp"> & { timestamp?: string }): void {
+    this.records.push({ ...record, timestamp: record.timestamp ?? new Date().toISOString() });
+  }
+
+  snapshot(): UsageRecord[] {
+    return this.records.slice();
+  }
+
+  merge(other: UsageCollector): void {
+    other.snapshot().forEach((record) => this.records.push(record));
+  }
+
+  clear(): void {
+    this.records.length = 0;
+  }
+
+  get size(): number {
+    return this.records.length;
+  }
+}

--- a/test/utils/test_usage_collector.ts
+++ b/test/utils/test_usage_collector.ts
@@ -43,12 +43,32 @@ test("UsageCollector: explicit timestamp is preserved", () => {
   assert.strictEqual(collector.snapshot()[0].timestamp, fixed);
 });
 
-test("UsageCollector: snapshot returns a copy", () => {
+test("UsageCollector: snapshot returns a copy (array + records)", () => {
   const collector = new UsageCollector();
-  collector.add({ agent: "x", provider: "openai", model: "m", cached: false });
+  collector.add({ agent: "x", provider: "openai", model: "m", totalTokens: 100, cached: false });
   const snap = collector.snapshot();
   snap.length = 0;
-  assert.strictEqual(collector.size, 1, "mutating snapshot must not affect collector");
+  assert.strictEqual(collector.size, 1, "mutating snapshot array must not affect collector");
+
+  const snap2 = collector.snapshot();
+  snap2[0].agent = "MUTATED";
+  snap2[0].totalTokens = 999;
+  const fresh = collector.snapshot();
+  assert.strictEqual(fresh[0].agent, "x", "mutating record in snapshot must not affect collector");
+  assert.strictEqual(fresh[0].totalTokens, 100, "mutating numeric field in snapshot must not affect collector");
+});
+
+test("UsageCollector: merge defensively copies records", () => {
+  const a = new UsageCollector();
+  const b = new UsageCollector();
+  b.add({ agent: "b1", provider: "openai", model: "m", totalTokens: 50, cached: false });
+  a.merge(b);
+
+  const aSnap = a.snapshot();
+  aSnap[0].totalTokens = 999;
+  const bSnap = b.snapshot();
+  assert.strictEqual(bSnap[0].totalTokens, 50, "mutating a's snapshot must not reach b's records");
+  assert.strictEqual(a.snapshot()[0].totalTokens, 50, "mutating snapshot must not reach a's records either");
 });
 
 test("UsageCollector: merge", () => {

--- a/test/utils/test_usage_collector.ts
+++ b/test/utils/test_usage_collector.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { UsageCollector } from "../../src/utils/usage_collector.js";
+
+test("UsageCollector: empty snapshot", () => {
+  const collector = new UsageCollector();
+  assert.deepStrictEqual(collector.snapshot(), []);
+  assert.strictEqual(collector.size, 0);
+});
+
+test("UsageCollector: add and snapshot", () => {
+  const collector = new UsageCollector();
+  collector.add({
+    agent: "imageOpenaiAgent",
+    provider: "openai",
+    model: "gpt-image-1",
+    beatIndex: 0,
+    inputTokens: 100,
+    outputTokens: 200,
+    totalTokens: 300,
+    cached: false,
+  });
+  const records = collector.snapshot();
+  assert.strictEqual(records.length, 1);
+  assert.strictEqual(records[0].agent, "imageOpenaiAgent");
+  assert.strictEqual(records[0].provider, "openai");
+  assert.strictEqual(records[0].totalTokens, 300);
+  assert.strictEqual(records[0].cached, false);
+  assert.ok(records[0].timestamp, "timestamp should be auto-set");
+});
+
+test("UsageCollector: explicit timestamp is preserved", () => {
+  const collector = new UsageCollector();
+  const fixed = "2026-06-19T00:00:00.000Z";
+  collector.add({
+    agent: "imageGenAIAgent",
+    provider: "google",
+    model: "gemini-2.5-flash-image",
+    cached: false,
+    timestamp: fixed,
+  });
+  assert.strictEqual(collector.snapshot()[0].timestamp, fixed);
+});
+
+test("UsageCollector: snapshot returns a copy", () => {
+  const collector = new UsageCollector();
+  collector.add({ agent: "x", provider: "openai", model: "m", cached: false });
+  const snap = collector.snapshot();
+  snap.length = 0;
+  assert.strictEqual(collector.size, 1, "mutating snapshot must not affect collector");
+});
+
+test("UsageCollector: merge", () => {
+  const a = new UsageCollector();
+  const b = new UsageCollector();
+  a.add({ agent: "a1", provider: "openai", model: "m1", cached: false });
+  b.add({ agent: "b1", provider: "google", model: "m2", cached: false });
+  b.add({ agent: "b2", provider: "replicate", model: "m3", predictSec: 4.2, cached: false });
+  a.merge(b);
+  const snap = a.snapshot();
+  assert.strictEqual(snap.length, 3);
+  assert.deepStrictEqual(
+    snap.map((r) => r.agent),
+    ["a1", "b1", "b2"],
+  );
+});
+
+test("UsageCollector: clear", () => {
+  const collector = new UsageCollector();
+  collector.add({ agent: "x", provider: "openai", model: "m", cached: false });
+  collector.add({ agent: "y", provider: "openai", model: "m", cached: false });
+  collector.clear();
+  assert.strictEqual(collector.size, 0);
+  assert.deepStrictEqual(collector.snapshot(), []);
+});
+
+test("UsageCollector: records mixed metric shapes", () => {
+  const collector = new UsageCollector();
+  collector.add({ agent: "llm", provider: "openai", model: "gpt-4", inputTokens: 50, outputTokens: 100, totalTokens: 150, cached: false });
+  collector.add({ agent: "tts", provider: "openai", model: "tts-1", inputChars: 240, cached: false });
+  collector.add({ agent: "replicate", provider: "replicate", model: "flux", predictSec: 12.5, cached: false });
+  collector.add({ agent: "cached", provider: "openai", model: "gpt-4", cached: true });
+  const records = collector.snapshot();
+  assert.strictEqual(records.length, 4);
+  assert.strictEqual(records[0].totalTokens, 150);
+  assert.strictEqual(records[1].inputChars, 240);
+  assert.strictEqual(records[2].predictSec, 12.5);
+  assert.strictEqual(records[3].cached, true);
+});

--- a/types/src/usage.ts
+++ b/types/src/usage.ts
@@ -1,0 +1,1 @@
+../../src/types/usage.ts


### PR DESCRIPTION
## Summary

Foundation for token / API usage tracking, the first step toward billing-grade per-request metering (umbrella #1415, plan #1424).

## Items to Confirm / Review

- **Additive only**: `usageCollector` is `?` on `MulmoStudioContext` and nothing currently reads it. No existing call path changes behavior.
- **Initialization site**: only `initializeContextFromFiles` populates the collector. Any other code path that constructs a `MulmoStudioContext` from scratch (none today, but if you add one) will have `usageCollector` undefined — agents are expected to no-op in that case.
- **Per-request scope**: deliberately not a global / module-level singleton. Multi-process API workers each get their own instance.
- **No persistence**: `UsageCollector` only lives in memory; the API layer reads `snapshot()` and persists. mulmocast has no cost table or DB.

## User Prompt

> 別の課題。tokenの利用について知りたいんだけどそういうのをデータやjsonファイルで残すことできる？  
> mulmocastの実行をAPI化して、そこでtoken課金をしたい  
> 料金表はもたない。サービス側でメンテする  
> 画像だけじゃなくmovie / lipSync / LLMも対応。抜けがある部分はメモる  
> まずissueにまとめよう。アンブレラ + 子issueに分割。  
> さて、まず簡単なもの、影響の少ないものから始めよう。

## Changes

- `src/utils/usage_collector.ts` (new) — `UsageRecord` type + `UsageCollector` class (`add` / `snapshot` / `merge` / `clear` / `size`).
- `src/types/type.ts` — add `usageCollector?: UsageCollector` to `MulmoStudioContext`.
- `src/utils/context.ts` — initialize a fresh `UsageCollector` in `initializeContextFromFiles`.
- `test/utils/test_usage_collector.ts` (new) — 7 unit tests, 100% coverage of the new module.

## Test plan

- [x] `yarn lint` clean (warnings unchanged from main)
- [x] `yarn build` succeeds
- [x] `yarn ci_test` all green; usage_collector.ts at 100% coverage
- [ ] (Reviewer) sanity-check that the type addition doesn't ripple in any unexpected way

## Related

- Umbrella: #1415
- Closes #1416
- Plan: #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a usage tracking collector that records usage with automatic timestamps, supports defensive snapshots, merging from another collector, clearing, and exposes a live `size` count.
  * Extended the studio context to optionally include the usage collector.
  * Expanded public type exports to include usage-related interfaces and records.
* **Tests**
  * Added a Node.js test suite covering initial state, `add`/`snapshot` behavior, explicit timestamps, snapshot immutability, `merge`/`clear`, `size`, and mixed metric shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->