### PR TITLE
feat: capture Veo (movie_genai) generated duration as predictSec

### DIFF
--- a/scripts/probe/probe_usage.ts
+++ b/scripts/probe/probe_usage.ts
@@ -1,27 +1,28 @@
-// Probe: run a mulmocast action (images / audio / translate) against a test
-// script and dump usageCollector contents.
+// Probe: run a mulmocast action (images / audio / translate / movie) against a
+// test script and dump usageCollector contents.
 //
 // Usage:
 //   OPENAI_API_KEY=sk-... npx tsx scripts/probe/probe_usage.ts
 //
 // Optional env:
-//   USAGE_ACTION=images | audio | translate         (default: images)
-//   USAGE_SCRIPT=scripts/test/test_gpt_image.json   (default depends on action)
-//   USAGE_OUTDIR=/tmp/probe_usage_output             (default: per-action subdir)
-//   USAGE_TARGET_LANG=ja                             (default: ja, translate only)
+//   USAGE_ACTION=images | audio | translate | movie  (default: images)
+//   USAGE_SCRIPT=scripts/test/test_gpt_image.json    (default depends on action)
+//   USAGE_OUTDIR=/tmp/probe_usage_output              (default: per-action subdir)
+//   USAGE_TARGET_LANG=ja                              (default: ja, translate only)
 
 import path from "path";
 import fs from "fs";
-import { images, audio, translate } from "../../src/actions/index.js";
+import { images, audio, translate, movie, captions } from "../../src/actions/index.js";
 import { initializeContextFromFiles } from "../../src/utils/context.js";
 import { getFileObject } from "../../src/cli/helpers.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
-const action = (process.env.USAGE_ACTION ?? "images") as "images" | "audio" | "translate";
+const action = (process.env.USAGE_ACTION ?? "images") as "images" | "audio" | "translate" | "movie";
 const defaultScript: Record<typeof action, string> = {
   images: "scripts/test/test_gpt_image.json",
   audio: "scripts/test/test_all_tts.json",
   translate: "scripts/test/test_lang.json",
+  movie: "scripts/test/test_veo31_lite.json",
 };
 const scriptArg = process.env.USAGE_SCRIPT ?? defaultScript[action];
 const scriptPath = path.resolve(repoRoot, scriptArg);
@@ -55,6 +56,9 @@ const main = async () => {
     await audio(context);
   } else if (action === "translate") {
     await translate(context);
+  } else if (action === "movie") {
+    // Mirror the CLI movie handler chain: audio → images → captions → movie.
+    await audio(context).then(images).then(captions).then(movie);
   }
   const elapsedSec = (Date.now() - before) / 1000;
 

--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -14,8 +14,10 @@ import {
   hasCause,
 } from "../utils/error_cause.js";
 import { getAspectRatio } from "../utils/utils.js";
+import { ffmpegGetMediaDuration } from "../utils/ffmpeg_utils.js";
 import { ASPECT_RATIOS } from "../types/const.js";
 import type { AgentBufferResult, GenAIImageAgentConfig, GoogleMovieAgentParams, MovieAgentInputs, MovieReferenceImage } from "../types/agent.js";
+import type { AgentUsage } from "../types/usage.js";
 import { getModelDuration, provider2MovieAgent, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
 
 type ImagePayload = { imageBytes: string; mimeType: string };
@@ -69,7 +71,22 @@ const loadImageAsBase64 = (imagePath: string): ImagePayload => {
   };
 };
 
-const downloadVideo = async (ai: GoogleGenAI, video: GenAIVideo, movieFile: string, isVertexAI: boolean): Promise<AgentBufferResult> => {
+// Veo bills per second of generated video. The SDK response carries no usage
+// metadata (GenerateVideosResponse only has generatedVideos and RAI flags), so
+// we ffprobe the downloaded file to get the actual duration. Falls back to
+// undefined if ffprobe fails, which lets the billing layer use the requested
+// duration as a fallback.
+const probeDurationSec = async (movieFile: string): Promise<number | undefined> => {
+  try {
+    const { duration } = await ffmpegGetMediaDuration(movieFile);
+    return duration > 0 ? duration : undefined;
+  } catch (e) {
+    GraphAILogger.warn("movieGenAIAgent: ffprobe failed, predictSec will be omitted", e);
+    return undefined;
+  }
+};
+
+const downloadVideo = async (ai: GoogleGenAI, video: GenAIVideo, movieFile: string, isVertexAI: boolean, model: string): Promise<AgentBufferResult> => {
   if (isVertexAI) {
     // Vertex AI returns videoBytes directly
     writeFileSync(movieFile, Buffer.from(video.videoBytes!, "base64"));
@@ -81,7 +98,9 @@ const downloadVideo = async (ai: GoogleGenAI, video: GenAIVideo, movieFile: stri
     });
     await sleep(5000); // HACK: Without this, the file is not ready yet.
   }
-  return { saved: movieFile };
+  const predictSec = await probeDurationSec(movieFile);
+  const usage: AgentUsage | undefined = predictSec !== undefined ? { provider: "google", model, predictSec } : undefined;
+  return { saved: movieFile, usage };
 };
 
 const createVeo31Payload = (
@@ -160,7 +179,7 @@ const generateExtendedVideo = async (
     });
   }
 
