### PR TITLE
fix(tts-gemini): unmask ffmpeg errors from "TTS Gemini Error" (#1451)

### DIFF
--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -39,59 +39,93 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
     });
   }
 
-  try {
-    const ai = new GoogleGenAI({ apiKey });
-    const response = await ai.models.generateContent({
-      model: model ?? provider2TTSAgent.gemini.defaultModel,
-      contents: [{ parts: [{ text: getPrompt(text, instructions) }] }],
-      config: {
-        responseModalities: ["AUDIO"],
-        speechConfig: {
-          voiceConfig: {
-            prebuiltVoiceConfig: { voiceName: voice ?? provider2TTSAgent.gemini.defaultVoice },
+  // Phase 1 — Gemini TTS: API call + response decode. Extracted into a
+  // helper so its result tuple is bound with `const`, and so its catch
+  // can return early without trapping the ffmpeg call below in the same
+  // try (#1451: an ffmpeg SIGABRT in `pcmToMp3` was previously masked
+  // as "TTS Gemini Error" because both phases shared one try/catch).
+  // Returns the decoded PCM + sample rate + usage, OR the suppressError
+  // `{ error }` envelope (in which case the outer function returns it
+  // verbatim, same as the original behaviour).
+  const geminiResult: { rawPcm: Buffer; sampleRate: number; usage: AgentUsage | undefined } | AgentErrorResult = await (async () => {
+    try {
+      const ai = new GoogleGenAI({ apiKey });
+      const response = await ai.models.generateContent({
+        model: model ?? provider2TTSAgent.gemini.defaultModel,
+        contents: [{ parts: [{ text: getPrompt(text, instructions) }] }],
+        config: {
+          responseModalities: ["AUDIO"],
+          speechConfig: {
+            voiceConfig: {
+              prebuiltVoiceConfig: { voiceName: voice ?? provider2TTSAgent.gemini.defaultVoice },
+            },
           },
         },
-      },
-    });
+      });
 
-    const inlineData = response.candidates?.[0]?.content?.parts?.[0]?.inlineData;
-    const pcmBase64 = inlineData?.data;
-    const mimeType = inlineData?.mimeType;
+      const inlineData = response.candidates?.[0]?.content?.parts?.[0]?.inlineData;
+      const pcmBase64 = inlineData?.data;
+      const mimeType = inlineData?.mimeType;
 
-    if (!pcmBase64 || typeof pcmBase64 !== "string") throw new Error("No audio data returned");
+      if (!pcmBase64 || typeof pcmBase64 !== "string") throw new Error("No audio data returned");
 
-    // Extract sample rate from mimeType (e.g., "audio/L16;codec=pcm;rate=24000")
-    const rateMatch = mimeType?.match(/rate=(\d+)/);
-    const sampleRate = rateMatch ? parseInt(rateMatch[1]) : 24000;
+      // Extract sample rate from mimeType (e.g., "audio/L16;codec=pcm;rate=24000")
+      const rateMatch = mimeType?.match(/rate=(\d+)/);
+      const sampleRate = rateMatch ? parseInt(rateMatch[1]) : 24000;
 
-    const rawPcm = Buffer.from(pcmBase64, "base64");
+      const rawPcm = Buffer.from(pcmBase64, "base64");
 
-    const usedModel = model ?? provider2TTSAgent.gemini.defaultModel;
-    const usage: AgentUsage | undefined = response.usageMetadata
-      ? {
-          provider: "gemini",
-          model: usedModel,
-          inputTokens: response.usageMetadata.promptTokenCount,
-          outputTokens: response.usageMetadata.candidatesTokenCount,
-          totalTokens: response.usageMetadata.totalTokenCount,
-        }
-      : undefined;
-    return { buffer: await pcmToMp3(rawPcm, sampleRate), usage };
-  } catch (e) {
-    if (suppressError) {
-      return {
-        error: e,
-      };
-    }
-    GraphAILogger.info(e);
+      const usedModel = model ?? provider2TTSAgent.gemini.defaultModel;
+      const usage: AgentUsage | undefined = response.usageMetadata
+        ? {
+            provider: "gemini",
+            model: usedModel,
+            inputTokens: response.usageMetadata.promptTokenCount,
+            outputTokens: response.usageMetadata.candidatesTokenCount,
+            totalTokens: response.usageMetadata.totalTokenCount,
+          }
+        : undefined;
+      return { rawPcm, sampleRate, usage };
+    } catch (e) {
+      if (suppressError) {
+        return { error: e };
+      }
+      GraphAILogger.info(e);
 
-    const reasonDetail = getGenAIErrorReason(e as Error);
-    if (reasonDetail && reasonDetail.reason && reasonDetail.reason === "API_KEY_INVALID") {
-      throw new Error("Failed to generate tts: 400 Incorrect API key provided with gemini", {
-        cause: agentIncorrectAPIKeyError("ttsGeminiAgent", audioAction, audioFileTarget),
+      const reasonDetail = getGenAIErrorReason(e as Error);
+      if (reasonDetail && reasonDetail.reason && reasonDetail.reason === "API_KEY_INVALID") {
+        throw new Error("Failed to generate tts: 400 Incorrect API key provided with gemini", {
+          cause: agentIncorrectAPIKeyError("ttsGeminiAgent", audioAction, audioFileTarget),
+        });
+      }
+      // Include the underlying message so non-API-KEY errors are
+      // identifiable in logs (previously every such error printed the
+      // same opaque "TTS Gemini Error" string).
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(`TTS Gemini Error: ${detail}`, {
+        cause: agentGenerationError("ttsGeminiAgent", audioAction, audioFileTarget),
       });
     }
-    throw new Error("TTS Gemini Error", {
+  })();
+
+  if ("error" in geminiResult) {
+    return geminiResult;
+  }
+
+  // Phase 2 — ffmpeg PCM → MP3. OS-side failure modes (missing/broken
+  // `ffmpeg` binary, missing `libmp3lame` encoder, SIGABRT under memory
+  // pressure) get their own label so the underlying message reaches
+  // mulmoclaude/CI logs instead of being collapsed into "TTS Gemini
+  // Error" (#1451).
+  try {
+    return { buffer: await pcmToMp3(geminiResult.rawPcm, geminiResult.sampleRate), usage: geminiResult.usage };
+  } catch (e) {
+    if (suppressError) {
+      return { error: e };
+    }
+    GraphAILogger.info(e);
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new Error(`Audio encoding (ffmpeg) failed: ${detail}`, {
       cause: agentGenerationError("ttsGeminiAgent", audioAction, audioFileTarget),
     });
   }

--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -39,14 +39,6 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
     });
   }
 
-  // Phase 1 — Gemini TTS: API call + response decode. Extracted into a
-  // helper so its result tuple is bound with `const`, and so its catch
-  // can return early without trapping the ffmpeg call below in the same
-  // try (#1451: an ffmpeg SIGABRT in `pcmToMp3` was previously masked
-  // as "TTS Gemini Error" because both phases shared one try/catch).
-  // Returns the decoded PCM + sample rate + usage, OR the suppressError
-  // `{ error }` envelope (in which case the outer function returns it
-  // verbatim, same as the original behaviour).
   const geminiResult: { rawPcm: Buffer; sampleRate: number; usage: AgentUsage | undefined } | AgentErrorResult = await (async () => {
     try {
       const ai = new GoogleGenAI({ apiKey });
@@ -98,9 +90,6 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
           cause: agentIncorrectAPIKeyError("ttsGeminiAgent", audioAction, audioFileTarget),
         });
       }
-      // Include the underlying message so non-API-KEY errors are
-      // identifiable in logs (previously every such error printed the
-      // same opaque "TTS Gemini Error" string).
       const detail = e instanceof Error ? e.message : String(e);
       throw new Error(`TTS Gemini Error: ${detail}`, {
         cause: agentGenerationError("ttsGeminiAgent", audioAction, audioFileTarget),
@@ -112,11 +101,6 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
     return geminiResult;
   }
 
-  // Phase 2 — ffmpeg PCM → MP3. OS-side failure modes (missing/broken
-  // `ffmpeg` binary, missing `libmp3lame` encoder, SIGABRT under memory
-  // pressure) get their own label so the underlying message reaches
-  // mulmoclaude/CI logs instead of being collapsed into "TTS Gemini
-  // Error" (#1451).
   try {
     return { buffer: await pcmToMp3(geminiResult.rawPcm, geminiResult.sampleRate), usage: geminiResult.usage };
   } catch (e) {


### PR DESCRIPTION
## Summary

`ttsGeminiAgent` wrapped the Gemini API call + `pcmToMp3` (ffmpeg) in a single try/catch that collapsed every non-API-KEY failure into `throw new Error("TTS Gemini Error")`. An end-user (via `mulmoclaude`) hit an ffmpeg `SIGABRT` and the logs showed only "TTS Gemini Error" — the actual ffmpeg stderr never surfaced, so triage chased the wrong subsystem.

Splits the function into two phases with distinct error semantics:

1. **Gemini API + response decode** — wrapped in an IIFE so its result tuple binds with `const`. Catch keeps the existing API-KEY-invalid path; for everything else it now interpolates the underlying error message into `"TTS Gemini Error: <detail>"` (no more opaque label even for genuine Gemini errors).
2. **`pcmToMp3`** — runs after the helper resolves, in its own try. Failures throw `"Audio encoding (ffmpeg) failed: <stderr>"` with the original message preserved. `suppressError` still returns the `{ error }` envelope at both phases.

Closes part of #1451 — the misleading-error-message half. The OS-side root-cause (libmp3lame missing / broken ffmpeg / SIGABRT under memory pressure) is the user-environment diagnosis tracked separately in that issue and isn't fixed here. Once this lands, the next reproduction will show the real ffmpeg message in logs, which closes the diagnostic loop.

## Items to Confirm / Review

- **No behaviour change on the happy path.** Identical return shape, identical IIFE / no-IIFE difference only in structure. `yarn ci_test` passes (no new tests added; no existing test grepped for the literal `"TTS Gemini Error"` so the wording change is safe).
- **IIFE pattern (`const x = await (async () => { ... })()`)** is used to keep the result tuple `const`-bound across the try/catch boundary without `let`. Reads cleanly imo, but ymmv — happy to refactor to a top-level helper function if you'd prefer.
- **`suppressError` semantics preserved at both phases.** Either phase failing with `suppressError: true` returns `{ error: e }`. Without `suppressError`, each phase throws its own labelled error.
- **`AgentErrorResult` typing.** The IIFE return type is `{ rawPcm; sampleRate; usage } | AgentErrorResult` — the outer function then narrows via `"error" in geminiResult` before proceeding to ffmpeg.
- **The "TTS Gemini Error" literal is gone** from the codebase except as the *prefix* of the new templated message (`TTS Gemini Error: <detail>`). Grep confirmed no test depended on the exact string.

## Lint / build / test status

- `yarn format` — clean
- `yarn lint` — 6 pre-existing `sonarjs/cognitive-complexity` warnings on unrelated files; no new errors / warnings on `tts_gemini_agent.ts`
- `yarn build` — clean
- `yarn ci_test` — passes

## Related

- #1451 (this PR addresses points "Fix 1" + "Fix 2" from the issue body). Environment diagnostics (`ffmpeg-static` adoption, OS ffmpeg health check) remain open for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech failure messaging, including more specific errors when AI requests fail and clearer details when audio encoding encounters issues.
  * Kept existing invalid API key handling intact, so authentication errors remain consistent while other failures are easier to identify.
  * Reduced misleading error masking by separating generation errors from encoding/ffmpeg problems (and keeping error suppression behavior intact when enabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->