### PR TITLE
fix(image-replicate): include underlying error in catch-all

### DIFF
--- a/src/agents/image_replicate_agent.ts
+++ b/src/agents/image_replicate_agent.ts
@@ -97,7 +97,11 @@ export const imageReplicateAgent: AgentFunction<ReplicateImageAgentParams, Agent
         });
       }
     }
-    throw new Error("Failed to generate image with Replicate", {
+    // Include the underlying message so the catch-all path doesn't
+    // mask Replicate SDK / fetch / arrayBuffer failures behind a
+    // generic label (same fix as tts_gemini #1452, whisper #1453).
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to generate image with Replicate: ${detail}`, {
       cause: agentGenerationError("imageReplicateAgent", imageAction, imageFileTarget),
     });
   }


### PR DESCRIPTION
## Summary

`imageReplicateAgent`'s catch-all rethrew unknown failures as the literal `"Failed to generate image with Replicate"`. The `GraphAILogger.info("Replicate generation error:", error)` line above it logged the underlying error, but the **thrown** error message was opaque — same diagnostic-masking problem as #1451 / #1452 / #1453, smaller surface (only the not-yet-classified branch).

One-line change: interpolate `error.message` into the catch-all throw. The `hasCause` guard above still routes structured throws (input validation, 401 API key) as before.

## Items to Confirm / Review

- **`hasCause` branch unchanged.** Existing structured throws (line 71 validation, line 78 download status, line 95 API-key) all carry `cause` and rethrow as-is via the existing guard.
- **What gets enriched now**: Replicate SDK errors without `cause` (e.g. a thrown TypeError from the SDK), `fetch()` errors (ETIMEDOUT, ECONNRESET, DNS), `arrayBuffer()` errors. Previously: all read as "Failed to generate image with Replicate" with no detail; now read as `"Failed to generate image with Replicate: <message>"`.
- **Mechanical template**, same as #1452 / #1453. Applied via `error instanceof Error ? error.message : String(error)` to handle non-Error throws safely.

## Gates

- `yarn format` clean
- `yarn lint` — pre-existing 6 cognitive-complexity warnings on unrelated files; 0 new
- `yarn build` (tsc) clean
- `yarn ci_test` — 910 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image generation error messages to include more helpful details when Replicate requests fail.
  * Users should now see clearer failure feedback instead of a generic image generation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->