### PR TITLE
mulmocast@2.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.6.21](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.21) (2026-06-21)
+
+- **Token / API usage tracking**: full umbrella ([#1415](https://github.com/receptron/mulmocast-cli/issues/1415)) landed. Per-request `UsageCollector` on `MulmoStudioContext` surfaces structured usage from every AI agent — OpenAI / Gemini image (token), Replicate image/movie/sound_effect/lipsync (predict_sec via `replicate.run()` progress callback), Veo movie_genai (ffprobed mp4 duration), 5 TTS providers (token + char + ElevenLabs `character-cost` header), translate + tools LLM (`@graphai/*` shape adapter). Opt-in CLI dump via `MULMOCAST_DUMP_USAGE=1` (stdout) or `MULMOCAST_DUMP_USAGE=/path/to/file.json`. Full reference in [`docs/api.md`](./docs/api.md).
+- **`docs/api.md`** ([#1442](https://github.com/receptron/mulmocast-cli/issues/1442) / [#1447](https://github.com/receptron/mulmocast-cli/pull/1447)): first consolidated programmatic API reference (lifecycle, action / per-beat / settings / callbacks / usage tracking matrix for all 17 AI agents).
+- **Dependency updates**: `undici` 7.25.0 → 7.28.0 ([#1443](https://github.com/receptron/mulmocast-cli/pull/1443)).
+
+📦 **npm**: [`mulmocast@2.6.21`](https://www.npmjs.com/package/mulmocast/v/2.6.21) · [`@mulmocast/types@2.6.21`](https://www.npmjs.com/package/@mulmocast/types/v/2.6.21)
+
 ## [2.6.20](https://github.com/receptron/mulmocast-cli/releases/tag/2.6.20) (2026-06-09)
 
 - **e2e CI parallelized**: split the monolithic `e2e` job into 16 shards × `[22.x, 24.x]` matrix so each script runs on its own runner; target wall-clock ~10 min vs ~30 min before (#1404)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast",
-  "version": "2.6.20",
+  "version": "2.6.21",
   "description": "",
   "type": "module",
   "main": "lib/index.node.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/types",
-  "version": "2.6.20",
+  "version": "2.6.21",
   "description": "Type definitions for MulmoCast",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Release **mulmocast@2.6.21** and **@mulmocast/types@2.6.21**.

Already published to npm:
- 📦 [\`mulmocast@2.6.21\`](https://www.npmjs.com/package/mulmocast/v/2.6.21)
- 📦 [\`@mulmocast/types@2.6.21\`](https://www.npmjs.com/package/@mulmocast/types/v/2.6.21)

## Highlights

- **Token / API usage tracking** — full umbrella #1415 landed across #1429–#1448. Every AI agent (image / movie / TTS / LLM / sound effect / lipsync) now surfaces structured `{ provider, model, inputTokens?, outputTokens?, totalTokens?, predictSec?, inputChars? }` via a per-request `MulmoStudioContext.usageCollector`. Opt-in CLI dump via `MULMOCAST_DUMP_USAGE=1` / `=/path/usage.json`. Full reference: `docs/api.md` / [`api.md` § usage tracking](https://github.com/receptron/mulmocast-cli/blob/main/docs/api.md#usage-tracking).
- **`docs/api.md`** — first consolidated programmatic API reference (#1442 / #1447). Lifecycle examples, action / per-beat / settings / callbacks coverage, per-agent populated-fields matrix for all 17 AI agents.
- **Dependency update** — `undici` 7.25.0 → 7.28.0 (#1443).

See `CHANGELOG.md` for full notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced token and API usage tracking with per-request collection and detailed monitoring across multiple services including image generation, video processing, text-to-speech, translation, and tool services. Includes optional CLI output support in both JSON and standard output formats for integration workflows.
  * Added comprehensive programmatic API reference documentation.

* **Dependencies**
  * Updated undici dependency to version 7.28.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->