### PR TITLE
feat: capture Replicate predict_time for 4 replicate agents

### DIFF
--- a/src/agents/image_replicate_agent.ts
+++ b/src/agents/image_replicate_agent.ts
@@ -14,7 +14,9 @@ import {
 } from "../utils/error_cause.js";
 
 import type { AgentBufferResult, ImageAgentInputs, AgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 import { provider2ImageAgent } from "../types/provider2agent.js";
+import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
 
 export type ReplicateImageAgentConfig = AgentConfig;
 
@@ -62,7 +64,7 @@ export const imageReplicateAgent: AgentFunction<ReplicateImageAgentParams, Agent
   }
 
   try {
-    const output = await replicate.run(model, { input });
+    const { output, predictSec } = await runReplicateWithMetrics(replicate, model, input);
 
     const imageUrl = extractImageUrl(output);
     if (!imageUrl) {
@@ -80,7 +82,8 @@ export const imageReplicateAgent: AgentFunction<ReplicateImageAgentParams, Agent
 
     const arrayBuffer = await imageResponse.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
-    return { buffer };
+    const usage: AgentUsage | undefined = predictSec !== undefined ? { provider: "replicate", model, predictSec } : undefined;
+    return { buffer, usage };
   } catch (error) {
     GraphAILogger.info("Replicate generation error:", error);
     if (hasCause(error) && error.cause) {

--- a/src/agents/lipsync_replicate_agent.ts
+++ b/src/agents/lipsync_replicate_agent.ts
@@ -14,6 +14,8 @@ import {
 } from "../utils/error_cause.js";
 
 import type { AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentParams, ReplicateLipSyncAgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
+import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
 
 export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentConfig> = async ({
   namedInputs,
@@ -84,12 +86,10 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
   const model_identifier: `${string}/${string}:${string}` | `${string}/${string}` = provider2LipSyncAgent.replicate.modelParams[model]?.identifier ?? model;
 
   try {
-    const output = await replicate.run(model_identifier, {
-      input,
-    });
+    const { output, predictSec } = await runReplicateWithMetrics(replicate, model_identifier, input);
 
     if (output && typeof output === "object" && "url" in output) {
-      const videoUrl = (output.url as () => URL)();
+      const videoUrl = ((output as { url: unknown }).url as () => URL)();
       const videoResponse = await fetch(videoUrl);
 
       if (!videoResponse.ok) {
@@ -99,7 +99,8 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
       }
 
       const arrayBuffer = await videoResponse.arrayBuffer();
-      return { buffer: Buffer.from(arrayBuffer) };
+      const usage: AgentUsage | undefined = predictSec !== undefined ? { provider: "replicate", model, predictSec } : undefined;
+      return { buffer: Buffer.from(arrayBuffer), usage };
     }
     return undefined;
   } catch (error) {

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -14,7 +14,9 @@ import {
 } from "../utils/error_cause.js";
 
 import type { AgentBufferResult, MovieAgentInputs, ReplicateMovieAgentParams, ReplicateMovieAgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 import { provider2MovieAgent, getModelDuration, AUDIO_MODE_OPTIONAL, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
+import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
 
 function replicate_get_videoUrl(output: unknown): string | URL | undefined {
   if (typeof output === "string") return output;
@@ -32,7 +34,7 @@ async function generateMovie(
   aspectRatio: string,
   duration: number,
   generateAudio: boolean | undefined,
-): Promise<Buffer | undefined> {
+): Promise<{ buffer: Buffer; predictSec?: number } | undefined> {
   const replicate = new Replicate({
     auth: apiKey,
   });
@@ -114,7 +116,7 @@ async function generateMovie(
   }
 
   try {
-    const output = await replicate.run(model, { input });
+    const { output, predictSec } = await runReplicateWithMetrics(replicate, model, input);
 
     // Download the generated video
     // Some models return a FileOutput object with a url() method; others return a plain string URL.
@@ -129,7 +131,7 @@ async function generateMovie(
       }
 
       const arrayBuffer = await videoResponse.arrayBuffer();
-      return Buffer.from(arrayBuffer);
+      return { buffer: Buffer.from(arrayBuffer), predictSec };
     }
 
     return undefined;
@@ -186,9 +188,10 @@ export const movieReplicateAgent: AgentFunction<ReplicateMovieAgentParams, Agent
   }
 
   try {
-    const buffer = await generateMovie(model, apiKey, prompt, imagePath, lastFrameImagePath, referenceImages, aspectRatio, duration, params.generateAudio);
-    if (buffer) {
-      return { buffer };
+    const result = await generateMovie(model, apiKey, prompt, imagePath, lastFrameImagePath, referenceImages, aspectRatio, duration, params.generateAudio);
+    if (result) {
+      const usage: AgentUsage | undefined = result.predictSec !== undefined ? { provider: "replicate", model, predictSec: result.predictSec } : undefined;
+      return { buffer: result.buffer, usage };
     }
   } catch (error) {
     if (hasCause(error)) {

--- a/src/agents/sound_effect_replicate_agent.ts
+++ b/src/agents/sound_effect_replicate_agent.ts
@@ -6,6 +6,8 @@ import { provider2SoundEffectAgent } from "../types/provider2agent.js";
 import { apiKeyMissingError, agentGenerationError, imageAction, movieFileTarget, hasCause } from "../utils/error_cause.js";
 
 import type { AgentBufferResult, SoundEffectAgentInputs, ReplicateSoundEffectAgentParams, ReplicateSoundEffectAgentConfig } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
+import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
 
 export const soundEffectReplicateAgent: AgentFunction<
   ReplicateSoundEffectAgentParams,
@@ -42,12 +44,10 @@ export const soundEffectReplicateAgent: AgentFunction<
   try {
     const model_identifier: `${string}/${string}:${string}` | `${string}/${string}` =
       provider2SoundEffectAgent.replicate.modelParams[model]?.identifier ?? model;
-    const output = await replicate.run(model_identifier, {
-      input,
-    });
+    const { output, predictSec } = await runReplicateWithMetrics(replicate, model_identifier, input);
 
     if (output && typeof output === "object" && "url" in output) {
-      const videoUrl = (output.url as () => URL)();
+      const videoUrl = ((output as { url: unknown }).url as () => URL)();
       const videoResponse = await fetch(videoUrl);
 
       if (!videoResponse.ok) {
@@ -57,7 +57,8 @@ export const soundEffectReplicateAgent: AgentFunction<
       }
 
       const arrayBuffer = await videoResponse.arrayBuffer();
-      return { buffer: Buffer.from(arrayBuffer) };
+      const usage: AgentUsage | undefined = predictSec !== undefined ? { provider: "replicate", model, predictSec } : undefined;
+      return { buffer: Buffer.from(arrayBuffer), usage };
     }
     return undefined;
   } catch (error) {

--- a/src/utils/replicate_usage.ts
+++ b/src/utils/replicate_usage.ts
@@ -1,0 +1,19 @@
+import type Replicate from "replicate";
+import type { Prediction } from "replicate";
+
+// Capture Replicate's exact billed seconds (`metrics.predict_time`) via the
+// progress callback on `replicate.run()`. Avoids switching the four
+// replicate agents from `.run()` to `predictions.create()` + poll, which
+// would be a much bigger blast radius.
+export const runReplicateWithMetrics = async (
+  replicate: Replicate,
+  identifier: `${string}/${string}` | `${string}/${string}:${string}`,
+  input: object,
+  signal?: AbortSignal,
+): Promise<{ output: unknown; predictSec?: number }> => {
+  let lastPrediction: Prediction | undefined;
+  const output = await replicate.run(identifier, { input, signal }, (prediction) => {
+    lastPrediction = prediction;
+  });
+  return { output, predictSec: lastPrediction?.metrics?.predict_time };
+};


### PR DESCRIPTION
Closes #1421.

## Summary

Replicate bills per second of compute (`metrics.predict_time`). Up to now the four replicate agents called `replicate.run()` and discarded the prediction object, so the collector never saw any seconds. This PR surfaces the exact upstream-billed amount with a minimal SDK pattern change.

## Approach

`replicate.run(identifier, options, progress?)` accepts an optional third arg — a callback invoked with the `Prediction` object on every status update, including the final terminal state with `metrics.predict_time` set. So I added a tiny wrapper that captures the latest prediction and returns `{ output, predictSec }`:

```ts
// src/utils/replicate_usage.ts (new)
export const runReplicateWithMetrics = async (replicate, identifier, input, signal?) => {
  let lastPrediction: Prediction | undefined;
  const output = await replicate.run(identifier, { input, signal }, (prediction) => {
    lastPrediction = prediction;
  });
  return { output, predictSec: lastPrediction?.metrics?.predict_time };
};
```

This avoids the bigger alternative — switching from `replicate.run()` to `predictions.create()` + `predictions.get()` polling — for the same end result.

## Items to Confirm / Review

- **Same call site shape**: agents just swap one line: `await replicate.run(model, { input })` → `await runReplicateWithMetrics(replicate, model, input)`. Output handling downstream (FileOutput object with `url()` method, plain URL string, etc.) is unchanged.
- **`predictSec === undefined` falls through gracefully**: if Replicate doesn't populate metrics (e.g. cancellation), `usage` is `undefined` and the callback's type guard rejects — no fake-zero seconds reach the collector / billing layer.
- **No agent-wiring change**: `createUsageCallback` already runs on the image / audio / movie graphs, so it picks these up the same way it picks up image_openai_agent (#1429) and image_genai_agent (#1430).
- **Local probe**: I didn't run a real Replicate request — the default test scripts I used for #1429/#1430/#1434 don't have replicate beats. Reviewer with a `REPLICATE_API_TOKEN` should sanity-check a replicate beat in the probe (`USAGE_ACTION=images USAGE_SCRIPT=scripts/test/some_replicate_script.json npx tsx scripts/probe/probe_usage.ts`).

## User Prompt

> 前から順に進めてほしい。

\#1421 was the next open Phase 2 issue in umbrella #1415.

## Changes

- `src/utils/replicate_usage.ts` (new) — `runReplicateWithMetrics` wrapper
- `src/agents/image_replicate_agent.ts`
- `src/agents/movie_replicate_agent.ts`
- `src/agents/sound_effect_replicate_agent.ts`
- `src/agents/lipsync_replicate_agent.ts`

## Test plan

- [x] `yarn lint` / `yarn build` (root + types) / `yarn ci_test` all green (907 / 903 pass / 0 fail / 4 skipped)
- [ ] (Reviewer with Replicate key) Run any image/movie/sound_effect/lipsync script that uses Replicate via the probe; expect `usage: { provider: "replicate", model, predictSec }` per beat

## Related

- Umbrella: #1415
- Closes #1421
- Sibling: #1422 (Veo movie_genai duration — Phase 2 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Usage metrics are now captured and included with content generation results, providing visibility into prediction execution time.

* **Refactor**
  * Content generation workflows have been refactored to consistently collect and report performance metrics across all agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->