### PR TITLE
docs(README): document MULMOCAST_DUMP_USAGE under the CLI commands section

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Payload shape:
 
 ```json
 {
-  "records": 5,
+  "records": 3,
   "byModel": [
     { "provider": "openai",     "model": "gpt-4o-mini-tts", "records": 1, "inputChars": 20 },
     { "provider": "gemini",     "model": "gemini-2.5-flash-preview-tts", "records": 1, "inputTokens": 9, "outputTokens": 59, "totalTokens": 68 },

--- a/README.md
+++ b/README.md
@@ -391,6 +391,34 @@ mulmo movie script.json
 mulmo translate script.json
 ```
 
+### Usage tracking (token / character / predict-second per provider:model)
+
+Any of the commands above can dump a JSON breakdown of upstream AI consumption when `MULMOCAST_DUMP_USAGE` is set:
+
+```bash
+# print JSON to stdout (pipe-friendly: `... | jq .`)
+MULMOCAST_DUMP_USAGE=1 mulmo audio script.json
+
+# ...or write it to a file
+MULMOCAST_DUMP_USAGE=/tmp/usage.json mulmo movie script.json
+```
+
+Payload shape:
+
+```json
+{
+  "records": 5,
+  "byModel": [
+    { "provider": "openai",     "model": "gpt-4o-mini-tts", "records": 1, "inputChars": 20 },
+    { "provider": "gemini",     "model": "gemini-2.5-flash-preview-tts", "records": 1, "inputTokens": 9, "outputTokens": 59, "totalTokens": 68 },
+    { "provider": "elevenlabs", "model": "eleven_multilingual_v2", "records": 1, "inputChars": 18 }
+  ],
+  "snapshot": [ /* per-call UsageRecord[] */ ]
+}
+```
+
+`byModel` groups by `provider:model` (different models have different rate cards, so summing across them isn't meaningful). The full per-call snapshot is also included so a billing layer can apply its own grouping. See [docs/api.md § Usage tracking](./docs/api.md#usage-tracking) for the per-agent field-population matrix and the programmatic (library) API.
+
 ## Cache and Re-run
 When running the same `mulmo` command multiple times, previously generated files are treated as cache. For example, audio or image files will not be regenerated if they already exist.
 


### PR DESCRIPTION
## Summary

Adds a "Usage tracking" subsection inside \`## Generate content from MulmoScript\` — the section where users invoke \`mulmo audio\` / \`mulmo movie\` / etc. The env var is currently only mentioned briefly in \`## Configuration\` next to API keys, which is too easy to miss.

## Items to Confirm / Review

- **Placement choice**: I put it right after the command list, before \`## Cache and Re-run\`. Open to moving if you'd rather have it as its own top-level \`## Usage tracking\` section, but I felt grouping with the CLI commands is more discoverable.
- **Example payload**: I dropped 3 representative rows (openai char, gemini token, elevenlabs char) to keep it visually short. The full per-agent matrix lives in docs/api.md so the README stays scannable.

## Changes

- README.md: new "Usage tracking" subsection (28 lines), preserves the existing one-liner in \`## Configuration\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Usage tracking” section explaining how to enable JSON reporting of upstream AI consumption for any `mulmo` command via `MULMOCAST_DUMP_USAGE`.
  * Documents pipe-friendly stdout output and file output options, plus the expected JSON payload structure (e.g., `records`, `byModel`, and `snapshot`) and links to additional field details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->