### PR TITLE
fix(lipsync-replicate): include underlying error in catch-all

### DIFF
--- a/src/agents/lipsync_replicate_agent.ts
+++ b/src/agents/lipsync_replicate_agent.ts
@@ -108,7 +108,12 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to lipSync with Replicate", {
+    // Include the underlying message so the catch-all path doesn't
+    // mask Replicate SDK / fetch / arrayBuffer failures behind a
+    // generic label (same fix as tts_gemini #1452, whisper #1453,
+    // image_replicate #1454).
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to lipSync with Replicate: ${detail}`, {
       cause: agentGenerationError("lipSyncReplicateAgent", imageAction, movieFileTarget),
     });
   }


### PR DESCRIPTION
## Summary

Same template as #1452 (tts_gemini) / #1453 (whisper) / #1454 (image-replicate). `lipSyncReplicateAgent`'s catch-all rethrew unknown failures as `"Failed to lipSync with Replicate"`, masking the underlying message that `GraphAILogger.info("Failed to generate lip sync:", (error as Error).message)` had logged on the line above.

## Items to Confirm / Review

- **`hasCause` guard preserved.** Structured throws still pass through unchanged: API key missing (line 30), audio file missing (line 39), movie/image required (line 49), model unsupported (line 70), download status (line 96).
- **What gets enriched**: Replicate SDK errors without `cause`, `fetch()` network errors, `arrayBuffer()` resets. Previously identical opaque message → now `"Failed to lipSync with Replicate: <message>"`.

## Gates

- `yarn format` clean
- `yarn lint` — pre-existing warnings only, 0 new
- `yarn build` (tsc) clean
- `yarn ci_test` — 910 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lip sync error messages to include the underlying failure detail, making issues easier to diagnose.
  * When a request fails, the app now surfaces the original error message instead of showing only a generic failure notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->