### PR TITLE
fix: register usage callback on image_references.ts GraphAI sites

### DIFF
--- a/src/actions/image_references.ts
+++ b/src/actions/image_references.ts
@@ -2,6 +2,7 @@ import { GraphAI, GraphAILogger } from "graphai";
 import { getReferenceImagePath } from "../utils/file.js";
 
 import { imageGraphOption } from "./graph_option.js";
+import { createUsageCallback } from "../utils/usage_callback.js";
 import { MulmoPresentationStyleMethods, MulmoMediaSourceMethods } from "../methods/index.js";
 import {
   MulmoStudioContext,
@@ -63,6 +64,7 @@ export const generateReferenceImage = async (inputs: {
   try {
     const options = await imageGraphOption(context);
     const graph = new GraphAI(image_graph_data, { imageGenAIAgent, imageOpenaiAgent, mediaMockAgent, imageReplicateAgent }, options);
+    graph.registerCallback(createUsageCallback(context));
     await graph.run<{ output: MulmoStudioBeat[] }>();
     return imagePath;
   } catch (error) {
@@ -168,6 +170,7 @@ const generateReferenceMovie = async (inputs: {
   try {
     const options = await imageGraphOption(context);
     const graph = new GraphAI(movie_graph_data, { movieGenAIAgent, movieReplicateAgent, mediaMockAgent }, options);
+    graph.registerCallback(createUsageCallback(context));
     await graph.run<{ output: MulmoStudioBeat[] }>();
     return moviePath;
   } catch (error) {


### PR DESCRIPTION
## Bug

\`generateReferenceImage\` and \`generateReferenceMovie\` (`src/actions/image_references.ts`) each build their own GraphAI graph that runs the same image / movie agents wired up by #1429 / #1430 / #1437 / #1438:

\`\`\`
generateReferenceImage  → image_graph_data { imageGenAIAgent, imageOpenaiAgent, mediaMockAgent, imageReplicateAgent }
generateReferenceMovie  → movie_graph_data { movieGenAIAgent, movieReplicateAgent, mediaMockAgent }
\`\`\`

All of those agents now return \`{ buffer, usage: { provider, model, ... } }\` — but **neither site registers \`createUsageCallback\`**, so every reference-image and reference-movie generation silently dropped its usage record.

Found during the umbrella #1415 audit ("usageってきちんと全部のllm/aiに対応している？").

## Fix

One line per site: \`graph.registerCallback(createUsageCallback(context));\` before \`await graph.run()\`. Mirrors the pattern in \`actions/images.ts\` and \`actions/audio.ts\`.

## Other gaps surfaced by the audit (filed separately)

- \`src/cli/commands/tool/whisper/handler.ts\` — calls \`openai.audio.transcriptions.create\` directly without a \`MulmoStudioContext\`. Whisper is per-minute billed; needs a collector plumbed through. Not in scope here.
- \`src/agents/tavily_agent.ts\` — per-request billed (Tavily search), but doesn't return a \`usage\` field. Used by \`deepResearch\`. Not in scope here.

## Test plan

- [x] \`yarn lint\` clean
- [x] \`yarn build\` (root + types) OK
- [x] \`yarn ci_test\` 914 / 910 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)