### PR TITLE
feat: wire usage callback through src/tools/* LLM graphs

### DIFF
--- a/src/tools/create_mulmo_script_from_url.ts
+++ b/src/tools/create_mulmo_script_from_url.ts
@@ -16,6 +16,7 @@ import { ScriptingParams } from "../types/index.js";
 import { cliLoadingPlugin } from "../utils/plugins.js";
 import { graphDataScriptFromUrlPrompt } from "../utils/prompt.js";
 import { llmPair, settings2GraphAIConfig } from "../utils/utils.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
 import { readFileSync } from "fs";
 
 dotenv.config({ quiet: true });
@@ -215,7 +216,7 @@ const graphDataText: GraphData = {
   },
 };
 
-export const createMulmoScriptFromUrl = async ({ urls, templateName, outDirPath, filename, cacheDirPath, llm, llm_model }: ScriptingParams) => {
+export const createMulmoScriptFromUrl = async ({ urls, templateName, outDirPath, filename, cacheDirPath, llm, llm_model, usageCollector }: ScriptingParams) => {
   mkdir(outDirPath);
   mkdir(cacheDirPath);
   const parsedUrls = urlsSchema.parse(urls);
@@ -254,6 +255,7 @@ export const createMulmoScriptFromUrl = async ({ urls, templateName, outDirPath,
   graph.injectValue("llmModel", model);
   graph.injectValue("maxTokens", max_tokens);
   graph.registerCallback(cliLoadingPlugin({ nodeId: "mulmoScript", message: "Generating script..." }));
+  graph.registerCallback(createUsageCallback(usageCollector));
 
   const result = await graph.run<{ path: string }>();
   if (!result?.writeJSON?.path) {
@@ -265,7 +267,7 @@ export const createMulmoScriptFromUrl = async ({ urls, templateName, outDirPath,
 
 export const createMulmoScriptFromFile = async (
   fileName: string,
-  { templateName, outDirPath, filename, cacheDirPath, llm, llm_model, verbose }: ScriptingParams,
+  { templateName, outDirPath, filename, cacheDirPath, llm, llm_model, verbose, usageCollector }: ScriptingParams,
 ) => {
   mkdir(outDirPath);
   mkdir(cacheDirPath);
@@ -299,6 +301,7 @@ export const createMulmoScriptFromFile = async (
   if (!verbose) {
     graph.registerCallback(cliLoadingPlugin({ nodeId: "mulmoScript", message: "Generating script..." }));
   }
+  graph.registerCallback(createUsageCallback(usageCollector));
   const result = await graph.run<{ path: string }>();
   if (!result?.writeJSON?.path) {
     showErrorMessage("Script generation failed. Please try again.");

--- a/src/tools/create_mulmo_script_interactively.ts
+++ b/src/tools/create_mulmo_script_interactively.ts
@@ -18,6 +18,8 @@ import { mulmoScriptSchema, ScriptingParams } from "../types/index.js";
 import { browserlessAgent } from "@graphai/browserless_agent";
 import validateSchemaAgent from "../agents/validate_schema_agent.js";
 import { llmPair, settings2GraphAIConfig } from "../utils/utils.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
+import type { UsageCollectorAPI } from "../types/usage.js";
 import { interactiveClarificationPrompt, prefixPrompt } from "../utils/prompt.js";
 // import { cliLoadingPlugin } from "../utils/plugins.js";
 
@@ -209,7 +211,7 @@ const graphData = {
   },
 };
 
-const scrapeWebContent = async (urls: string[], cacheDirPath: string) => {
+const scrapeWebContent = async (urls: string[], cacheDirPath: string, usageCollector?: UsageCollectorAPI) => {
   mkdir(cacheDirPath);
   GraphAILogger.info(`${agentHeader} Scraping ${urls.length} URLs...\n`);
 
@@ -224,6 +226,7 @@ const scrapeWebContent = async (urls: string[], cacheDirPath: string) => {
 
   const graph = new GraphAI(graphDataForScraping, { ...vanillaAgents, openAIAgent, textInputAgent, fileWriteAgent, browserlessAgent }, { agentFilters });
   graph.injectValue("urls", urls);
+  graph.registerCallback(createUsageCallback(usageCollector));
 
   const result = (await graph.run()) as { sourceText: { text: string } };
   if (!result?.sourceText?.text) {
@@ -232,10 +235,19 @@ const scrapeWebContent = async (urls: string[], cacheDirPath: string) => {
   return `\n\n${prefixPrompt}\n${result?.sourceText.text}`;
 };
 
-export const createMulmoScriptInteractively = async ({ outDirPath, cacheDirPath, filename, templateName, urls, llm, llm_model }: ScriptingParams) => {
+export const createMulmoScriptInteractively = async ({
+  outDirPath,
+  cacheDirPath,
+  filename,
+  templateName,
+  urls,
+  llm,
+  llm_model,
+  usageCollector,
+}: ScriptingParams) => {
   mkdir(outDirPath);
   // if urls is not empty, scrape web content and reference it in the prompt
-  const webContentPrompt = urls.length > 0 ? await scrapeWebContent(urls, cacheDirPath) : "";
+  const webContentPrompt = urls.length > 0 ? await scrapeWebContent(urls, cacheDirPath, usageCollector) : "";
 
   const { agent, model, max_tokens } = llmPair(llm, llm_model);
   GraphAILogger.log({ agent, model, max_tokens });
@@ -277,6 +289,7 @@ export const createMulmoScriptInteractively = async ({ outDirPath, cacheDirPath,
       }
     }
   });
+  graph.registerCallback(createUsageCallback(usageCollector));
   // graph.registerCallback(cliLoadingPlugin({ nodeId: "reply", message: "Loading..." }));
 
   GraphAILogger.info(`${agentHeader} Hi! What topic would you like me to generate about?\n`);

--- a/src/tools/deep_research.ts
+++ b/src/tools/deep_research.ts
@@ -11,6 +11,8 @@ import * as agents from "@graphai/vanilla";
 import tavilySearchAgent from "../agents/tavily_agent.js";
 import { cliLoadingPlugin } from "../utils/plugins.js";
 import { searchQueryPrompt, reflectionPrompt, finalAnswerPrompt } from "../utils/prompt.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
+import type { UsageCollectorAPI } from "../types/usage.js";
 
 dotenv.config({ quiet: true });
 
@@ -267,7 +269,7 @@ const graphData = {
   },
 };
 
-export const deepResearch = async () => {
+export const deepResearch = async (usageCollector?: UsageCollectorAPI) => {
   const agentFilters = [
     {
       name: "consoleStreamDataAgentFilter",
@@ -283,6 +285,7 @@ export const deepResearch = async () => {
   graph.registerCallback(cliLoadingPlugin({ nodeId: "reflectionAgent", message: "Analyzing search results..." }));
   graph.registerCallback(cliLoadingPlugin({ nodeId: "tavilySearchAgent", message: "Searching..." }));
   graph.registerCallback(cliLoadingPlugin({ nodeId: "finalAnswer", message: "Generating final answer..." }));
+  graph.registerCallback(createUsageCallback(usageCollector));
 
   GraphAILogger.info(`${agentHeader} What would you like to know?\n`);
   await graph.run();

--- a/src/tools/story_to_script.ts
+++ b/src/tools/story_to_script.ts
@@ -12,7 +12,9 @@ import { fileWriteAgent } from "@graphai/vanilla_node_agents";
 import validateSchemaAgent from "../agents/validate_schema_agent.js";
 import { ZodSchema } from "zod";
 import { llmPair, settings2GraphAIConfig } from "../utils/utils.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
 import type { LLM } from "../types/provider2agent.js";
+import type { UsageCollectorAPI } from "../types/usage.js";
 import { storyToScriptGenerateMode } from "../types/const.js";
 import { cliLoadingPlugin } from "../utils/plugins.js";
 
@@ -282,6 +284,7 @@ export const storyToScript = async ({
   llm,
   llmModel,
   generateMode,
+  usageCollector,
 }: {
   story: MulmoStoryboard;
   beatsPerScene: number;
@@ -291,6 +294,7 @@ export const storyToScript = async ({
   llm?: LLM;
   llmModel?: string;
   generateMode: StoryToScriptGenerateMode;
+  usageCollector?: UsageCollectorAPI;
 }) => {
   const template = readAndParseJson(getPromptTemplateFilePath(templateName), mulmoPromptTemplateSchema);
   const { agent, model, max_tokens } = llmPair(llm, llmModel);
@@ -322,6 +326,7 @@ export const storyToScript = async ({
   graph.injectValue("llmModel", model);
   graph.injectValue("maxTokens", max_tokens);
   graph.registerCallback(cliLoadingPlugin({ nodeId: "script", message: "Generating script..." }));
+  graph.registerCallback(createUsageCallback(usageCollector));
 
   const result = await graph.run<{ path: string }>();
   writingMessage(result?.writeJSON?.path ?? "");

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -145,6 +145,7 @@ export type ScriptingParams = {
   llm_model?: string;
   llm?: LLM;
   verbose?: boolean;
+  usageCollector?: UsageCollectorAPI;
 };
 
 export type ImageProcessorParams = {

--- a/src/utils/usage_callback.ts
+++ b/src/utils/usage_callback.ts
@@ -1,6 +1,6 @@
 import { NodeState, type CallbackFunction, type TransactionLog } from "graphai";
 import type { MulmoStudioContext } from "../types/type.js";
-import type { AgentUsage } from "../types/usage.js";
+import type { AgentUsage, UsageCollectorAPI } from "../types/usage.js";
 
 // @graphai/* LLM agents (openAIAgent / geminiAgent / anthropicAgent / groqAgent)
 // return usage in the OpenAI chat-completions wire shape:
@@ -52,17 +52,27 @@ const extractUsage = (log: TransactionLog): AgentUsage | undefined => {
   return extractLLMUsage(log);
 };
 
-// GraphAI callback that pushes any agent's reported usage into
-// context.usageCollector when the node completes successfully. No-op when
-// usageCollector is absent, the node fails, or the result has no `usage`.
-export const createUsageCallback = (context: MulmoStudioContext): CallbackFunction => {
+const resolveCollector = (target: MulmoStudioContext | UsageCollectorAPI | undefined): UsageCollectorAPI | undefined => {
+  if (!target) return undefined;
+  // A MulmoStudioContext has the optional `usageCollector` slot; the API itself
+  // doesn't. Distinguishing on the slot name lets either form pass through.
+  if ("usageCollector" in target) return (target as MulmoStudioContext).usageCollector;
+  return target as UsageCollectorAPI;
+};
+
+// GraphAI callback that pushes any agent's reported usage into the given
+// UsageCollector when the node completes successfully. No-op when the
+// collector is absent (either undefined directly or `context.usageCollector`
+// undefined), the node fails, or the result has no `usage`.
+export const createUsageCallback = (target: MulmoStudioContext | UsageCollectorAPI | undefined): CallbackFunction => {
   return (log: TransactionLog, isUpdate: boolean) => {
     if (isUpdate) return;
     if (log.state !== NodeState.Completed) return;
-    if (!context.usageCollector) return;
+    const collector = resolveCollector(target);
+    if (!collector) return;
     const usage = extractUsage(log);
     if (!usage) return;
-    context.usageCollector.add({
+    collector.add({
       agent: log.agentId ?? "unknown",
       provider: usage.provider,
       model: usage.model,

--- a/test/utils/test_usage_callback.ts
+++ b/test/utils/test_usage_callback.ts
@@ -182,3 +182,27 @@ test("usage callback preserves retryAttempt from log.retryCount", () => {
   );
   assert.strictEqual(collector.snapshot()[0].retryAttempt, 2);
 });
+
+test("usage callback accepts a UsageCollectorAPI directly (no context)", () => {
+  const collector = new UsageCollector();
+  const cb = createUsageCallback(collector);
+  cb(
+    makeLog({
+      result: { usage: { provider: "openai", model: "gpt-image-1", totalTokens: 42 } },
+    }),
+    false,
+  );
+  assert.strictEqual(collector.size, 1);
+  assert.strictEqual(collector.snapshot()[0].totalTokens, 42);
+});
+
+test("usage callback is a no-op when undefined is passed directly", () => {
+  const cb = createUsageCallback(undefined);
+  cb(
+    makeLog({
+      result: { usage: { provider: "openai", model: "m", totalTokens: 10 } },
+    }),
+    false,
+  );
+  // Should not throw — no collector to record into.
+});


### PR DESCRIPTION
Closes the deferred tools/* portion of #1419. (The translate.ts portion shipped via #1433.)

## Summary

Six GraphAI sites across `src/tools/*` now register `createUsageCallback` so programmatic callers (the future billing-API layer) can collect token usage from script-generation and research tools without further mulmocast changes.

| File | Function | Graph sites |
|---|---|---|
| `story_to_script.ts` | `storyToScript` | 1 |
| `create_mulmo_script_from_url.ts` | `createMulmoScriptFromUrl`, `createMulmoScriptFromFile` | 2 |
| `create_mulmo_script_interactively.ts` | `scrapeWebContent` (helper) + `createMulmoScriptInteractively` | 2 |
| `deep_research.ts` | `deepResearch` | 1 |

## Items to Confirm / Review

- **`createUsageCallback` now accepts either form**: a `MulmoStudioContext` (existing call sites) or a `UsageCollectorAPI` directly (tools). Backward compatible; the existing 3 sites in `actions/` are untouched.
- **API surface change**: `ScriptingParams.usageCollector?: UsageCollectorAPI` added (optional, doesn't break existing callers). `storyToScript` and `deepResearch` also gain an optional `usageCollector` argument.
- **CLI handlers don't pass a collector yet**: the CLI side of this lives in #1435 (`MULMOCAST_DUMP_USAGE` env var). Once #1435 lands, the CLI tool commands (`src/cli/commands/tool/*`) can opt in by populating it.
- **`deep_research.ts`** isn't exposed via a CLI handler today (it runs only when the file is invoked directly, see `deepResearch()` call at the bottom). I still added the optional param for symmetry — no runtime cost when unset.

## User Prompt

> 前から順に進めてほしい。

\#1419 was the next open one in umbrella #1415 numerical order; the translate.ts half landed in #1433 and the tools/* half was explicitly deferred. This PR closes that remainder.

## Changes

- `src/utils/usage_callback.ts` — `createUsageCallback` accepts `MulmoStudioContext | UsageCollectorAPI | undefined`
- `src/types/type.ts` — `ScriptingParams.usageCollector?`
- `src/tools/story_to_script.ts`, `create_mulmo_script_from_url.ts`, `create_mulmo_script_interactively.ts`, `deep_research.ts` — register callback on every GraphAI site
- `test/utils/test_usage_callback.ts` — 2 new tests (collector-direct path, undefined no-op)

## Test plan

- [x] `yarn lint` clean, `yarn build` (root + types) OK
- [x] `yarn ci_test` 909 / 905 pass / 0 fail (2 new)
- [ ] (Reviewer / probe) Real E2E needs a tool CLI flow with a real API key + #1435 to actually surface the collector. Until then, callers can construct one and pass it programmatically.

## Related

- Umbrella: #1415
- Closes the tools/* portion of #1419
- Sibling: #1435 (CLI dump — unblocks tool CLI verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated optional usage tracking across script generation and research tools to monitor resource consumption and API usage during operation execution.

* **Tests**
  * Enhanced test coverage for usage collection capabilities, validating behavior with direct collectors and safe handling of absent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->