### PR TITLE
feat: surface Gemini image-gen usage via UsageCollector

### DIFF
--- a/src/agents/image_genai_agent.ts
+++ b/src/agents/image_genai_agent.ts
@@ -22,6 +22,7 @@ import {
 import { getAspectRatio } from "../utils/utils.js";
 import { ASPECT_RATIOS, PRO_ASPECT_RATIOS } from "../types/const.js";
 import type { AgentBufferResult, ImageAgentInputs, ImageAgentParams, GenAIImageAgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 import { GoogleGenAI, PersonGeneration, GenerateContentResponse } from "@google/genai";
 
 const isDeprecatedGoogleImageModel = (model: string): model is DeprecatedGoogleImageModel => model in deprecatedGoogleImageModelHints;
@@ -42,12 +43,21 @@ const getGeminiContents = (prompt: string, referenceImages?: string[] | null) =>
   return contents;
 };
 
-const geminiFlashResult = (response: GenerateContentResponse) => {
+const geminiFlashResult = (response: GenerateContentResponse, model: string) => {
   if (!response.candidates?.[0]?.content?.parts) {
     throw new Error("ERROR: generateContent returned no candidates", {
       cause: agentInvalidResponseError("imageGenAIAgent", imageAction, imageFileTarget),
     });
   }
+  const usage: AgentUsage | undefined = response.usageMetadata
+    ? {
+        provider: "google",
+        model,
+        inputTokens: response.usageMetadata.promptTokenCount,
+        outputTokens: response.usageMetadata.candidatesTokenCount,
+        totalTokens: response.usageMetadata.totalTokenCount,
+      }
+    : undefined;
   for (const part of response.candidates[0].content.parts) {
     if (part.text) {
       GraphAILogger.info("Gemini image generation response:", part.text);
@@ -59,7 +69,7 @@ const geminiFlashResult = (response: GenerateContentResponse) => {
         });
       }
       const buffer = Buffer.from(imageData, "base64");
-      return { buffer };
+      return { buffer, usage };
     }
   }
   throw new Error("ERROR: generateContent returned no image data", {
@@ -135,7 +145,7 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
     })();
     const res = await resultify(() => ai.models.generateContent(contentParams));
     if (res.ok) {
-      return geminiFlashResult(res.value);
+      return geminiFlashResult(res.value, model);
     }
     return errorProcess(res.error);
   }


### PR DESCRIPTION
## Summary

Stacked on top of #1429 (the OpenAI image-gen usage PR). Adds the same usage surfacing for Gemini's image-gen (`gemini-2.5-flash-image` and the gemini-3 family). Closes #1418.

> ⚠️ **Base branch is `feat/usage-openai-image`, not `main`.** Will rebase to main after #1429 merges.

## Items to Confirm / Review

- **Flash/Pro path only**: `ai.models.generateContent` returns `GenerateContentResponse.usageMetadata` (prompt/candidates/total token counts). Imagen via `ai.models.generateImages` returns `GenerateImagesResponse` which has NO usage fields, so that path keeps returning `{ buffer }` only.
- **No callback wiring change**: `createUsageCallback` was already registered on both `generateImages` (outer graph) and `generateBeatImage` (per-beat public API) in #1429. Agents only need to opt in by returning `{ buffer, usage }`.
- **`usage` is `undefined`-tolerant**: if Gemini returns a response without `usageMetadata` (cached, retried, etc.), we emit `usage: undefined` rather than fabricating zero counts. The callback's type guard skips records without `provider`/`model`, so no garbage data reaches the collector.

## User Prompt

> #1429をベースにできるものをすすめて

Picked #1418 (Gemini image) as the smallest stackable next step — same code shape as #1417, no new wiring, exercises the AgentUsage / createUsageCallback contract from a second provider to confirm it generalizes.

## Changes

- `src/agents/image_genai_agent.ts` — `geminiFlashResult(response, model)` now extracts `response.usageMetadata` and includes it in the return.

## Test plan

- [x] `yarn lint` clean (warnings unchanged)
- [x] `yarn build` (root + types) OK
- [x] `yarn ci_test` 901 pass / 0 fail
- [ ] (Reviewer / probe) E2E with `GEMINI_API_KEY` against a script that uses `gemini-2.5-flash-image` — I haven't run this myself (no key locally). The pattern matches #1429's `scripts/probe/probe_usage.ts` so swapping the script JSON is enough.

## Related

- Stacked on: #1429
- Closes #1418
- Sibling: #1426 (TTS v1), #1419 (LLM callback wiring), #1421 (Replicate), #1422 (Veo), #1427 (ElevenLabs/Gemini TTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)