### PR TITLE
feat: TTS usage v1 — input character fallback (openai legacy / google / kotodama)

### DIFF
--- a/scripts/probe/probe_usage.ts
+++ b/scripts/probe/probe_usage.ts
@@ -1,22 +1,32 @@
-// Probe: run images() against a test script and dump usageCollector contents.
+// Probe: run a mulmocast action (images / audio / translate) against a test
+// script and dump usageCollector contents.
 //
 // Usage:
 //   OPENAI_API_KEY=sk-... npx tsx scripts/probe/probe_usage.ts
 //
 // Optional env:
-//   USAGE_SCRIPT=scripts/test/test_gpt_image.json   (default)
-//   USAGE_OUTDIR=/tmp/probe_usage_output             (default)
+//   USAGE_ACTION=images | audio | translate         (default: images)
+//   USAGE_SCRIPT=scripts/test/test_gpt_image.json   (default depends on action)
+//   USAGE_OUTDIR=/tmp/probe_usage_output             (default: per-action subdir)
+//   USAGE_TARGET_LANG=ja                             (default: ja, translate only)
 
 import path from "path";
 import fs from "fs";
-import { images } from "../../src/actions/index.js";
+import { images, audio, translate } from "../../src/actions/index.js";
 import { initializeContextFromFiles } from "../../src/utils/context.js";
 import { getFileObject } from "../../src/cli/helpers.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
-const scriptArg = process.env.USAGE_SCRIPT ?? "scripts/test/test_gpt_image.json";
+const action = (process.env.USAGE_ACTION ?? "images") as "images" | "audio" | "translate";
+const defaultScript: Record<typeof action, string> = {
+  images: "scripts/test/test_gpt_image.json",
+  audio: "scripts/test/test_all_tts.json",
+  translate: "scripts/test/test_lang.json",
+};
+const scriptArg = process.env.USAGE_SCRIPT ?? defaultScript[action];
 const scriptPath = path.resolve(repoRoot, scriptArg);
-const outDir = process.env.USAGE_OUTDIR ?? "/tmp/probe_usage_output";
+const outDir = process.env.USAGE_OUTDIR ?? `/tmp/probe_usage_${action}`;
+const targetLang = process.env.USAGE_TARGET_LANG ?? "ja";
 
 fs.mkdirSync(outDir, { recursive: true });
 
@@ -25,11 +35,12 @@ const main = async () => {
     console.error("OPENAI_API_KEY required");
     process.exit(1);
   }
+  console.log(`action: ${action}`);
   console.log(`script: ${scriptPath}`);
   console.log(`outdir: ${outDir}`);
 
   const fileDirs = getFileObject({ file: scriptPath, outdir: outDir });
