### PR TITLE
fix(whisper-handler): split phases so errors point at the right subsystem

### DIFF
--- a/src/cli/commands/tool/whisper/handler.ts
+++ b/src/cli/commands/tool/whisper/handler.ts
@@ -57,56 +57,76 @@ export const handler = async (argv: ToolCliArgs<{ file: string }>) => {
     process.exit(1);
   }
 
-  try {
-    // Get audio duration using FFmpeg
-    const { duration: audioDuration } = await ffmpegGetMediaDuration(fullPath);
-    GraphAILogger.info(`Audio duration: ${audioDuration.toFixed(2)} seconds`);
+  // Each phase has its own try/catch so a failure points at the right
+  // subsystem instead of being collapsed into "Error transcribing audio"
+  // (same anti-pattern as #1451 in tts_gemini_agent.ts — an ffmpeg
+  // SIGABRT or a permission-denied write would otherwise read as an
+  // OpenAI-side failure).
 
-    const openai = new OpenAI({ apiKey });
+  // Phase 1 — ffmpeg: read the audio file's duration.
+  const audioDuration = await (async (): Promise<number> => {
+    try {
+      const { duration } = await ffmpegGetMediaDuration(fullPath);
+      return duration;
+    } catch (error) {
+      GraphAILogger.error("Error reading audio duration with ffmpeg:", error);
+      process.exit(1);
+    }
+  })();
+  GraphAILogger.info(`Audio duration: ${audioDuration.toFixed(2)} seconds`);
 
-    const transcription = await openai.audio.transcriptions.create({
-      file: createReadStream(fullPath),
-      model: "whisper-1",
-      response_format: "verbose_json",
-      timestamp_granularities: ["word", "segment"],
+  // Phase 2 — OpenAI: Whisper transcription API call.
+  const transcription = await (async () => {
+    try {
+      const openai = new OpenAI({ apiKey });
+      return await openai.audio.transcriptions.create({
+        file: createReadStream(fullPath),
+        model: "whisper-1",
+        response_format: "verbose_json",
+        timestamp_granularities: ["word", "segment"],
+      });
+    } catch (error) {
+      GraphAILogger.error("Error calling OpenAI transcription API:", error);
+      process.exit(1);
+    }
+  })();
+
+  if (transcription.segments) {
+    const starts = transcription.segments.map((segment) => segment.start);
+    starts[0] = 0;
+    starts.push(audioDuration);
+    // Create beats from transcription segments
+    const beats = transcription.segments.map((segment, index) => {
+      const duration = Math.round((starts[index + 1] - starts[index]) * 100) / 100;
+      return {
+        text: segment.text,
+        duration,
+        /*
+        image: {
+          type: "textSlide",
+          slide: {
+            title: "Place Holder",
+          },
+        },
+        */
+      };
     });
 
-    if (transcription.segments) {
-      const starts = transcription.segments.map((segment) => segment.start);
-      starts[0] = 0;
-      starts.push(audioDuration);
-      // Create beats from transcription segments
-      const beats = transcription.segments.map((segment, index) => {
-        const duration = Math.round((starts[index + 1] - starts[index]) * 100) / 100;
-        return {
-          text: segment.text,
-          duration,
-          /*
-          image: {
-            type: "textSlide",
-            slide: {
-              title: "Place Holder",
-            },
-          },
-          */
-        };
-      });
+    // Create the script with the processed beats
+    const script = createMulmoScript(fullPath, beats);
 
-      // Create the script with the processed beats
-      const script = createMulmoScript(fullPath, beats);
-
-      // Save script to output directory
+    // Phase 3 — fs: write the generated script to disk.
+    try {
       const outputDir = "output";
       if (!existsSync(outputDir)) {
         mkdirSync(outputDir, { recursive: true });
       }
-
       const outputPath = join(outputDir, `${filename}.json`);
       writeFileSync(outputPath, JSON.stringify(script, null, 2));
       GraphAILogger.info(`Script saved to: ${outputPath}`);
+    } catch (error) {
+      GraphAILogger.error("Error writing transcription output file:", error);
+      process.exit(1);
     }
-  } catch (error) {
-    GraphAILogger.error("Error transcribing audio:", error);
-    process.exit(1);
   }
 };


### PR DESCRIPTION
## Summary

`src/cli/commands/tool/whisper/handler.ts` wrapped three independent failure surfaces — `ffmpegGetMediaDuration`, OpenAI Whisper transcription, and the output `mkdirSync` / `writeFileSync` — in a single try/catch that collapsed every failure into the same `"Error transcribing audio:"` log line + `process.exit(1)`.

Same diagnostic-masking anti-pattern as #1451 in `tts_gemini_agent.ts` (fixed in #1452): an ffmpeg SIGABRT or a missing `libmp3lame` encoder reads as an OpenAI failure; an OpenAI 429 or 401 reads ambiguously; a permission-denied write reads as something it isn't.

## Fix

Three phases, each with its own try/catch wrapped in an IIFE so the result binds with `const` (no `let` per repo style). Each catch logs a subsystem-specific message before `process.exit(1)`:

| Phase | Operation | Catch log |
|---|---|---|
| 1 | `ffmpegGetMediaDuration(fullPath)` | `"Error reading audio duration with ffmpeg:"` |
| 2 | `openai.audio.transcriptions.create(...)` | `"Error calling OpenAI transcription API:"` |
| 3 | `mkdirSync` + `writeFileSync` | `"Error writing transcription output file:"` |

Beat-construction (`transcription.segments.map(...)` + `createMulmoScript(...)`) is pure and untrapped — it's just data manipulation, no IO.

## Items to Confirm / Review

- **No behaviour change on the happy path.** Identical outputs, identical order, identical exit codes (1 on any failure).
- **`process.exit(1)` is typed `never`**, so TS infers the IIFE return type as `Promise<number>` / `Promise<Transcription>` cleanly (no need to annotate the second IIFE).
- **OpenAI client construction (`new OpenAI({ apiKey })`)** moved into Phase 2 — the constructor is synchronous and just stores the key, so the move is a no-op functionally but keeps API setup co-located with the API call.
- **Comment block** with the `image: { type: "textSlide", ... }` placeholder preserved verbatim (it was deliberately commented-out scaffolding).

## Gates

- `yarn format` clean
- `yarn lint` — 6 pre-existing `sonarjs/cognitive-complexity` warnings on unrelated files; no new issues on `handler.ts`
- `yarn build` (tsc) clean
- `yarn ci_test` — **910 pass / 0 fail**

## Related

- Follows the same pattern as #1452 (TTS Gemini split)
- Closes the second batch of the survey requested in #1451's parent discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio processing error handling with clearer, phase-specific messages when duration lookup, transcription, or output generation fails.
  * Reduced the chance of a single failure masking where the problem occurred.

* **Refactor**
  * Reworked the transcription workflow into separate steps for better reliability and easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->