### PR TITLE
fix(tts-elevenlabs): include underlying error in IIFE catch-all

### DIFF
--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -62,7 +62,12 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
         };
       }
       GraphAILogger.info(e);
-      throw new Error("TTS Eleven Labs Error", {
+      // Include the underlying message so fetch failures (DNS / TLS /
+      // ETIMEDOUT / ECONNRESET) are diagnosable from the thrown error
+      // — previously every such case collapsed to the static label.
+      // Same template as #1452 / #1453 / #1454 / #1455 / #1456 / #1457.
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(`TTS Eleven Labs Error: ${detail}`, {
         cause: agentGenerationError("ttsElevenlabsAgent", audioAction, audioFileTarget),
       });
     }


### PR DESCRIPTION
The fetch-call IIFE's catch (line 58) rethrew unknown failures (DNS / TLS / ETIMEDOUT / ECONNRESET on the ElevenLabs HTTP call) as the static literal "TTS Eleven Labs Error" — the underlying network error message that GraphAILogger.info(e) had just logged never reached the thrown error.

Interpolate error.message into the catch-all, same template as #1452 / #1453 / #1454 / #1455 / #1456 / #1457. The OUTER branches (401, voice_limit_reached, generic API error) already include response.status / detail in their labels — left alone.