### PR TITLE
fix(image-openai): include underlying error in catch branches

### DIFF
--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -110,17 +110,22 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
       }
       if (error instanceof APIError) {
         if (error.code && error.type) {
-          throw new Error("Failed to generate image with OpenAI", {
+          throw new Error(`Failed to generate image with OpenAI: ${error.message}`, {
             cause: openAIAgentGenerationError("imageOpenaiAgent", imageAction, error.code, error.type),
           });
         }
         if (error.type === "invalid_request_error" && error?.error?.message?.includes("Your organization must be verified")) {
-          throw new Error("Failed to generate image with OpenAI", {
+          throw new Error(`Failed to generate image with OpenAI: ${error.message}`, {
             cause: openAIAgentGenerationError("imageOpenaiAgent", imageAction, "need_verified_organization", error.type),
           });
         }
       }
-      throw new Error("Failed to generate image with OpenAI", {
+      // Catch-all: include the underlying message so unknown errors
+      // (OpenAI SDK exceptions w/o APIError shape, fetch resets) are
+      // diagnosable from the thrown error alone — not just the log
+      // line above. Same template as #1452 / #1453 / #1454 / #1455 / #1456.
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to generate image with OpenAI: ${detail}`, {
         cause: agentGenerationError("imageOpenaiAgent", imageAction, imageFileTarget),
       });
     }


### PR DESCRIPTION
## Summary

`imageOpenaiAgent`'s OpenAI-call IIFE catch had three throws emitting the **identical** literal `"Failed to generate image with OpenAI"`:
- Line 113 — `APIError` with `code` + `type`
- Line 118 — `invalid_request_error` requiring org verification
- Line 123 — catch-all

The `cause` objects distinguished them programmatically (`error.code`, `error.type`, `need_verified_organization`), but a downstream consumer reading only the thrown error message couldn't tell which case fired or what the underlying provider message was.

Interpolate `error.message` into all three. APIError instances expose `.message`; the catch-all uses `error instanceof Error ? error.message : String(error)` for safe narrowing.

## Items to Confirm / Review

- **`AuthenticationError` (line 102) and `RateLimitError` (line 107) branches unchanged.** Their literal messages ("Failed to generate image: 401 Incorrect API key provided with OpenAI" / "You exceeded your current quota") are already specific enough that adding the SDK message would be noise.
- **`cause` objects unchanged.** Programmatic consumers that branch on `cause` (the existing pattern) still get the same structured cause. Only the *string* message becomes richer.
- **No new imports.** `error.message` is reachable via the existing `instanceof` narrowings.
- **Same template** as #1452 (tts_gemini) / #1453 (whisper) / #1454 (image_replicate) / #1455 (lipsync_replicate) / #1456 (movie_replicate).

## Gates

- `yarn format` clean
- `yarn lint` — pre-existing warnings only, 0 new
- `yarn build` (tsc) clean
- `yarn ci_test` — 910 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)