### PR TITLE
fix(movie-replicate): label catch-all with underlying error

### DIFF
--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -198,6 +198,15 @@ export const movieReplicateAgent: AgentFunction<ReplicateMovieAgentParams, Agent
       throw error;
     }
     GraphAILogger.info("Failed to generate movie:", (error as Error).message);
+    // Throw a properly-labeled error with the underlying message
+    // preserved rather than falling through to the "returned
+    // undefined" line below — that message is only meaningful when
+    // `result` actually IS undefined, not when generation threw.
+    // (Same template as #1452 / #1453 / #1454 / #1455.)
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to generate movie with Replicate: ${detail}`, {
+      cause: agentGenerationError("movieReplicateAgent", imageAction, movieFileTarget),
+    });
   }
   throw new Error("ERROR: generateMovie returned undefined", {
     cause: agentInvalidResponseError("movieReplicateAgent", imageAction, movieFileTarget),


### PR DESCRIPTION
## Summary

`movieReplicateAgent` had a subtle variant of the same masking problem as #1452 / #1453 / #1454 / #1455. The catch block at lines 196-201 logged the underlying message and then **fell through** to a `throw new Error("ERROR: generateMovie returned undefined", ...)` on line 202 — but that "returned undefined" label is only meaningful when `result` is literally undefined, not when an exception bubbled up from `generateMovie`.

Fix: throw a properly-labeled error inside the catch (with `${error.message}` interpolated) and let the line-202 throw stay reserved for its actual semantic — `result === undefined` after a clean run.

## Items to Confirm / Review

- **`hasCause` guard preserved.** Structured throws still rethrown as-is (line 197-198).
- **"returned undefined" semantic restored.** Line 202 now only fires when `generateMovie` resolved to an undefined value (e.g. the inner `if (output && typeof output === "object" && "url" in output)` branch wasn't taken). Previously it was overloaded with the "we threw and don't have cause" case too.
- **What gets enriched**: Replicate SDK errors without `cause`, `fetch()` failures, `arrayBuffer()` resets. Previously read as "generateMovie returned undefined" (misleading); now reads as `"Failed to generate movie with Replicate: <message>"`.
- **`agentGenerationError` import already present** (line 7); no new imports needed.

## Gates

- `yarn format` clean
- `yarn lint` — pre-existing warnings only, 0 new
- `yarn build` (tsc) clean
- `yarn ci_test` — 910 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)