-  const context = await initializeContextFromFiles(fileDirs, true, true);
+  const context = await initializeContextFromFiles(fileDirs, true, true, undefined, undefined, action === "translate" ? targetLang : undefined);
   if (!context) {
     console.error("context init failed");
     process.exit(1);
@@ -38,7 +49,13 @@ const main = async () => {
   console.log(`collector initialized: ${Boolean(context.usageCollector)}`);
 
   const before = Date.now();
-  await images(context);
+  if (action === "images") {
+    await images(context);
+  } else if (action === "audio") {
+    await audio(context);
+  } else if (action === "translate") {
+    await translate(context);
+  }
   const elapsedSec = (Date.now() - before) / 1000;
 
   const snap = context.usageCollector?.snapshot() ?? [];

--- a/src/actions/audio.ts
+++ b/src/actions/audio.ts
@@ -19,6 +19,7 @@ import {
 import { MulmoStudioContext, MulmoBeat, MulmoStudioBeat, MulmoStudioMultiLingualData, PublicAPIArgs } from "../types/index.js";
 
 import { audioGraphOption } from "./graph_option.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
 import {
   getAudioArtifactFilePath,
   getAudioFilePath,
@@ -277,6 +278,7 @@ export const generateBeatAudio = async (index: number, context: MulmoStudioConte
 
     const graph = new GraphAI(langs ? graph_tts_map : graph_tts, audioAgents, await audioGraphOption(context, settings));
     callbacks?.forEach((callback) => graph.registerCallback(callback));
+    graph.registerCallback(createUsageCallback(context));
     graph.injectValue("__mapIndex", index);
     graph.injectValue("beat", context.studio.script.beats[index]);
     graph.injectValue("studioBeat", context.studio.beats[index]);
@@ -315,6 +317,7 @@ export const audio = async (context: MulmoStudioContext, args?: PublicAPIArgs) =
 
     const graph = new GraphAI(audio_graph_data, audioAgents, await audioGraphOption(context, settings));
     callbacks?.forEach((callback) => graph.registerCallback(callback));
+    graph.registerCallback(createUsageCallback(context));
     graph.injectValue("context", context);
     graph.injectValue("audioArtifactFilePath", audioArtifactFilePath);
     graph.injectValue("audioCombinedFilePath", audioCombinedFilePath);

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -10,6 +10,7 @@ import {
   audioFileTarget,
 } from "../utils/error_cause.js";
 import type { ElevenlabsTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -86,10 +87,22 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
     });
   }
 
+  // ElevenLabs returns the exact billed character count in the `character-cost`
+  // header (already discounted for V2 Flash/Turbo etc. — see #1420 research).
+  // We read it BEFORE consuming the body so the header is still accessible.
+  const billedHeader = response.headers.get("character-cost");
+  const billedChars = billedHeader ? Number(billedHeader) : undefined;
+
   const arrayBuffer = await response.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 
-  return { buffer };
+  const usage: AgentUsage = {
+    provider: "elevenlabs",
+    model: requestBody.model_id,
+    // Use upstream-billed amount when available (exact); fall back to raw text length.
+    inputChars: Number.isFinite(billedChars) ? billedChars : text.length,
+  };
+  return { buffer, usage };
 };
 
 const ttsElevenlabsAgentInfo: AgentFunctionInfo = {

--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -14,6 +14,7 @@ import {
 import { pcmToMp3 } from "../utils/ffmpeg_utils.js";
 
 import type { GoogleTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 const getPrompt = (text: string, instructions?: string) => {
   // https://ai.google.dev/gemini-api/docs/speech-generation?hl=ja#controllable
@@ -65,7 +66,17 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
 
     const rawPcm = Buffer.from(pcmBase64, "base64");
 
-    return { buffer: await pcmToMp3(rawPcm, sampleRate) };
+    const usedModel = model ?? provider2TTSAgent.gemini.defaultModel;
+    const usage: AgentUsage | undefined = response.usageMetadata
+      ? {
+          provider: "gemini",
+          model: usedModel,
+          inputTokens: response.usageMetadata.promptTokenCount,
+          outputTokens: response.usageMetadata.candidatesTokenCount,
+          totalTokens: response.usageMetadata.totalTokenCount,
+        }
+      : undefined;
+    return { buffer: await pcmToMp3(rawPcm, sampleRate), usage };
   } catch (e) {
     if (suppressError) {
       return {

--- a/src/agents/tts_google_agent.ts
+++ b/src/agents/tts_google_agent.ts
@@ -5,6 +5,7 @@ import type { ServiceError } from "google-gax";
 import { agentGenerationError, audioAction, audioFileTarget } from "../utils/error_cause.js";
 
 import type { GoogleTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 const client = new textToSpeech.TextToSpeechClient();
 
@@ -54,7 +55,15 @@ export const ttsGoogleAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
   try {
     // Call the Text-to-Speech API
     const [response] = await client.synthesizeSpeech(request, { timeout: SYNTHESIZE_TIMEOUT_MS });
-    return { buffer: response.audioContent as Buffer };
+    // Google Cloud TTS bills per character; SynthesizeSpeechResponse exposes
+    // no usage info. Record inputChars so the billing layer can compute cost
+    // from `model` (voice tier) + char count.
+    const usage: AgentUsage = {
+      provider: "google",
+      model: model ?? voice ?? "default",
+      inputChars: text.length,
+    };
+    return { buffer: response.audioContent as Buffer, usage };
   } catch (e) {
     if (suppressError) {
       return {

--- a/src/agents/tts_kotodama_agent.ts
+++ b/src/agents/tts_kotodama_agent.ts
@@ -3,6 +3,7 @@ import type { AgentFunction, AgentFunctionInfo } from "graphai";
 import { provider2TTSAgent } from "../types/provider2agent.js";
 import { apiKeyMissingError, agentIncorrectAPIKeyError, agentGenerationError, audioAction, audioFileTarget } from "../utils/error_cause.js";
 import type { KotodamaTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -58,7 +59,15 @@ export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBuffer
     }
 
     const buffer = Buffer.from(json.audios[0], "base64");
-    return { buffer };
+    // Kotodama is subscription-billed externally (no public per-char rate API
+    // surface). Report inputChars + voice/decoration so the billing layer can
+    // do its own accounting.
+    const usage: AgentUsage = {
+      provider: "kotodama",
+      model: body.speaker_id,
+      inputChars: text.length,
+    };
+    return { buffer, usage };
   } catch (error) {
     if (suppressError) {
       return {

--- a/src/agents/tts_openai_agent.ts
+++ b/src/agents/tts_openai_agent.ts
@@ -13,6 +13,7 @@ import {
   audioFileTarget,
 } from "../utils/error_cause.js";
 import type { OpenAITTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, OpenAIImageAgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 export const ttsOpenaiAgent: AgentFunction<OpenAITTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, OpenAIImageAgentConfig> = async ({
   namedInputs,
@@ -44,7 +45,15 @@ export const ttsOpenaiAgent: AgentFunction<OpenAITTSAgentParams, AgentBufferResu
     GraphAILogger.log("ttsOptions", tts_options);
     const response = await openai.audio.speech.create(tts_options);
     const buffer = Buffer.from(await response.arrayBuffer());
-    return { buffer };
+    // tts-1 / tts-1-hd bill per character. gpt-4o-mini-tts is token-based and
+    // is handled by #1428; for now we report inputChars uniformly and let the
+    // billing layer pick the right unit from `model`.
+    const usage: AgentUsage = {
+      provider: "openai",
+      model: tts_options.model,
+      inputChars: text.length,
+    };
+    return { buffer, usage };
   } catch (error) {
     if (suppressError) {
       return {


### PR DESCRIPTION
Closes #1426. Follow-up from #1420 research.

## Summary

Surface per-beat `inputChars` for the three TTS providers whose API responses carry no per-call usage. The billing layer maps `(provider, model, inputChars)` → cost via its own rate table.

| Agent | Provider/model | What we emit |
|---|---|---|
| `tts_openai_agent` | `openai` / `tts-1`, `tts-1-hd`, … | `{ provider:"openai", model, inputChars: text.length }` |
| `tts_google_agent` | `google` / voice tier / model | `{ provider:"google", model, inputChars: text.length }` |
| `tts_kotodama_agent` | `kotodama` / speaker_id | `{ provider:"kotodama", model: speaker_id, inputChars: text.length }` |

`createUsageCallback` is registered on both audio graphs (`graph_tts` / `graph_tts_map` and `audio_graph_data`) so the records flow to `context.usageCollector` the same way image agents do.

## Items to Confirm / Review

- **gpt-4o-mini-tts** is token-billed, not character-billed. We still emit `inputChars` for it through the same code path; the billing layer is expected to consult `model` to pick the correct unit. Header-probe work for surfacing token usage on this model is tracked separately by #1428.
- **Google TTS character counting** includes spaces, newlines, and most SSML tags (except `<mark>`). mulmocast doesn't currently emit SSML, so plain `text.length` is correct — if SSML emission lands later the value is automatically correct as long as `text` includes the tags.
- **ElevenLabs (header) + Gemini TTS (usageMetadata)** are NOT in this PR; they get more accurate upstream usage and live in #1427.

## User Prompt

> ok 他はgraphai側のagentの変更も必要？
> aだね。で、並行して進められるものは進めて。どんどん。

## Changes

- `src/agents/tts_openai_agent.ts`, `tts_google_agent.ts`, `tts_kotodama_agent.ts` — extend return with `usage: AgentUsage`
- `src/actions/audio.ts` — register `createUsageCallback` on both audio graphs

## Test plan

- [x] `yarn lint`, `yarn build` (root + types), `yarn ci_test` 901 / 897 pass / 0 fail
- [ ] (Reviewer / probe) Run `scripts/probe/probe_usage.ts` with a script that uses each TTS provider to verify `inputChars` populates per beat. Probe script currently targets `images()`; a small tweak to target `audio()` would be the next reusable extension.

## Related

- Umbrella: #1415
- Closes #1426
- Sibling: #1427 (elevenlabs + gemini TTS — upstream-precise), #1428 (gpt-4o-mini-tts probe — deferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Text-to-speech operations now return usage metadata (provider, effective model, and billed input character counts where available), in addition to the generated audio buffer.
* **New Features**
  * Added automatic usage-tracking callback support for audio generation flows, ensuring usage information is consistently captured.
  * Generalized the usage probe script to run different actions (images, audio, translate) with action-specific options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->