-  return downloadVideo(ai, result.video, movieFile, isVertexAI);
+  return downloadVideo(ai, result.video, movieFile, isVertexAI, model);
 };
 
 const generateStandardVideo = async (
@@ -218,7 +237,7 @@ const generateStandardVideo = async (
   const response = await pollUntilDone(ai, operation);
   const video = getVideoFromResponse(response);
 
-  return downloadVideo(ai, video, movieFile, isVertexAI);
+  return downloadVideo(ai, video, movieFile, isVertexAI, model);
 };
 
 export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferResult, MovieAgentInputs, GenAIImageAgentConfig> = async ({


### PR DESCRIPTION
Closes #1422.

## Summary

Veo bills per second of generated video. `@google/genai`'s `GenerateVideosResponse` only exposes `generatedVideos` and RAI flags — there is **no** token / duration / usage metadata in the SDK response. So I capture the actual generated duration by ffprobing the downloaded mp4.

## Approach

`movie_genai_agent` already writes the generated video to disk in `downloadVideo` (both the Vertex AI base64 path and the Gemini API download path). Right after the file lands, run `ffmpegGetMediaDuration` and surface the actual duration as `predictSec`:

```ts
const probeDurationSec = async (movieFile: string): Promise<number | undefined> => {
  try {
    const { duration } = await ffmpegGetMediaDuration(movieFile);
    return duration > 0 ? duration : undefined;
  } catch (e) {
    GraphAILogger.warn("movieGenAIAgent: ffprobe failed, predictSec will be omitted", e);
    return undefined;
  }
};
```

## Items to Confirm / Review

- **Why ffprobe instead of the SDK?**: `GenerateVideosResponse` literally has three fields (`generatedVideos`, `raiMediaFilteredCount`, `raiMediaFilteredReasons`). `Video` itself has `uri`, `videoBytes`, `mimeType` — also no duration. Confirmed against `node_modules/@google/genai/dist/genai.d.ts`. The actual mp4 is the source of truth.
- **Why post-download instead of pre-billing the requested duration?**: the requested duration is a billing hint, but if Veo serves something different (rare, but possible — extension paths, model variations), we'd be off. The mp4 length is what Google actually produced.
- **Fallback behavior**: if ffprobe fails (corrupt file, missing ffmpeg, etc.), we emit `usage: undefined` instead of a fake-zero or the requested duration. The billing layer can fall back to whatever default it likes; mulmocast doesn't fabricate numbers.
- **Veo 3.1 extension path**: `generateExtendedVideo` builds a multi-segment video and the final segment goes through the same `downloadVideo`. ffprobe sees the final concatenated mp4, so `predictSec` reflects the total accumulated duration — the right shape for billing.
- **Vertex AI vs Gemini API paths both share `downloadVideo`** — same usage emission for both.

## Test plan

- [x] `yarn lint` clean
- [x] `yarn build` (root + types) OK
- [x] `yarn ci_test` 909 / 905 pass / 0 fail
- [ ] (Reviewer with `GEMINI_API_KEY` or Vertex AI access) Run a Veo beat via the probe; expect `usage: { provider: "google", model, predictSec }` matching the actual mp4 duration

## Related

- Umbrella: #1415
- Closes #1422
- Sibling: #1421 (#1437 — Replicate predict_time, also Phase 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved video generation usage tracking by measuring the actual generated video duration, providing more accurate usage and billing metadata.
  * Updated the usage probing script to add support for a new movie usage flow, enabling consistent end-to-end usage checks for generated videos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->