### PR TITLE
test: pin createUsageCallback nested mapAgent propagation

### DIFF
--- a/test/utils/test_usage_nested_callback.ts
+++ b/test/utils/test_usage_nested_callback.ts
@@ -1,0 +1,92 @@
+// #1423 — verify that GraphAI's mapAgent propagates registered callbacks
+// to nested child graphs, so createUsageCallback registered on the outer
+// graph captures usage from agents that run inside per-row child graphs.
+//
+// The probe (scripts/probe/probe_usage.ts) already demonstrated this works
+// end-to-end with the real OpenAI / Gemini image agents. This test pins
+// the behavior so future graphai upgrades or refactors can't silently
+// break the collector.
+
+import test from "node:test";
+import assert from "node:assert";
+import { GraphAI } from "graphai";
+import * as vanilla_agents from "@graphai/vanilla";
+
+import { createUsageCallback } from "../../src/utils/usage_callback.js";
+import { UsageCollector } from "../../src/utils/usage_collector.js";
+import type { MulmoStudioContext } from "../../src/types/type.js";
+
+const agents = { ...(vanilla_agents.default ?? vanilla_agents) };
+
+const makeContext = (collector: UsageCollector): MulmoStudioContext => ({ usageCollector: collector }) as unknown as MulmoStudioContext;
+
+// Inner graph: one node that just echoes a fake `usage` object so the
+// callback sees a Completed result with the AgentUsage shape.
+const beatGraph = {
+  version: 0.5 as const,
+  nodes: {
+    row: {},
+    fakeImageAgent: {
+      agent: "copyAgent",
+      inputs: {
+        usage: {
+          provider: "openai",
+          model: "gpt-image-1",
+          inputTokens: 100,
+          outputTokens: 200,
+          totalTokens: 300,
+        },
+      },
+      isResult: true,
+    },
+  },
+};
+
+const buildOuter = () => ({
+  version: 0.5 as const,
+  concurrency: 4,
+  nodes: {
+    rows: {},
+    fanout: {
+      agent: "mapAgent",
+      inputs: { rows: ":rows" },
+      params: { rowKey: "row", compositeResult: true },
+      graph: beatGraph,
+      isResult: true,
+    },
+  },
+});
+
+test("createUsageCallback receives records from nested mapAgent children", async () => {
+  const collector = new UsageCollector();
+  const graph = new GraphAI(buildOuter(), agents);
+  graph.injectValue("rows", ["a", "b", "c"]);
+  graph.registerCallback(createUsageCallback(makeContext(collector)));
+
+  await graph.run();
+
+  const snap = collector.snapshot();
+  assert.strictEqual(snap.length, 3, "expected one record per inner row");
+  for (const r of snap) {
+    assert.strictEqual(r.provider, "openai");
+    assert.strictEqual(r.model, "gpt-image-1");
+    assert.strictEqual(r.totalTokens, 300);
+    assert.strictEqual(r.cached, false);
+  }
+  // beatIndex comes from log.mapIndex which mapAgent sets per row.
+  const indices = snap.map((r) => r.beatIndex).sort();
+  assert.deepStrictEqual(indices, [0, 1, 2]);
+});
+
+test("nested callback also collects when outer graph has 12 rows (matches mulmocast beat count)", async () => {
+  const collector = new UsageCollector();
+  const graph = new GraphAI(buildOuter(), agents);
+  graph.injectValue(
+    "rows",
+    Array.from({ length: 12 }, (_, i) => `r${i}`),
+  );
+  graph.registerCallback(createUsageCallback(makeContext(collector)));
+
+  await graph.run();
+  assert.strictEqual(collector.size, 12, "expected one usage record per beat");
+});


### PR DESCRIPTION
Closes #1423.

## Summary

Pins the behavior that `createUsageCallback` registered on an outer GraphAI graph captures usage from agents that run inside per-row child graphs dispatched by `mapAgent`. This is the path that #1429's real-world probe (3 OpenAI image records) and #1430's probe (6 Gemini image records) already validated end-to-end — this PR codifies it so a future graphai upgrade or mapAgent refactor can't silently break the collector.

## What it covers

- Outer graph: one `mapAgent` node iterating over `rows`.
- Inner graph: one node returning `{ usage: { provider, model, totalTokens, ... } }` via `copyAgent` (no external SDK dependency).
- Registers `createUsageCallback` on the outer graph only.
- Asserts the inner-node usage reaches `context.usageCollector` with `beatIndex === mapIndex`.

Two cases:
- 3 rows (sanity).
- 12 rows (matches typical mulmocast beat count, mirrors translate's `beats × targetLangs` nesting depth).

## Why now

The empirical probe results in #1429 and #1430 are convincing but not durable — only this test guarantees the invariant under future graphai upgrades. Every subsequent agent surfacing (#1426 / #1427 / #1419 / #1421 / #1422) depends on it.

## Test plan

- [x] `yarn lint`, `yarn build`, `yarn ci_test` 903 / 899 pass / 0 fail (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for usage tracking in nested graph scenarios, validating correct capture of usage records from child graphs across multi-row operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->