### PR TITLE
feat: TTS usage v1.5 — elevenlabs character-cost header + gemini usageMetadata

### DIFF
--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -10,6 +10,7 @@ import {
   audioFileTarget,
 } from "../utils/error_cause.js";
 import type { ElevenlabsTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -86,10 +87,22 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
     });
   }
 
+  // ElevenLabs returns the exact billed character count in the `character-cost`
+  // header (already discounted for V2 Flash/Turbo etc. — see #1420 research).
+  // We read it BEFORE consuming the body so the header is still accessible.
+  const billedHeader = response.headers.get("character-cost");
+  const billedChars = billedHeader ? Number(billedHeader) : undefined;
+
   const arrayBuffer = await response.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 
-  return { buffer };
+  const usage: AgentUsage = {
+    provider: "elevenlabs",
+    model: requestBody.model_id,
+    // Use upstream-billed amount when available (exact); fall back to raw text length.
+    inputChars: Number.isFinite(billedChars) ? billedChars : text.length,
+  };
+  return { buffer, usage };
 };
 
 const ttsElevenlabsAgentInfo: AgentFunctionInfo = {

--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -14,6 +14,7 @@ import {
 import { pcmToMp3 } from "../utils/ffmpeg_utils.js";
 
 import type { GoogleTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 
 const getPrompt = (text: string, instructions?: string) => {
   // https://ai.google.dev/gemini-api/docs/speech-generation?hl=ja#controllable
@@ -65,7 +66,17 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
 
     const rawPcm = Buffer.from(pcmBase64, "base64");
 
-    return { buffer: await pcmToMp3(rawPcm, sampleRate) };
+    const usedModel = model ?? provider2TTSAgent.gemini.defaultModel;
+    const usage: AgentUsage | undefined = response.usageMetadata
+      ? {
+          provider: "gemini",
+          model: usedModel,
+          inputTokens: response.usageMetadata.promptTokenCount,
+          outputTokens: response.usageMetadata.candidatesTokenCount,
+          totalTokens: response.usageMetadata.totalTokenCount,
+        }
+      : undefined;
+    return { buffer: await pcmToMp3(rawPcm, sampleRate), usage };
   } catch (e) {
     if (suppressError) {
       return {


### PR DESCRIPTION
Stacked on #1432. Closes #1427.

> ⚠️ **Base branch is `feat/usage-tts-charfallback` (#1432), not `main`.** Will rebase to main after #1432 merges.

## Summary

The two TTS providers that DO expose per-call usage in their responses:

| Agent | Upstream source | Captured as |
|---|---|---|
| `tts_elevenlabs_agent` | `character-cost` HTTP response header (already discounted for V2 Flash/Turbo) | `{ provider:"elevenlabs", model, inputChars }` |
| `tts_gemini_agent` | `response.usageMetadata.{promptTokenCount, candidatesTokenCount, totalTokenCount}` | `{ provider:"gemini", model, inputTokens, outputTokens, totalTokens }` |

Both agents reuse the `createUsageCallback` already registered on the audio graphs in #1432 — no new wiring.

## Items to Confirm / Review

- **ElevenLabs header read happens BEFORE `response.arrayBuffer()`** — once the body is consumed, the headers are still accessible in fetch's Response, but I read them first explicitly so the data dependency is obvious. `Number.isFinite()` guards against missing / malformed header.
- **`inputChars` field choice for ElevenLabs**: the upstream amount is post-discount (e.g. 0.5/char on V2 Flash). I'm storing it in `inputChars` rather than adding a new `charactersBilled` field. The billing layer can read `(provider, model, inputChars)` and apply a "post-discount" multiplier of 1.0 for elevenlabs (since the discount is already applied), and a per-tier multiplier for char-fallback providers. Open to changing to a dedicated `charactersBilled` field if reviewers prefer explicit naming.
- **Gemini TTS model**: uses `provider2TTSAgent.gemini.defaultModel` when params doesn't specify, matching what's actually sent to the API. Currently `gemini-2.5-flash-preview-tts`.

## Local E2E verification

Ran `scripts/probe/probe_usage.ts USAGE_ACTION=audio` against `scripts/test/test_all_tts.json` (5 speakers covering all 5 TTS providers). All 5 records now flow through:

```json
"byModel": [
  { "provider": "openai",     "model": "gpt-4o-mini-tts",              "records": 1, "inputChars":  20 },
  { "provider": "gemini",     "model": "gemini-2.5-flash-preview-tts", "records": 1, "inputTokens": 9, "outputTokens": 59, "totalTokens": 68 },
  { "provider": "google",     "model": "ja-JP-Standard-A",             "records": 1, "inputChars":  16 },
  { "provider": "elevenlabs", "model": "eleven_multilingual_v2",       "records": 1, "inputChars":  18 },
  { "provider": "kotodama",   "model": "Poporo",                       "records": 1, "inputChars":  16 }
]
```

Per-record sample (ElevenLabs):
```json
{
  "agent": "ttsElevenlabsAgent",
  "provider": "elevenlabs",
  "model": "eleven_multilingual_v2",
  "beatIndex": 3,
  "inputChars": 18,
  "cached": false,
  "timestamp": "2026-06-20T01:33:03.447Z"
}
```

## Changes

- `src/agents/tts_elevenlabs_agent.ts` — read `character-cost` header, surface as `inputChars`
- `src/agents/tts_gemini_agent.ts` — extract `usageMetadata`, surface tokens

## Test plan

- [x] `yarn lint` clean, `yarn build` (root + types) OK, `yarn ci_test` 901 / 897 pass / 0 fail
- [x] Local probe captures all 5 TTS providers (see above)

## Related

- Umbrella: #1415
- Closes #1427
- Stacked on: #1432 (TTS v1 char-fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)