### PR TITLE
feat: pre-run usage estimator (estimateUsage) with dated pricing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,21 @@ Payload shape:
 
 `byModel` groups by `provider:model` (different models have different rate cards, so summing across them isn't meaningful). The full per-call snapshot is also included so a billing layer can apply its own grouping. See [docs/api.md § Usage tracking](./docs/api.md#usage-tracking) for the per-agent field-population matrix and the programmatic (library) API.
 
+### Usage estimation (before running anything)
+
+The library API can estimate what a full run would consume — per beat, per process — without calling any API:
+
+```typescript
+import { estimateUsage } from "mulmocast";
+
+const estimates = estimateUsage(script, { targetLangs: ["ja"] });
+// [{ process: "tts", beatIndex: 0, provider: "openai", model: "gpt-4o-mini-tts",
+//    inputChars: { value: 50, precision: "exact" }, outputTokens: { value: 150, precision: "estimated" },
+//    costUSD: 0.0019, pricingAsOf: "2026-07-03" }, ...]
+```
+
+Each metric carries a `precision` flag: `"exact"` for values that are deterministic from the script (TTS character counts, tokenized OpenAI prompts, fixed image-output token tables) and `"estimated"` for heuristics (LLM output length, speech duration derived from text). `costUSD` appears when pricing data exists in `modelPricing` (`src/types/provider2agent.ts`), where every price records the date it was last verified. See [docs/api.md § Pre-run estimation](./docs/api.md#pre-run-estimation-estimateusage).
+
 ## Cache and Re-run
 When running the same `mulmo` command multiple times, previously generated files are treated as cache. For example, audio or image files will not be regenerated if they already exist.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,6 +32,7 @@ What `import { … } from "mulmocast"` gives you, by area:
 | Logging | `setGraphAILogger` |
 | Path helpers | `getOutputStudioFilePath`, `getOutputMultilingualFilePath`, `getOutputVideoFilePath`, `getOutputPdfFilePath`, `getReferenceImagePath`, `getBeatPngImagePath`, `getCaptionImagePath`, `getBeatMoviePaths` |
 | Usage tracking | `UsageCollector`, `UsageRecord`, `UsageCollectorAPI`, `AgentUsage` (see [Usage tracking](#usage-tracking) below) |
+| Usage estimation | `estimateUsage`, `UsageEstimate`, `EstimatedMetric`, `modelPricing`, `ModelPricing` (see [Pre-run estimation](#pre-run-estimation-estimateusage) below) |
 | Agents (direct use) | `puppeteerCrawlerAgent`, `validateSchemaAgent`, all `image*Agent` / `tts*Agent` / `movie*Agent` / `lipsync*Agent` agents |
 
 ## Lifecycle: from MulmoScript JSON to rendered video
@@ -323,10 +324,31 @@ Mulmocast caches generated media on disk. When a beat is re-run and the artifact
 
 ### Known gaps
 
-- **gpt-4o-mini-tts** is token-billed (text input + audio output) but OpenAI does not expose per-call token usage in the response or headers (probed and documented in PR #1439 / issue #1428). `inputChars: text.length` is the only signal mulmocast surfaces; the billing layer needs either a tokenizer (e.g. `tiktoken` with `o200k_base`) or an estimator (input chars × 4.1 chars/token, audio tokens ≈ 50/s).
+- **gpt-4o-mini-tts** is token-billed (text input + audio output) but OpenAI does not expose per-call token usage in the response or headers (probed and documented in PR #1439 / issue #1428). `inputChars: text.length` is the only signal mulmocast surfaces at runtime; [`estimateUsage`](#pre-run-estimation-estimateusage) fills the gap with tokenized input (`o200k_base`) and audio tokens ≈ 50/s.
 - **Tavily search** (used only by `deepResearch`, not by the regular generation flow) is per-request billed and not surfaced. Out of scope (closed via #1446).
 - **Whisper transcription** (only by `mulmo tool whisper`) is per-minute billed and not surfaced. Out of scope (closed via #1445).
 - **Standalone CLI tools** (`mulmo tool scripting`, `mulmo tool whisper`, `mulmo tool sound_effect`) do not initialize a `MulmoStudioContext`. They are not part of the billed API surface.
+
+### Pre-run estimation (`estimateUsage`)
+
+```ts
+import { estimateUsage } from "mulmocast";
+
+const estimates = estimateUsage(script, { langs: ["en"], targetLangs: ["ja"] });
+```
+
+Walks the script without calling any API and returns `UsageEstimate[]` — one record per beat per process (`tts`, `image`, `htmlImage`, `movie`, `soundEffect`, `lipSync`, `translate`, `imageReference`, `movieReference`). Field names mirror `UsageRecord`, so estimates can be compared with runtime actuals per `provider:model`.
+
+Every metric is an `EstimatedMetric` — `{ value, precision: "exact" | "estimated" }`:
+
+- `exact`: deterministic from the script — TTS character counts, tokenized OpenAI prompts (`o200k_base` via js-tiktoken), the fixed gpt-image output-token table, explicit beat durations snapped to model-supported values.
+- `estimated`: heuristic — LLM output length, speech duration derived from text, char-based token counts for non-OpenAI tokenizers, TTS input for languages whose translation doesn't exist yet.
+
+`costUSD` (+ `pricingAsOf`) is attached when pricing is known. Prices live in `modelPricing` in `src/types/provider2agent.ts`; each entry records the date it was last verified against the provider's pricing page (`asOf`) because rates drift. Supporting a new model is a data change there, not a code change.
+
+Options: `langs` (audio languages), `targetLangs` (translate targets; defaults to `langs` + `captionParams.lang` minus the script language), `presentationStyle` (overrides the script's own style, like the CLI `--presentation-style` flag).
+
+Caveats: assumes a fresh run (no cache hits — see [Cache hits](#cache-hits)); mock providers are skipped; `zsxkib/mmaudio` (sound effects) gets no `costUSD` because it bills by GPU time rather than clip duration. The function is pure and browser-compatible, but bundling it pulls in the ~2 MB `o200k_base` rank table.
 
 ### Probes (for verifying new agents)
 

--- a/docs/plans/feat-estimate-usage.md
+++ b/docs/plans/feat-estimate-usage.md
@@ -1,0 +1,116 @@
+# Plan: Pre-run usage estimator for MulmoScript
+
+Issue: https://github.com/receptron/mulmocast-cli/issues/1465
+
+## Goal
+
+`estimateUsage(script, options?)` — a pure function that walks a MulmoScript and returns, per beat and per process, the API usage a full generation run would consume (tokens / characters / billed seconds), before running anything. Each metric carries a precision flag (`exact` vs `estimated`).
+
+## Schema design
+
+### 1. Pricing metadata in `src/types/provider2agent.ts`
+
+Generalize the existing `price_per_sec` (currently on replicate movie models only, no runtime readers) into a pricing structure usable by all providers. Prices change over time, so every entry records when it was last verified:
+
+```typescript
+export type ModelPricing = {
+  unit: "tokens" | "chars" | "seconds" | "images";
+  inputPerMTokensUSD?: number;
+  outputPerMTokensUSD?: number;
+  perMCharsUSD?: number;
+  perSecUSD?: number;
+  perImageUSD?: number;
+  asOf: string; // YYYY-MM-DD, date the price was last verified against the provider's pricing page
+};
+```
+
+- A separate `modelPricing: Record<provider, Record<model, ModelPricing>>` map plus a `getModelPricing(provider, model)` helper (the existing tables keep their published shapes; per-entry pricing would have required restructuring them).
+- Keep `price_per_sec` untouched (published via `@mulmocast/types`; external consumers may read it). The replicate movie / lipSync pricing entries are **generated** from `price_per_sec` so there is a single source of truth.
+- Populate pricing for default/common models from official pricing pages (all values verified 2026-07-03); missing pricing simply yields no `costUSD`.
+- Also export `gptImageOutputTokens` (the fixed size × quality output-token table for gpt-image-1 / gpt-image-1-mini).
+
+### 2. Estimate result types in `src/types/usage.ts`
+
+Mirrors `UsageRecord` vocabulary so estimates can be compared with actuals collected by `usage_callback.ts`:
+
+```typescript
+export type EstimatePrecision = "exact" | "estimated";
+export type EstimatedMetric = { value: number; precision: EstimatePrecision };
+
+export type UsageEstimate = {
+  process: "tts" | "image" | "htmlImage" | "movie" | "soundEffect" | "lipSync" | "translate" | "imageReference" | "movieReference";
+  beatIndex?: number; // undefined for script-level imageParams.images references
+  refKey?: string; // reference image key for imageReference / movieReference
+  lang?: string; // tts / translate target language
+  provider: string;
+  model: string;
+  inputTokens?: EstimatedMetric;
+  outputTokens?: EstimatedMetric;
+  inputChars?: EstimatedMetric;
+  predictSec?: EstimatedMetric;
+  imageCount?: EstimatedMetric;
+  costUSD?: number; // present only when pricing data exists; inherently an estimate (prices drift)
+  pricingAsOf?: string;
+};
+```
+
+## Estimator: `src/utils/estimate_usage.ts` (new, browser-compatible)
+
+Signature:
+
+```typescript
+estimateUsage(script: MulmoScript, options?: {
+  lang?: string;           // audio language (default: script default lang)
+  targetLangs?: string[];  // translate targets (default: derived like translate action)
+  presentationStyle?: MulmoPresentationStyle; // default: the script itself
+}): UsageEstimate[];
+```
+
+Provider/model resolution reuses the same Methods the actions use: `getSpeaker`, `getImageAgentInfo`, `getMovieAgentInfo`, `getHtmlImageAgentInfo`, `getSoundEffectAgentInfo`, `getLipSyncAgentInfo`, `getModelDuration`, and the prompt builders `imagePrompt()`, `getHtmlPrompt()`, `htmlImageSystemPrompt()`, `translateSystemPrompt` / `translatePrompts`.
+
+Tokenizer: add `js-tiktoken` (pure JS/TS — no WASM, no Node built-ins, so it runs in browsers too; already a transitive dep). Use `js-tiktoken/lite` + explicit `o200k_base` ranks import so only one encoding is bundled. OpenAI models → exact token counts. Gemini / Claude → char-based heuristic, flagged `estimated`.
+
+Browser compatibility: the estimator uses no Node built-ins (its dependencies — `MulmoPresentationStyleMethods`, `prompt.ts`, `provider2agent.ts` — are all browser-safe), so it is exported from `index.common.ts` and works in both Node and browsers. Caveat: the o200k_base rank data adds ~2 MB to browser bundles that import it.
+
+### Per-pipeline rules (mirroring the real gating in actions)
+
+| process | gate (beat) | metrics and precision |
+|---|---|---|
+| tts | skip if `beat.audio`, empty `text`, or `suppressSpeech` | char-billed providers (openai char models / google / elevenlabs / kotodama): `inputChars` = text length → exact. Token-billed (`gpt-4o-mini-tts`): tiktoken → exact. gemini: wrapper prompt (Director's Notes) + char heuristic → estimated |
+| image | `imagePrompt` present, or no `beat.image` and not movie-only (mirror `imagePreprocessAgent`) | prompt = `imagePrompt(beat, style)`. openai gpt-image-1: `inputTokens` tiktoken → exact, `outputTokens` fixed by size/quality table → exact. google: heuristic → estimated. replicate: `imageCount` = 1 → exact |
+| htmlImage | `beat.htmlPrompt` | `inputTokens` = system + user prompt (openai: tiktoken → exact; anthropic: heuristic). `outputTokens`: heuristic (HTML output length is unknowable) → estimated |
+| movie | `beat.moviePrompt` | `predictSec` = `beat.duration` snapped via `getModelDuration` → exact when `duration` set; otherwise estimated from text speech duration heuristic (chars/sec) → estimated |
+| soundEffect | `soundEffectPrompt` && isMovie | `predictSec` = beat duration (same precision rule as movie) |
+| lipSync | `enableLipSync` | `predictSec` = beat duration (same precision rule) |
+| translate | per beat × targetLang; skip same-lang and empty text | `inputTokens` = system + prompts + text via tiktoken (gpt-4o) → exact; `outputTokens` ≈ text tokens × language factor → estimated |
+| imageReference / movieReference | `imageParams.images` and `beat.images` entries of type `imagePrompt` / `moviePrompt` | one generation call each, same rules as image / movie |
+
+Non-billable (no records): all local image plugins (textSlide, markdown, chart, mermaid, html_tailwind, slide, image, movie, source, vision, voice_over, beat) and captions.
+
+### Cost
+
+When pricing is known for provider+model, emit `costUSD` (always flagged `estimated` — prices drift) and `pricingAsOf`.
+
+## Files
+
+- `src/types/provider2agent.ts` — `ModelPricing` type + pricing data with `asOf`
+- `src/types/usage.ts` — `EstimatePrecision`, `EstimatedMetric`, `UsageEstimate`
+- `src/utils/estimate_usage.ts` — new estimator (browser-compatible)
+- `src/index.common.ts` — export `estimateUsage` (available in both Node and browser entries)
+- `test/test_estimate_usage.ts` — new tests
+- `package.json` — add `js-tiktoken`
+
+## Implementation steps
+
+1. Add `ModelPricing` type and pricing data (researched from official pricing pages, dated `asOf`)
+2. Add estimate types to `usage.ts`
+3. Implement estimator pipeline by pipeline (tts → image → htmlImage → movie → soundEffect/lipSync → translate → references)
+4. Tests (node:test, pure function, no API keys): happy path, gating rules (beat.audio / suppressSpeech / same-lang / movie-only), precision flags, unknown model → no costUSD, empty/edge cases
+5. `yarn format` / `yarn lint` / `yarn build` / `yarn ci_test`
+6. README: short API section for `estimateUsage`
+
+## Out of scope (future)
+
+- Cache-aware estimation (checking existing output files / force flag)
+- CLI subcommand (`mulmo estimate`) — function only for now
+- Note: `src/types/` changes ⇒ `@mulmocast/types` release needed when merged

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "clipboardy": "^5.3.1",
     "dotenv": "^17.4.2",
     "graphai": "^2.0.18",
+    "js-tiktoken": "^1.0.21",
     "jsdom": "^29.1.1",
     "marked": "^18.0.5",
     "mulmocast-vision": "^1.0.11",

--- a/scripts/probe/probe_estimate_vs_actual.ts
+++ b/scripts/probe/probe_estimate_vs_actual.ts
@@ -1,0 +1,98 @@
+// Probe: compare estimateUsage() predictions against the actual usage recorded
+// by a real generation run, aggregated per provider:model.
+//
+// Procedure:
+//   1. Run an action with usage dumping enabled:
+//        MULMOCAST_DUMP_USAGE=/tmp/usage_audio.json yarn cli audio script.json -o /tmp/out -l en
+//   2. Compare against the estimator:
+//        npx tsx scripts/probe/probe_estimate_vs_actual.ts script.json /tmp/usage_audio.json
+//
+// Optional env:
+//   ESTIMATE_LANGS=en,ja         (audio languages passed to estimateUsage)
+//   ESTIMATE_TARGET_LANGS=ja     (translate targets passed to estimateUsage)
+
+import fs from "fs";
+import path from "path";
+import { estimateUsage } from "../../src/utils/estimate_usage.js";
+import { mulmoScriptSchema } from "../../src/types/schema.js";
+import type { UsageRecord, UsageEstimate } from "../../src/types/usage.js";
+
+type MetricTotals = { inputChars: number; inputTokens: number; outputTokens: number; predictSec: number; records: number };
+
+const emptyTotals = (): MetricTotals => ({ inputChars: 0, inputTokens: 0, outputTokens: 0, predictSec: 0, records: 0 });
+
+const addEstimate = (totals: MetricTotals, record: UsageEstimate) => {
+  totals.inputChars += record.inputChars?.value ?? 0;
+  totals.inputTokens += record.inputTokens?.value ?? 0;
+  totals.outputTokens += record.outputTokens?.value ?? 0;
+  totals.predictSec += record.predictSec?.value ?? 0;
+  totals.records += 1;
+};
+
+const addActual = (totals: MetricTotals, record: UsageRecord) => {
+  totals.inputChars += record.inputChars ?? 0;
+  totals.inputTokens += record.inputTokens ?? 0;
+  totals.outputTokens += record.outputTokens ?? 0;
+  totals.predictSec += record.predictSec ?? 0;
+  totals.records += 1;
+};
+
+const groupTotals = <T>(records: T[], key: (r: T) => string, add: (totals: MetricTotals, record: T) => void): Map<string, MetricTotals> => {
+  const groups = new Map<string, MetricTotals>();
+  records.forEach((record) => {
+    const totals = groups.get(key(record)) ?? emptyTotals();
+    add(totals, record);
+    groups.set(key(record), totals);
+  });
+  return groups;
+};
+
+const deltaLabel = (estimateValue: number, actualValue: number): string => {
+  if (estimateValue === 0 && actualValue === 0) {
+    return "-";
+  }
+  if (actualValue === 0) {
+    return "n/a";
+  }
+  const deltaPercent = ((estimateValue - actualValue) / actualValue) * 100;
+  return `${deltaPercent >= 0 ? "+" : ""}${deltaPercent.toFixed(1)}%`;
+};
+
+const main = () => {
+  const [scriptArg, dumpArg] = process.argv.slice(2);
+  if (!scriptArg || !dumpArg) {
+    console.error("Usage: npx tsx scripts/probe/probe_estimate_vs_actual.ts <script.json> <usage_dump.json>");
+    process.exit(1);
+  }
+  const script = mulmoScriptSchema.parse(JSON.parse(fs.readFileSync(path.resolve(scriptArg), "utf8")));
+  const dump = JSON.parse(fs.readFileSync(path.resolve(dumpArg), "utf8")) as { snapshot: UsageRecord[] };
+
+  const langs = process.env.ESTIMATE_LANGS?.split(",");
+  const targetLangs = process.env.ESTIMATE_TARGET_LANGS?.split(",");
+  const estimates = estimateUsage(script, { langs, targetLangs });
+
+  // The API reports dated snapshot names (gpt-4o-2024-08-06) while the estimator uses
+  // the requested alias (gpt-4o) — strip the date suffix so the groups join.
+  const normalizeModel = (model: string) => model.replace(/-\d{4}-\d{2}-\d{2}$/, "");
+  const estimateGroups = groupTotals(estimates, (r) => `${r.provider}:${normalizeModel(r.model)}`, addEstimate);
+  const actualGroups = groupTotals(dump.snapshot, (r) => `${r.provider}:${normalizeModel(r.model)}`, addActual);
+
+  // Only compare provider:model groups the run actually exercised — a dump from
+  // a single action (e.g. audio) doesn't cover the estimator's other processes.
+  const keys = [...actualGroups.keys()].sort();
+  const metrics: (keyof Omit<MetricTotals, "records">)[] = ["inputChars", "inputTokens", "outputTokens", "predictSec"];
+  console.log("| provider:model | metric | estimated | actual | delta |");
+  console.log("|---|---|---|---|---|");
+  keys.forEach((key) => {
+    const estimate = estimateGroups.get(key) ?? emptyTotals();
+    const actual = actualGroups.get(key) ?? emptyTotals();
+    metrics.forEach((metricName) => {
+      if (estimate[metricName] === 0 && actual[metricName] === 0) {
+        return;
+      }
+      console.log(`| ${key} | ${metricName} | ${estimate[metricName]} | ${actual[metricName]} | ${deltaLabel(estimate[metricName], actual[metricName])} |`);
+    });
+  });
+};
+
+main();

--- a/src/index.common.ts
+++ b/src/index.common.ts
@@ -7,6 +7,7 @@ export * from "./utils/string.js";
 export * from "./utils/utils.js";
 export * from "./utils/prompt.js";
 export * from "./utils/error_cause.js";
+export * from "./utils/estimate_usage.js";
 
 export * from "./methods/mulmo_presentation_style.js";
 export * from "./methods/mulmo_script.js";

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -107,18 +107,21 @@ export const MulmoPresentationStyleMethods = {
     }
     return keys[0];
   },
-  getSpeaker(context: MulmoStudioContext, beat: MulmoBeat, targetLang: string | undefined): SpeakerData {
-    userAssert(!!context.presentationStyle?.speechParams?.speakers, "presentationStyle.speechParams.speakers is not set!!");
-    const speakerId = beat?.speaker ?? MulmoPresentationStyleMethods.getDefaultSpeaker(context.presentationStyle);
-    const speaker = context.presentationStyle.speechParams.speakers[speakerId];
+  getSpeakerData(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat, lang: string | undefined): SpeakerData {
+    userAssert(!!presentationStyle?.speechParams?.speakers, "presentationStyle.speechParams.speakers is not set!!");
+    const speakerId = beat?.speaker ?? MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
+    const speaker = presentationStyle.speechParams.speakers[speakerId];
     userAssert(!!speaker, `speaker is not set: speaker "${speakerId}"`);
     // Check if the speaker has a language-specific version.
-    // Normally, lang is determined by the context, but lang may be specified when using the API.
-    const lang = targetLang ?? context.lang ?? context?.studio?.script?.lang;
     if (speaker.lang && lang && speaker.lang[lang]) {
       return speaker.lang[lang];
     }
     return speaker;
+  },
+  getSpeaker(context: MulmoStudioContext, beat: MulmoBeat, targetLang: string | undefined): SpeakerData {
+    // Normally, lang is determined by the context, but lang may be specified when using the API.
+    const lang = targetLang ?? context.lang ?? context?.studio?.script?.lang;
+    return MulmoPresentationStyleMethods.getSpeakerData(context.presentationStyle, beat, lang);
   },
   getMovieTransition(context: MulmoStudioContext, beat: MulmoBeat): MulmoTransition | null {
     const transitionData = beat.movieParams?.transition ?? context.presentationStyle.movieParams?.transition;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./type.js";
 export * from "./schema.js";
 export * from "./viewer.js";
 export * from "./usage.js";
+export * from "./provider2agent.js";

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -474,7 +474,10 @@ export const provider2LipSyncAgent = {
         audio: "audio_file",
       },
       */
-    } as Record<ReplicateModel, { identifier?: `${string}/${string}:${string}` | `${string}/${string}`; video?: string; audio: string; image?: string }>,
+    } as Record<
+      ReplicateModel,
+      { identifier?: `${string}/${string}:${string}` | `${string}/${string}`; video?: string; audio: string; image?: string; price_per_sec?: number }
+    >,
   },
 };
 
@@ -565,4 +568,107 @@ export const getModelDuration = (provider: keyof typeof provider2MovieAgent, mod
     return largerDurations.length > 0 ? largerDurations[0] : durations[durations.length - 1];
   }
   return durations?.[0];
+};
+
+// ---- Pricing metadata (for pre-run usage estimation and cost reporting) ----
+// Prices drift over time; every entry records the date it was last verified
+// against the provider's official pricing page (asOf, YYYY-MM-DD).
+
+export type ModelPricing = {
+  unit: "tokens" | "chars" | "seconds" | "images";
+  inputPerMTokensUSD?: number;
+  outputPerMTokensUSD?: number;
+  perMCharsUSD?: number;
+  perSecUSD?: number;
+  perImageUSD?: number;
+  asOf: string;
+};
+
+// gpt-image-1 / gpt-image-1-mini emit a fixed number of image output tokens per size × quality.
+// Later gpt-image models (1.5 / 2) use variable resolutions, so this table is only an approximation for them.
+// Source: https://developers.openai.com/api/docs/guides/image-generation (verified 2026-07-03)
+export const gptImageOutputTokens: Record<string, { low: number; medium: number; high: number }> = {
+  "1024x1024": { low: 272, medium: 1056, high: 4160 },
+  "1024x1536": { low: 408, medium: 1584, high: 6240 },
+  "1536x1024": { low: 400, medium: 1568, high: 6208 },
+};
+
+// Spot-checked against replicate.com model pages on this date (seedance-1-lite, kling-v2.1, omni-human).
+// Some replicate prices vary by resolution/variant; price_per_sec holds the rate for the typical configuration
+// (e.g. seedance-1-lite at 720p, kling-v2.1 standard).
+const REPLICATE_PRICING_AS_OF = "2026-07-03";
+
+const replicateMoviePricing: Record<string, ModelPricing> = Object.fromEntries(
+  Object.entries(provider2MovieAgent.replicate.modelParams).map(([model, params]) => [
+    model,
+    { unit: "seconds", perSecUSD: params.price_per_sec, asOf: REPLICATE_PRICING_AS_OF },
+  ]),
+);
+
+const replicateLipSyncPricing: Record<string, ModelPricing> = Object.fromEntries(
+  Object.entries(provider2LipSyncAgent.replicate.modelParams)
+    .filter(([, params]) => params.price_per_sec !== undefined)
+    .map(([model, params]) => [model, { unit: "seconds", perSecUSD: params.price_per_sec, asOf: REPLICATE_PRICING_AS_OF }]),
+);
+
+export const modelPricing: Record<string, Record<string, ModelPricing>> = {
+  openai: {
+    // https://developers.openai.com/api/docs/models/gpt-4o-mini-tts
+    "gpt-4o-mini-tts": { unit: "tokens", inputPerMTokensUSD: 0.6, outputPerMTokensUSD: 12, asOf: "2026-07-03" },
+    "tts-1": { unit: "chars", perMCharsUSD: 15, asOf: "2026-07-03" },
+    "tts-1-hd": { unit: "chars", perMCharsUSD: 30, asOf: "2026-07-03" },
+    // https://developers.openai.com/api/docs/models/gpt-image-1 (image input tokens, $10/1M, are not modeled)
+    "gpt-image-1": { unit: "tokens", inputPerMTokensUSD: 5, outputPerMTokensUSD: 40, asOf: "2026-07-03" },
+    "gpt-image-1.5": { unit: "tokens", inputPerMTokensUSD: 5, outputPerMTokensUSD: 32, asOf: "2026-07-03" },
+    "gpt-image-2": { unit: "tokens", inputPerMTokensUSD: 5, outputPerMTokensUSD: 30, asOf: "2026-07-03" },
+    "gpt-image-1-mini": { unit: "tokens", inputPerMTokensUSD: 2, outputPerMTokensUSD: 8, asOf: "2026-07-03" },
+    // https://developers.openai.com/api/docs/models/gpt-5 etc.
+    "gpt-5": { unit: "tokens", inputPerMTokensUSD: 1.25, outputPerMTokensUSD: 10, asOf: "2026-07-03" },
+    "gpt-5-mini": { unit: "tokens", inputPerMTokensUSD: 0.25, outputPerMTokensUSD: 2, asOf: "2026-07-03" },
+    "gpt-4o": { unit: "tokens", inputPerMTokensUSD: 2.5, outputPerMTokensUSD: 10, asOf: "2026-07-03" },
+  },
+  gemini: {
+    // https://ai.google.dev/gemini-api/docs/pricing
+    "gemini-2.5-flash-preview-tts": { unit: "tokens", inputPerMTokensUSD: 0.5, outputPerMTokensUSD: 10, asOf: "2026-07-03" },
+    "gemini-2.5-pro-preview-tts": { unit: "tokens", inputPerMTokensUSD: 1, outputPerMTokensUSD: 20, asOf: "2026-07-03" },
+  },
+  google: {
+    // https://ai.google.dev/gemini-api/docs/pricing ($0.039/image ≒ 1290 output tokens at $30/1M)
+    "gemini-2.5-flash-image": { unit: "images", inputPerMTokensUSD: 0.3, perImageUSD: 0.039, asOf: "2026-07-03" },
+    // Veo per second of generated video (720p). veo-2.0-generate-001 was shut down on 2026-06-30 (no price).
+    "veo-3.0-generate-001": { unit: "seconds", perSecUSD: 0.4, asOf: "2026-07-03" },
+    "veo-3.1-generate-preview": { unit: "seconds", perSecUSD: 0.4, asOf: "2026-07-03" },
+    "veo-3.1-lite-generate-preview": { unit: "seconds", perSecUSD: 0.05, asOf: "2026-07-03" },
+    // Google Cloud Text-to-Speech per 1M characters, keyed by voice tier.
+    // https://cloud.google.com/text-to-speech/pricing
+    "tts-standard": { unit: "chars", perMCharsUSD: 4, asOf: "2026-07-03" },
+    "tts-wavenet": { unit: "chars", perMCharsUSD: 4, asOf: "2026-07-03" },
+    "tts-neural2": { unit: "chars", perMCharsUSD: 16, asOf: "2026-07-03" },
+    "tts-chirp3-hd": { unit: "chars", perMCharsUSD: 30, asOf: "2026-07-03" },
+    "tts-studio": { unit: "chars", perMCharsUSD: 160, asOf: "2026-07-03" },
+  },
+  anthropic: {
+    // https://platform.claude.com/docs/en/docs/about-claude/pricing
+    "claude-sonnet-4-5-20250929": { unit: "tokens", inputPerMTokensUSD: 3, outputPerMTokensUSD: 15, asOf: "2026-07-03" },
+  },
+  elevenlabs: {
+    // https://elevenlabs.io/pricing/api ($0.10 per 1k chars for multilingual/v3, $0.05 for flash/turbo)
+    eleven_v3: { unit: "chars", perMCharsUSD: 100, asOf: "2026-07-03" },
+    eleven_multilingual_v2: { unit: "chars", perMCharsUSD: 100, asOf: "2026-07-03" },
+    eleven_turbo_v2_5: { unit: "chars", perMCharsUSD: 50, asOf: "2026-07-03" },
+    eleven_turbo_v2: { unit: "chars", perMCharsUSD: 50, asOf: "2026-07-03" },
+    eleven_flash_v2_5: { unit: "chars", perMCharsUSD: 50, asOf: "2026-07-03" },
+    eleven_flash_v2: { unit: "chars", perMCharsUSD: 50, asOf: "2026-07-03" },
+  },
+  replicate: {
+    ...replicateMoviePricing,
+    ...replicateLipSyncPricing,
+    // https://replicate.com/bytedance/seedream-4 ($0.03 per output image)
+    // zsxkib/mmaudio is intentionally unpriced: it bills by GPU time (~$0.005 per run), not by clip duration.
+    "bytedance/seedream-4": { unit: "images", perImageUSD: 0.03, asOf: "2026-07-03" },
+  },
+};
+
+export const getModelPricing = (provider: string, model: string): ModelPricing | undefined => {
+  return modelPricing[provider]?.[model];
 };

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -635,8 +635,8 @@ export const modelPricing: Record<string, Record<string, ModelPricing>> = {
   google: {
     // https://ai.google.dev/gemini-api/docs/pricing ($0.039/image ≒ 1290 output tokens at $30/1M)
     "gemini-2.5-flash-image": { unit: "images", inputPerMTokensUSD: 0.3, perImageUSD: 0.039, asOf: "2026-07-03" },
-    // Veo per second of generated video (720p). veo-2.0-generate-001 was shut down on 2026-06-30 (no price).
-    "veo-3.0-generate-001": { unit: "seconds", perSecUSD: 0.4, asOf: "2026-07-03" },
+    // Veo per second of generated video (720p). veo-2.0-generate-001 and veo-3.0-generate-001
+    // were shut down on 2026-06-30, so they intentionally have no price.
     "veo-3.1-generate-preview": { unit: "seconds", perSecUSD: 0.4, asOf: "2026-07-03" },
     "veo-3.1-lite-generate-preview": { unit: "seconds", perSecUSD: 0.05, asOf: "2026-07-03" },
     // Google Cloud Text-to-Speech per 1M characters, keyed by voice tier.

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -32,3 +32,30 @@ export type UsageCollectorAPI = {
   clear(): void;
   readonly size: number;
 };
+
+// Pre-run estimates. Field names mirror UsageRecord so an estimate can be
+// compared with the actuals collected at runtime.
+export type EstimatePrecision = "exact" | "estimated";
+
+export type EstimatedMetric = {
+  value: number;
+  precision: EstimatePrecision;
+};
+
+export type UsageEstimateProcess = "tts" | "image" | "htmlImage" | "movie" | "soundEffect" | "lipSync" | "translate" | "imageReference" | "movieReference";
+
+export type UsageEstimate = {
+  process: UsageEstimateProcess;
+  beatIndex?: number;
+  refKey?: string;
+  lang?: string;
+  provider: string;
+  model: string;
+  inputTokens?: EstimatedMetric;
+  outputTokens?: EstimatedMetric;
+  inputChars?: EstimatedMetric;
+  predictSec?: EstimatedMetric;
+  imageCount?: EstimatedMetric;
+  costUSD?: number;
+  pricingAsOf?: string;
+};

--- a/src/utils/estimate_usage.ts
+++ b/src/utils/estimate_usage.ts
@@ -28,13 +28,19 @@ const LATIN_CHARS_PER_SEC = 15;
 const OPENAI_TTS_AUDIO_TOKENS_PER_SEC = 50;
 // Documented: Gemini TTS audio tokens = 25 per second of audio.
 const GEMINI_TTS_AUDIO_TOKENS_PER_SEC = 25;
-// A typical generated Tailwind slide is 4-8 KB of HTML.
-const HTML_OUTPUT_TOKENS_GUESS = 2000;
+// gpt-5 completion_tokens include reasoning tokens; a simple slide measured ≈4.4k (probe 2026-07-03).
+const HTML_OUTPUT_TOKENS_GUESS = 4000;
 const TRANSLATE_OUTPUT_FACTOR = 1.2;
 // The translate action doesn't set a model, so @graphai/openai_agent's default applies.
 const TRANSLATE_DEFAULT_MODEL = "gpt-4o";
 const DEFAULT_MOVIE_DURATION_SEC = 8;
 const GPT_IMAGE_FIXED_TOKEN_MODELS = ["gpt-image-1", "gpt-image-1-mini"];
+// Fixed request framing the API adds on top of the tokenized prompt text. Both values
+// reproduced the billed prompt_tokens exactly, per record, in the 2026-07-03 probes
+// (scripts/probe/probe_estimate_vs_actual.ts): chat completions (system + user) +10,
+// image generation +6.
+const OPENAI_CHAT_INPUT_OVERHEAD_TOKENS = 10;
+const GPT_IMAGE_INPUT_OVERHEAD_TOKENS = 6;
 
 export type EstimateUsageOptions = {
   langs?: string[];
@@ -212,7 +218,11 @@ type ImageRecordInput = {
 const buildImageRecord = ({ process, provider, model, prompt, canvasSize, quality, beatIndex, refKey }: ImageRecordInput): UsageEstimate => {
   const base = { process, beatIndex, refKey, provider, model };
   if (provider === "openai") {
-    return { ...base, inputTokens: exact(countOpenAITokens(prompt)), outputTokens: gptImageOutputMetric(model, canvasSize, quality) };
+    return {
+      ...base,
+      inputTokens: exact(countOpenAITokens(prompt) + GPT_IMAGE_INPUT_OVERHEAD_TOKENS),
+      outputTokens: gptImageOutputMetric(model, canvasSize, quality),
+    };
   }
   if (provider === "google") {
     return { ...base, inputTokens: estimated(countHeuristicTokens(prompt)), imageCount: exact(1) };
@@ -242,7 +252,10 @@ const estimateHtmlImage = (style: MulmoPresentationStyle, beat: MulmoBeat, beatI
     return undefined;
   }
   const fullPrompt = htmlImageSystemPrompt(MulmoPresentationStyleMethods.getCanvasSize(style)) + "\n" + (MulmoBeatMethods.getHtmlPrompt(beat) ?? "");
-  const inputTokens = info.provider === "openai" ? exact(countOpenAITokens(fullPrompt)) : estimated(countHeuristicTokens(fullPrompt));
+  const inputTokens =
+    info.provider === "openai"
+      ? exact(countOpenAITokens(fullPrompt) + OPENAI_CHAT_INPUT_OVERHEAD_TOKENS)
+      : estimated(countHeuristicTokens(fullPrompt) + OPENAI_CHAT_INPUT_OVERHEAD_TOKENS);
   return attachCost({
     process: "htmlImage",
     beatIndex,
@@ -364,7 +377,7 @@ const buildTranslateRecord = (defaultLang: string, text: string, targetLang: str
     lang: targetLang,
     provider: "openai",
     model: TRANSLATE_DEFAULT_MODEL,
-    inputTokens: exact(countOpenAITokens(input)),
+    inputTokens: exact(countOpenAITokens(input) + OPENAI_CHAT_INPUT_OVERHEAD_TOKENS),
     outputTokens: estimated(Math.ceil(countOpenAITokens(text) * TRANSLATE_OUTPUT_FACTOR)),
   });
 };

--- a/src/utils/estimate_usage.ts
+++ b/src/utils/estimate_usage.ts
@@ -1,0 +1,400 @@
+// Pre-run usage estimator: walks a MulmoScript and returns, per beat and per
+// process, the API usage a full generation run would consume. Pure and
+// browser-compatible (js-tiktoken is pure JS). No cache awareness: estimates
+// assume every asset is generated fresh.
+import { Tiktoken } from "js-tiktoken/lite";
+import o200k_base from "js-tiktoken/ranks/o200k_base";
+import type { MulmoScript, MulmoPresentationStyle, MulmoBeat, MulmoCanvasDimension, MulmoImageParams, SpeakerData, SpeechOptions } from "../types/index.js";
+import type { EstimatedMetric, UsageEstimate } from "../types/usage.js";
+import {
+  provider2TTSAgent,
+  provider2MovieAgent,
+  gptImageOutputTokens,
+  getModelDuration,
+  getModelPricing,
+  defaultProviders,
+  type ModelPricing,
+} from "../types/provider2agent.js";
+import { text2SpeechProviderSchema, text2MovieProviderSchema } from "../types/schema.js";
+import { MulmoPresentationStyleMethods } from "../methods/mulmo_presentation_style.js";
+import { MulmoBeatMethods } from "../methods/mulmo_beat.js";
+import { imagePrompt, htmlImageSystemPrompt, translateSystemPrompt, translatePrompts } from "./prompt.js";
+
+const MILLION = 1_000_000;
+const LATIN_CHARS_PER_TOKEN = 4;
+const CJK_CHARS_PER_SEC = 6;
+const LATIN_CHARS_PER_SEC = 15;
+// Measured ≈50 audio output tokens per second (docs/api.md § Known gaps, probed in PR #1439).
+const OPENAI_TTS_AUDIO_TOKENS_PER_SEC = 50;
+// Documented: Gemini TTS audio tokens = 25 per second of audio.
+const GEMINI_TTS_AUDIO_TOKENS_PER_SEC = 25;
+// A typical generated Tailwind slide is 4-8 KB of HTML.
+const HTML_OUTPUT_TOKENS_GUESS = 2000;
+const TRANSLATE_OUTPUT_FACTOR = 1.2;
+// The translate action doesn't set a model, so @graphai/openai_agent's default applies.
+const TRANSLATE_DEFAULT_MODEL = "gpt-4o";
+const DEFAULT_MOVIE_DURATION_SEC = 8;
+const GPT_IMAGE_FIXED_TOKEN_MODELS = ["gpt-image-1", "gpt-image-1-mini"];
+
+export type EstimateUsageOptions = {
+  langs?: string[];
+  targetLangs?: string[];
+  presentationStyle?: MulmoPresentationStyle;
+};
+
+const isDefined = <T>(value: T | undefined): value is T => value !== undefined;
+const isKeyOf = <T extends object>(obj: T, key: PropertyKey): key is keyof T => key in obj;
+
+let openAITokenizer: Tiktoken | undefined;
+const countOpenAITokens = (text: string): number => {
+  // Lazy: building the o200k_base BPE table is expensive and most importers never estimate.
+  openAITokenizer = openAITokenizer ?? new Tiktoken(o200k_base);
+  return openAITokenizer.encode(text).length;
+};
+
+const cjkPattern = /[⺀-鿿가-힯豈-﫿ｦ-ﾟ]/g;
+const countCjkChars = (text: string): number => (text.match(cjkPattern) ?? []).length;
+
+const countHeuristicTokens = (text: string): number => {
+  const cjkChars = countCjkChars(text);
+  return cjkChars + Math.ceil((text.length - cjkChars) / LATIN_CHARS_PER_TOKEN);
+};
+
+const estimateSpeechSec = (text: string): number => {
+  const cjkChars = countCjkChars(text);
+  const latinChars = text.length - cjkChars;
+  return Math.max(1, Math.round(cjkChars / CJK_CHARS_PER_SEC + latinChars / LATIN_CHARS_PER_SEC));
+};
+
+const exact = (value: number): EstimatedMetric => ({ value, precision: "exact" });
+const estimated = (value: number): EstimatedMetric => ({ value, precision: "estimated" });
+const metric = (value: number, isExact: boolean): EstimatedMetric => ({ value, precision: isExact ? "exact" : "estimated" });
+
+const computeCostUSD = (pricing: ModelPricing, record: UsageEstimate): number | undefined => {
+  const tokenValue = (m: EstimatedMetric | undefined, rate: number | undefined) => (m && rate ? (m.value * rate) / MILLION : 0);
+  const total =
+    tokenValue(record.inputTokens, pricing.inputPerMTokensUSD) +
+    tokenValue(record.outputTokens, pricing.outputPerMTokensUSD) +
+    tokenValue(record.inputChars, pricing.perMCharsUSD) +
+    (record.predictSec && pricing.perSecUSD ? record.predictSec.value * pricing.perSecUSD : 0) +
+    (record.imageCount && pricing.perImageUSD ? record.imageCount.value * pricing.perImageUSD : 0);
+  return total > 0 ? total : undefined;
+};
+
+const attachCost = (record: UsageEstimate, pricingKey?: string): UsageEstimate => {
+  const pricing = getModelPricing(record.provider, pricingKey ?? record.model);
+  if (!pricing) {
+    return record;
+  }
+  const costUSD = computeCostUSD(pricing, record);
+  return costUSD !== undefined ? { ...record, costUSD, pricingAsOf: pricing.asOf } : record;
+};
+
+// ---- TTS ----
+
+type TtsBuilderInput = {
+  speaker: SpeakerData;
+  speechOptions?: SpeechOptions;
+  text: string;
+  textIsFinal: boolean;
+  beatIndex: number;
+  lang: string;
+};
+
+const buildOpenAITts = ({ speaker, text, textIsFinal, beatIndex, lang }: TtsBuilderInput): UsageEstimate => {
+  const model = speaker.model ?? provider2TTSAgent.openai.defaultModel;
+  // gpt-* TTS models are token-billed; legacy tts-1 models are character-billed.
+  const tokenMetrics = model.startsWith("gpt-")
+    ? {
+        inputTokens: metric(countOpenAITokens(text), textIsFinal),
+        outputTokens: estimated(estimateSpeechSec(text) * OPENAI_TTS_AUDIO_TOKENS_PER_SEC),
+      }
+    : {};
+  return { process: "tts", beatIndex, lang, provider: "openai", model, inputChars: metric(text.length, textIsFinal), ...tokenMetrics };
+};
+
+const buildGeminiTts = ({ speaker, speechOptions, text, beatIndex, lang }: TtsBuilderInput): UsageEstimate => {
+  // The gemini TTS agent wraps the transcript in a "Director's Notes" prompt when an instruction is set.
+  const prompt = speechOptions?.instruction ? `### DIRECTOR'S NOTES\n${speechOptions.instruction}\n\n#### TRANSCRIPT\n${text}` : text;
+  return {
+    process: "tts",
+    beatIndex,
+    lang,
+    provider: "gemini",
+    model: speaker.model ?? provider2TTSAgent.gemini.defaultModel,
+    inputTokens: estimated(countHeuristicTokens(prompt)),
+    outputTokens: estimated(estimateSpeechSec(text) * GEMINI_TTS_AUDIO_TOKENS_PER_SEC),
+  };
+};
+
+const buildGoogleTts = ({ speaker, text, textIsFinal, beatIndex, lang }: TtsBuilderInput): UsageEstimate => {
+  // Mirrors the runtime usage record: model falls back to the voice name; billing is per character.
+  const model = speaker.model ?? speaker.voiceId;
+  return { process: "tts", beatIndex, lang, provider: "google", model, inputChars: metric(text.length, textIsFinal) };
+};
+
+const buildElevenLabsTts = ({ speaker, text, textIsFinal, beatIndex, lang }: TtsBuilderInput): UsageEstimate => {
+  const model = speaker.model ?? provider2TTSAgent.elevenlabs.defaultModel;
+  return { process: "tts", beatIndex, lang, provider: "elevenlabs", model, inputChars: metric(text.length, textIsFinal) };
+};
+
+const buildKotodamaTts = ({ speaker, text, textIsFinal, beatIndex, lang }: TtsBuilderInput): UsageEstimate => {
+  // Mirrors the runtime usage record: the kotodama agent reports the speaker id as the model.
+  return { process: "tts", beatIndex, lang, provider: "kotodama", model: speaker.voiceId, inputChars: metric(text.length, textIsFinal) };
+};
+
+const ttsRecordBuilders: Record<string, (input: TtsBuilderInput) => UsageEstimate> = {
+  openai: buildOpenAITts,
+  gemini: buildGeminiTts,
+  google: buildGoogleTts,
+  elevenlabs: buildElevenLabsTts,
+  kotodama: buildKotodamaTts,
+};
+
+const googleTtsPricingKey = (voiceId: string): string | undefined => {
+  const tiers: Record<string, string> = {
+    neural2: "tts-neural2",
+    wavenet: "tts-wavenet",
+    studio: "tts-studio",
+    chirp: "tts-chirp3-hd",
+    standard: "tts-standard",
+  };
+  const lower = voiceId.toLowerCase();
+  const tier = Object.keys(tiers).find((key) => lower.includes(key));
+  return tier ? tiers[tier] : undefined;
+};
+
+const estimateBeatTts = (script: MulmoScript, style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number, lang: string): UsageEstimate | undefined => {
+  if (beat.audio || !beat.text || script.audioParams?.suppressSpeech || !style.speechParams?.speakers) {
+    return undefined;
+  }
+  const speaker = MulmoPresentationStyleMethods.getSpeakerData(style, beat, lang);
+  const provider = text2SpeechProviderSchema.parse(speaker.provider);
+  const builder = ttsRecordBuilders[provider];
+  if (!builder) {
+    return undefined; // mock
+  }
+  // For non-default languages the TTS input is a translation that doesn't exist yet.
+  const textIsFinal = lang === (script.lang ?? "en");
+  const speechOptions = { ...speaker.speechOptions, ...beat.speechOptions };
+  const record = builder({ speaker, speechOptions, text: beat.text, textIsFinal, beatIndex, lang });
+  return attachCost(record, provider === "google" ? googleTtsPricingKey(speaker.voiceId) : undefined);
+};
+
+// ---- Images / movies / sound effects / lip sync ----
+
+const gptImageSize = (canvasSize: MulmoCanvasDimension): string => {
+  if (canvasSize.width > canvasSize.height) {
+    return "1536x1024";
+  }
+  return canvasSize.width < canvasSize.height ? "1024x1536" : "1024x1024";
+};
+
+const gptImageOutputMetric = (model: string, canvasSize: MulmoCanvasDimension, quality?: string): EstimatedMetric => {
+  const table = gptImageOutputTokens[gptImageSize(canvasSize)];
+  const knownQuality = quality === "low" || quality === "medium" || quality === "high" ? quality : undefined;
+  // Unspecified quality means API "auto"; assume "high" as the conservative upper bound.
+  const tokens = table[knownQuality ?? "high"];
+  return metric(tokens, GPT_IMAGE_FIXED_TOKEN_MODELS.includes(model) && knownQuality !== undefined);
+};
+
+type ImageRecordInput = {
+  process: "image" | "imageReference";
+  provider: string;
+  model: string;
+  prompt: string;
+  canvasSize: MulmoCanvasDimension;
+  quality?: string;
+  beatIndex?: number;
+  refKey?: string;
+};
+
+const buildImageRecord = ({ process, provider, model, prompt, canvasSize, quality, beatIndex, refKey }: ImageRecordInput): UsageEstimate => {
+  const base = { process, beatIndex, refKey, provider, model };
+  if (provider === "openai") {
+    return { ...base, inputTokens: exact(countOpenAITokens(prompt)), outputTokens: gptImageOutputMetric(model, canvasSize, quality) };
+  }
+  if (provider === "google") {
+    return { ...base, inputTokens: estimated(countHeuristicTokens(prompt)), imageCount: exact(1) };
+  }
+  return { ...base, imageCount: exact(1) }; // replicate bills per image
+};
+
+const isMovieBeat = (beat: MulmoBeat): boolean => Boolean(beat.moviePrompt || beat.image?.type === "movie");
+
+// Mirrors imagePreprocessAgent: no AI image when a plugin renders the beat or the beat is movie-only.
+const needsImageGeneration = (beat: MulmoBeat): boolean => !beat.image && !(beat.moviePrompt && !beat.imagePrompt);
+
+const estimateImageGeneration = (style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number): UsageEstimate | undefined => {
+  const info = MulmoPresentationStyleMethods.getImageAgentInfo(style, beat);
+  const { provider, model, quality } = info.imageParams;
+  if (!provider || provider === "mock" || !model) {
+    return undefined;
+  }
+  const prompt = imagePrompt(beat, info.imageParams.style);
+  const canvasSize = MulmoPresentationStyleMethods.getCanvasSize(style);
+  return attachCost(buildImageRecord({ process: "image", provider, model, prompt, canvasSize, quality, beatIndex }));
+};
+
+const estimateHtmlImage = (style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number): UsageEstimate | undefined => {
+  const info = MulmoPresentationStyleMethods.getHtmlImageAgentInfo(style);
+  if (info.provider === "mock") {
+    return undefined;
+  }
+  const fullPrompt = htmlImageSystemPrompt(MulmoPresentationStyleMethods.getCanvasSize(style)) + "\n" + (MulmoBeatMethods.getHtmlPrompt(beat) ?? "");
+  const inputTokens = info.provider === "openai" ? exact(countOpenAITokens(fullPrompt)) : estimated(countHeuristicTokens(fullPrompt));
+  return attachCost({
+    process: "htmlImage",
+    beatIndex,
+    provider: info.provider,
+    model: info.model,
+    inputTokens,
+    outputTokens: estimated(HTML_OUTPUT_TOKENS_GUESS),
+  });
+};
+
+const beatDurationMetric = (beat: MulmoBeat): EstimatedMetric => {
+  if (beat.duration !== undefined) {
+    return exact(beat.duration);
+  }
+  return estimated(beat.text ? estimateSpeechSec(beat.text) : DEFAULT_MOVIE_DURATION_SEC);
+};
+
+const snapMovieDuration = (provider: keyof typeof provider2MovieAgent, model: string, duration: EstimatedMetric): EstimatedMetric => {
+  if (!isKeyOf(provider2MovieAgent[provider].modelParams, model)) {
+    return duration;
+  }
+  const snapped = getModelDuration(provider, model, duration.value);
+  return snapped !== undefined ? metric(snapped, duration.precision === "exact") : duration;
+};
+
+const estimateMovieGeneration = (
+  style: MulmoPresentationStyle,
+  beat: MulmoBeat | undefined,
+  beatIndex?: number,
+  refKey?: string,
+): UsageEstimate | undefined => {
+  const info = MulmoPresentationStyleMethods.getMovieAgentInfo(style, beat);
+  const provider = text2MovieProviderSchema.parse(info.movieParams?.provider ?? defaultProviders.text2movie);
+  if (!isKeyOf(provider2MovieAgent, provider) || provider === "mock") {
+    return undefined;
+  }
+  const model = info.movieParams?.model ?? provider2MovieAgent[provider].defaultModel;
+  const duration = beat ? beatDurationMetric(beat) : estimated(DEFAULT_MOVIE_DURATION_SEC);
+  const predictSec = snapMovieDuration(provider, model, duration);
+  return attachCost({ process: refKey === undefined ? "movie" : "movieReference", beatIndex, refKey, provider, model, predictSec });
+};
+
+const estimateSoundEffect = (style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number): UsageEstimate => {
+  const info = MulmoPresentationStyleMethods.getSoundEffectAgentInfo(style, beat);
+  const model = beat.soundEffectParams?.model ?? style.soundEffectParams?.model ?? info.defaultModel;
+  const provider = beat.soundEffectParams?.provider ?? style.soundEffectParams?.provider ?? defaultProviders.soundEffect;
+  // Replicate bills sound effects by GPU prediction time, which differs from clip duration.
+  const predictSec = estimated(beatDurationMetric(beat).value);
+  return attachCost({ process: "soundEffect", beatIndex, provider, model, predictSec });
+};
+
+const estimateLipSync = (style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number): UsageEstimate => {
+  const info = MulmoPresentationStyleMethods.getLipSyncAgentInfo(style, beat);
+  const model = beat.lipSyncParams?.model ?? style.lipSyncParams?.model ?? info.defaultModel;
+  const provider = beat.lipSyncParams?.provider ?? style.lipSyncParams?.provider ?? defaultProviders.lipSync;
+  return attachCost({ process: "lipSync", beatIndex, provider, model, predictSec: beatDurationMetric(beat) });
+};
+
+const estimateBeatVisuals = (style: MulmoPresentationStyle, beat: MulmoBeat, beatIndex: number): UsageEstimate[] => {
+  if (beat.htmlPrompt) {
+    // The image preprocessor returns early for htmlPrompt beats; no other generation runs.
+    return [estimateHtmlImage(style, beat, beatIndex)].filter(isDefined);
+  }
+  return [
+    needsImageGeneration(beat) ? estimateImageGeneration(style, beat, beatIndex) : undefined,
+    beat.moviePrompt ? estimateMovieGeneration(style, beat, beatIndex) : undefined,
+    beat.soundEffectPrompt && isMovieBeat(beat) ? estimateSoundEffect(style, beat, beatIndex) : undefined,
+    beat.enableLipSync ? estimateLipSync(style, beat, beatIndex) : undefined,
+  ].filter(isDefined);
+};
+
+// ---- Reference images / movies (imageParams.images and beat.images) ----
+
+const estimateReferenceImage = (
+  style: MulmoPresentationStyle,
+  prompt: string,
+  canvasSize: MulmoCanvasDimension | undefined,
+  refKey: string,
+  beatIndex?: number,
+) => {
+  const info = MulmoPresentationStyleMethods.getImageAgentInfo(style);
+  const { provider, model, quality } = info.imageParams;
+  if (!provider || provider === "mock" || !model) {
+    return undefined;
+  }
+  // Mirrors generateReferenceImage: the style is appended to the reference prompt.
+  const fullPrompt = `${prompt}\n${info.imageParams.style || ""}`;
+  const size = canvasSize ?? MulmoPresentationStyleMethods.getCanvasSize(style);
+  return attachCost(buildImageRecord({ process: "imageReference", provider, model, prompt: fullPrompt, canvasSize: size, quality, refKey, beatIndex }));
+};
+
+const estimateMediaReferences = (style: MulmoPresentationStyle, images: MulmoImageParams["images"], beatIndex?: number): UsageEstimate[] => {
+  return Object.entries(images ?? {})
+    .map(([refKey, media]) => {
+      if (media.type === "imagePrompt") {
+        return estimateReferenceImage(style, media.prompt, media.canvasSize, refKey, beatIndex);
+      }
+      if (media.type === "moviePrompt") {
+        return estimateMovieGeneration(style, undefined, beatIndex, refKey);
+      }
+      return undefined;
+    })
+    .filter(isDefined);
+};
+
+// ---- Translate ----
+
+const buildTranslateInput = (defaultLang: string, text: string, targetLang: string): string => {
+  const substitutions: Record<string, string> = { ":lang": defaultLang, ":beat.text": text, ":targetLang": targetLang };
+  const prompt = translatePrompts.map((line) => substitutions[line] ?? line).join("\n");
+  return translateSystemPrompt + "\n" + prompt;
+};
+
+const buildTranslateRecord = (defaultLang: string, text: string, targetLang: string, beatIndex: number): UsageEstimate => {
+  const input = buildTranslateInput(defaultLang, text, targetLang);
+  return attachCost({
+    process: "translate",
+    beatIndex,
+    lang: targetLang,
+    provider: "openai",
+    model: TRANSLATE_DEFAULT_MODEL,
+    inputTokens: exact(countOpenAITokens(input)),
+    outputTokens: estimated(Math.ceil(countOpenAITokens(text) * TRANSLATE_OUTPUT_FACTOR)),
+  });
+};
+
+const estimateTranslate = (script: MulmoScript, targetLangs: string[]): UsageEstimate[] => {
+  const defaultLang = script.lang ?? "en";
+  return targetLangs
+    .filter((targetLang) => targetLang !== defaultLang)
+    .flatMap((targetLang) =>
+      script.beats.map((beat, beatIndex) => (beat.text ? buildTranslateRecord(defaultLang, beat.text, targetLang, beatIndex) : undefined)).filter(isDefined),
+    );
+};
+
+// ---- Entry point ----
+
+const defaultTargetLangs = (style: MulmoPresentationStyle, langs: string[], defaultLang: string): string[] => {
+  // Mirrors the translate action's default: the requested languages plus the caption language.
+  const candidates = [...langs, style.captionParams?.lang];
+  return [...new Set(candidates.filter((lang): lang is string => !!lang && lang !== defaultLang))];
+};
+
+export const estimateUsage = (script: MulmoScript, options?: EstimateUsageOptions): UsageEstimate[] => {
+  const style = options?.presentationStyle ?? script;
+  const defaultLang = script.lang ?? "en";
+  const langs = options?.langs ?? [defaultLang];
+  const targetLangs = options?.targetLangs ?? defaultTargetLangs(style, langs, defaultLang);
+  const beatRecords = script.beats.flatMap((beat, beatIndex) => [
+    ...langs.map((lang) => estimateBeatTts(script, style, beat, beatIndex, lang)).filter(isDefined),
+    ...estimateBeatVisuals(style, beat, beatIndex),
+    ...estimateMediaReferences(style, beat.images, beatIndex),
+  ]);
+  return [...estimateMediaReferences(style, style.imageParams?.images), ...beatRecords, ...estimateTranslate(script, targetLangs)];
+};

--- a/test/utils/test_estimate_usage.ts
+++ b/test/utils/test_estimate_usage.ts
@@ -1,0 +1,248 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { estimateUsage } from "../../src/utils/estimate_usage.js";
+import { mulmoScriptSchema } from "../../src/types/schema.js";
+import type { UsageEstimate } from "../../src/types/usage.js";
+
+type BeatInput = Record<string, unknown>;
+
+const makeScript = (beats: BeatInput[], extra: Record<string, unknown> = {}) => {
+  return mulmoScriptSchema.parse({
+    $mulmocast: { version: "1.1" },
+    lang: "en",
+    speechParams: { speakers: { Presenter: { voiceId: "shimmer", displayName: { en: "Presenter" } } } },
+    beats,
+    ...extra,
+  });
+};
+
+const byProcess = (records: UsageEstimate[], process: UsageEstimate["process"]) => records.filter((r) => r.process === process);
+
+describe("estimateUsage: tts", () => {
+  it("emits an exact char count and openai token metrics for a text beat", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "Hello world" }]));
+    const tts = byProcess(records, "tts");
+    assert.equal(tts.length, 1);
+    assert.deepEqual(tts[0].inputChars, { value: 11, precision: "exact" });
+    assert.equal(tts[0].model, "gpt-4o-mini-tts");
+    assert.equal(tts[0].inputTokens?.precision, "exact");
+    assert.equal(tts[0].outputTokens?.precision, "estimated");
+    assert.ok(tts[0].costUSD !== undefined);
+  });
+
+  it("skips beats with empty text, pre-supplied audio, or suppressSpeech", () => {
+    const emptyText = estimateUsage(makeScript([{ speaker: "Presenter", text: "" }]));
+    assert.equal(byProcess(emptyText, "tts").length, 0);
+
+    const preSupplied = estimateUsage(makeScript([{ speaker: "Presenter", text: "hi", audio: { type: "audio", source: { kind: "path", path: "a.mp3" } } }]));
+    assert.equal(byProcess(preSupplied, "tts").length, 0);
+
+    const suppressed = estimateUsage(makeScript([{ speaker: "Presenter", text: "hi" }], { audioParams: { suppressSpeech: true } }));
+    assert.equal(byProcess(suppressed, "tts").length, 0);
+  });
+
+  it("marks the char count as estimated for non-default languages (translation does not exist yet)", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "Hello world" }]), { langs: ["ja"] });
+    const tts = byProcess(records, "tts");
+    assert.equal(tts[0].lang, "ja");
+    assert.equal(tts[0].inputChars?.precision, "estimated");
+  });
+
+  it("uses heuristic token estimation for gemini voices", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "こんにちは" }], {
+      speechParams: { speakers: { Presenter: { voiceId: "Kore", provider: "gemini", displayName: { en: "Presenter" } } } },
+    });
+    const tts = byProcess(estimateUsage(script), "tts");
+    assert.equal(tts[0].provider, "gemini");
+    assert.equal(tts[0].inputTokens?.precision, "estimated");
+    assert.deepEqual(tts[0].outputTokens, { value: 25, precision: "estimated" }); // 1 sec of audio at 25 tokens/sec
+  });
+
+  it("prices google voices by voice tier", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "0123456789" }], {
+      speechParams: { speakers: { Presenter: { voiceId: "en-US-Neural2-C", provider: "google", displayName: { en: "Presenter" } } } },
+    });
+    const tts = byProcess(estimateUsage(script), "tts");
+    assert.deepEqual(tts[0].inputChars, { value: 10, precision: "exact" });
+    assert.ok(Math.abs((tts[0].costUSD ?? 0) - (10 * 16) / 1_000_000) < 1e-12);
+  });
+
+  it("emits one record per language when langs is set", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "Hello" }]), { langs: ["en", "ja"], targetLangs: [] });
+    assert.equal(byProcess(records, "tts").length, 2);
+  });
+});
+
+describe("estimateUsage: image generation", () => {
+  it("counts prompt tokens exactly and uses the size/quality output-token table", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", imagePrompt: "a cat", imageParams: { quality: "low" } }]));
+    const images = byProcess(records, "image");
+    assert.equal(images.length, 1);
+    assert.equal(images[0].model, "gpt-image-1");
+    assert.equal(images[0].inputTokens?.precision, "exact");
+    // default canvas 1280x720 is landscape → 1536x1024; low quality → 400 tokens (fixed table)
+    assert.deepEqual(images[0].outputTokens, { value: 400, precision: "exact" });
+  });
+
+  it("falls back to high quality as an estimate when quality is unspecified", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", imagePrompt: "a cat" }]));
+    assert.deepEqual(byProcess(records, "image")[0].outputTokens, { value: 6208, precision: "estimated" });
+  });
+
+  it("generates an image from text when no imagePrompt is present", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "Just narration" }]));
+    assert.equal(byProcess(records, "image").length, 1);
+  });
+
+  it("emits no image record for plugin beats or movie-only beats", () => {
+    const plugin = estimateUsage(makeScript([{ speaker: "Presenter", text: "", image: { type: "textSlide", slide: { title: "T" } } }]));
+    assert.equal(byProcess(plugin, "image").length, 0);
+
+    const movieOnly = estimateUsage(makeScript([{ speaker: "Presenter", text: "", moviePrompt: "a wave" }]));
+    assert.equal(byProcess(movieOnly, "image").length, 0);
+    assert.equal(byProcess(movieOnly, "movie").length, 1);
+  });
+
+  it("reports per-image billing for replicate", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", imagePrompt: "a cat" }], { imageParams: { provider: "replicate" } }));
+    const image = byProcess(records, "image")[0];
+    assert.equal(image.model, "bytedance/seedream-4");
+    assert.deepEqual(image.imageCount, { value: 1, precision: "exact" });
+  });
+});
+
+describe("estimateUsage: htmlPrompt beats", () => {
+  it("emits a single htmlImage record and nothing else for the beat", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", htmlPrompt: { prompt: "sales chart", data: { a: 1 } } }]));
+    assert.equal(records.length, 1);
+    assert.equal(records[0].process, "htmlImage");
+    assert.equal(records[0].model, "gpt-5");
+    assert.equal(records[0].inputTokens?.precision, "exact");
+    assert.equal(records[0].outputTokens?.precision, "estimated");
+  });
+});
+
+describe("estimateUsage: movie / soundEffect / lipSync", () => {
+  it("snaps an explicit beat duration to the model's supported durations as exact", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", moviePrompt: "wave", duration: 7 }]));
+    const movie = byProcess(records, "movie")[0];
+    assert.equal(movie.model, "bytedance/seedance-1-lite");
+    assert.deepEqual(movie.predictSec, { value: 10, precision: "exact" }); // supported durations are [5, 10]
+    assert.ok(Math.abs((movie.costUSD ?? 0) - 10 * 0.036) < 1e-12);
+  });
+
+  it("estimates the duration from the narration text when no duration is set", () => {
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "こんにちは。これはテストです。", moviePrompt: "city" }]));
+    assert.deepEqual(byProcess(records, "movie")[0].predictSec, { value: 5, precision: "estimated" });
+  });
+
+  it("emits soundEffect only for movie beats, and lipSync when enabled", () => {
+    const noMovie = estimateUsage(makeScript([{ speaker: "Presenter", text: "", imagePrompt: "cat", soundEffectPrompt: "meow" }]));
+    assert.equal(byProcess(noMovie, "soundEffect").length, 0);
+
+    const records = estimateUsage(
+      makeScript([{ speaker: "Presenter", text: "", moviePrompt: "cat", duration: 5, soundEffectPrompt: "meow", enableLipSync: true }]),
+    );
+    assert.deepEqual(byProcess(records, "soundEffect")[0].predictSec, { value: 5, precision: "estimated" }); // GPU time differs from clip length
+    const lipSync = byProcess(records, "lipSync")[0];
+    assert.equal(lipSync.model, "bytedance/omni-human");
+    assert.deepEqual(lipSync.predictSec, { value: 5, precision: "exact" });
+    assert.ok(Math.abs((lipSync.costUSD ?? 0) - 5 * 0.14) < 1e-12);
+  });
+});
+
+describe("estimateUsage: reference images", () => {
+  it("counts imagePrompt / moviePrompt entries in imageParams.images and beat.images", () => {
+    const script = makeScript(
+      [
+        {
+          speaker: "Presenter",
+          text: "",
+          image: { type: "textSlide", slide: { title: "T" } },
+          images: { local: { type: "imagePrompt", prompt: "a local ref" } },
+        },
+      ],
+      {
+        imageParams: {
+          images: {
+            hero: { type: "imagePrompt", prompt: "a hero" },
+            intro: { type: "moviePrompt", prompt: "an intro" },
+            fixed: { type: "image", source: { kind: "url", url: "https://example.com/a.png" } },
+          },
+        },
+      },
+    );
+    const records = estimateUsage(script);
+    const imageRefs = byProcess(records, "imageReference");
+    assert.deepEqual(imageRefs.map((r) => r.refKey).sort(), ["hero", "local"]);
+    assert.equal(imageRefs.find((r) => r.refKey === "local")?.beatIndex, 0);
+    const movieRefs = byProcess(records, "movieReference");
+    assert.deepEqual(
+      movieRefs.map((r) => r.refKey),
+      ["intro"],
+    );
+    assert.equal(movieRefs[0].predictSec?.precision, "estimated");
+  });
+});
+
+describe("estimateUsage: translate", () => {
+  it("derives target languages from captionParams and skips the script language and empty beats", () => {
+    const script = makeScript(
+      [
+        { speaker: "Presenter", text: "Hello" },
+        { speaker: "Presenter", text: "" },
+      ],
+      { captionParams: { lang: "ja" } },
+    );
+    const translate = byProcess(estimateUsage(script), "translate");
+    assert.equal(translate.length, 1);
+    assert.equal(translate[0].lang, "ja");
+    assert.equal(translate[0].model, "gpt-4o");
+    assert.equal(translate[0].inputTokens?.precision, "exact");
+    assert.equal(translate[0].outputTokens?.precision, "estimated");
+  });
+
+  it("emits no translate records when the only target equals the script language", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "Hello" }], { captionParams: { lang: "en" } });
+    assert.equal(byProcess(estimateUsage(script), "translate").length, 0);
+  });
+
+  it("multiplies across beats and target languages", () => {
+    const script = makeScript([
+      { speaker: "Presenter", text: "One" },
+      { speaker: "Presenter", text: "Two" },
+    ]);
+    const translate = byProcess(estimateUsage(script, { targetLangs: ["ja", "fr"] }), "translate");
+    assert.equal(translate.length, 4);
+  });
+});
+
+describe("estimateUsage: pricing edges", () => {
+  it("omits costUSD when no pricing data exists for the model", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "Hello" }], {
+      speechParams: { speakers: { Presenter: { voiceId: "Atla", provider: "kotodama", displayName: { en: "Presenter" } } } },
+    });
+    const tts = byProcess(estimateUsage(script), "tts")[0];
+    assert.equal(tts.costUSD, undefined);
+    assert.equal(tts.pricingAsOf, undefined);
+  });
+
+  it("prices elevenlabs by characters", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "0123456789" }], {
+      speechParams: { speakers: { Presenter: { voiceId: "v1", provider: "elevenlabs", displayName: { en: "Presenter" } } } },
+    });
+    const tts = byProcess(estimateUsage(script), "tts")[0];
+    assert.equal(tts.model, "eleven_multilingual_v2");
+    assert.ok(Math.abs((tts.costUSD ?? 0) - (10 * 100) / 1_000_000) < 1e-12);
+  });
+
+  it("emits no records for mock providers", () => {
+    const script = makeScript([{ speaker: "Presenter", text: "Hello", imagePrompt: "cat" }], {
+      imageParams: { provider: "mock" },
+      speechParams: { speakers: { Presenter: { voiceId: "v", provider: "mock", displayName: { en: "Presenter" } } } },
+    });
+    const records = estimateUsage(script, { targetLangs: [] });
+    assert.equal(byProcess(records, "tts").length, 0);
+    assert.equal(byProcess(records, "image").length, 0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -639,14 +639,6 @@
   resolved "https://npm.flatt.tech/@protobufjs/utf8/-/utf8-1.1.1.tgz#eaee5900122c110a3dbcb728c0597014a2621774"
   integrity sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==
 
-"@puppeteer/browsers@3.0.5":
-  version "3.0.5"
-  resolved "https://npm.flatt.tech/@puppeteer/browsers/-/browsers-3.0.5.tgz#0c546a545bd4be7f39e89862200b5e93a1776d72"
-  integrity sha512-xYXNuEQmHNIPWWcbL/skf2KF7seyp7c1xmKFRk3wmdFx7VwBsKVrtOLKs8ecaezsKPsWeF1YsgwIiElAscaryA==
-  dependencies:
-    modern-tar "^0.7.6"
-    yargs "^18.0.0"
-
 "@puppeteer/browsers@3.0.6":
   version "3.0.6"
   resolved "https://npm.flatt.tech/@puppeteer/browsers/-/browsers-3.0.6.tgz#6b772e0fc11deb255c8a3c14219e34a16a2ab23d"
@@ -2906,6 +2898,13 @@ js-tiktoken@^1.0.14:
   dependencies:
     base64-js "^1.5.1"
 
+js-tiktoken@^1.0.21:
+  version "1.0.21"
+  resolved "https://npm.flatt.tech/js-tiktoken/-/js-tiktoken-1.0.21.tgz#368a9957591a30a62997dd0c4cf30866f00f8221"
+  integrity sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==
+  dependencies:
+    base64-js "^1.5.1"
+
 jsdom@^29.1.1:
   version "29.1.1"
   resolved "https://npm.flatt.tech/jsdom/-/jsdom-29.1.1.tgz#5b9704906f3cd510c34aa941ae2f8f7f8179df01"
@@ -3621,18 +3620,6 @@ punycode@^2.1.0, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://npm.flatt.tech/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
-
-puppeteer-core@25.2.1:
-  version "25.2.1"
-  resolved "https://npm.flatt.tech/puppeteer-core/-/puppeteer-core-25.2.1.tgz#ebc7ea02cf742f1714652b4d34d5e267f3da1c54"
-  integrity sha512-MwEZ4FFGJ1ZLOmu/04eISxoEMKtCnHyJBRFfgpwPPSYNG6gT6Xw1laNziFSV7uwDcx3jK+ATYIo9SfOd8Uhc3w==
-  dependencies:
-    "@puppeteer/browsers" "3.0.5"
-    chromium-bidi "16.0.1"
-    devtools-protocol "0.0.1638949"
-    typed-query-selector "^2.12.2"
-    webdriver-bidi-protocol "0.4.2"
-    ws "^8.21.0"
 
 puppeteer-core@25.3.0:
   version "25.3.0"


### PR DESCRIPTION
## Summary

Adds `estimateUsage(script, options?)` — a pure, browser-compatible function that walks a MulmoScript **before running anything** and returns per-beat, per-process usage estimates (`UsageEstimate[]`): tokens / characters / billed seconds, each flagged `exact` or `estimated`, plus `costUSD` when pricing is known. Pricing lives as data in `src/types/provider2agent.ts` (`modelPricing`), where every price records the date it was verified (`asOf`) — adding a model is a data change, not a code change.

Closes #1465. Plan: `docs/plans/feat-estimate-usage.md`.

## Items to Confirm / Review

- **Heuristic constants** (`src/utils/estimate_usage.ts`): OpenAI TTS audio output ≈ **50 tokens/sec** (adopted from this repo's own probe research documented in docs/api.md § Known gaps / PR #1439); speech rate CJK 6 chars/sec, Latin 15 chars/sec; HTML output guess 2000 tokens; translate output factor 1.2. These drive `estimated` values — sanity-check the choices.
- **Pricing values** (`modelPricing`): all verified against official pricing pages on 2026-07-03 (OpenAI model pages, ai.google.dev, cloud.google.com/text-to-speech, elevenlabs.io/pricing/api, platform.claude.com, replicate.com model pages). Existing replicate `price_per_sec` values were spot-checked (seedance-1-lite = 720p rate, kling-v2.1 = standard variant, omni-human ✓) and are *generated* into `modelPricing`, keeping one source of truth.
- **`zsxkib/mmaudio` intentionally has no price**: it bills by GPU time (~$0.005/run), not clip duration; an honest `costUSD: undefined` was chosen over a wrong number.
- **gpt-image quality unset → assumes "high"** (API "auto"), flagged `estimated` — conservative upper bound.
- **Translate model hardcoded as `gpt-4o`**: the translate action sets no model, so `@graphai/openai_agent`'s default applies; the estimator mirrors that. Will drift if the graphai default changes.
- **`getSpeaker` refactor** (`mulmo_presentation_style.ts`): extracted `getSpeakerData(presentationStyle, beat, lang)`; `getSpeaker(context, …)` now delegates. Behavior should be unchanged — please double-check.
- **`src/types/` changed** → `@mulmocast/types` needs a release when this ships.
- **Browser bundle**: exported from `index.common.ts`; importing it pulls the ~2 MB o200k_base rank table (tokenizer is lazily constructed, so runtime cost is only paid on first use).

## User Prompt

- mulmoscriptから、利用される想定のtokenを求める関数を作りたい。できそう？
- 推定含めてできるだけ網羅。結果には、推定と実測に近いものをフラグで分ける（データとして返す。beatごとに、処理ごとに出す）。tiktokenを入れてできるだけ正しい値にできる部分は正しく（nodeで）、できない部分はヒューリスティックで。
- モデルが増えても対応しやすいように。`src/types/provider2agent.ts` にデータを入れる。課金情報もそこに入れて後で使えると良い。それは定期的に更新が必要なので、更新日も入れたほうが良い。
- （置き場所の議論）`index.node.ts` になっているけどブラウザでは動かせない？精度が落ちるならnodeでも良い。→ 精度は同一と確認の上、両対応（`index.common.ts`）を選択。

## Implementation

**Coverage** — one record per beat per process, mirroring each action's real gating logic:

| process | gate | exact | estimated |
|---|---|---|---|
| `tts` | text set, no `beat.audio`, no `suppressSpeech` | char counts (openai/google/elevenlabs/kotodama), o200k tokens for gpt-4o-mini-tts | gemini tokens (incl. Director's-Notes wrapper), audio output tokens, non-default-language text |
| `image` | mirror of `imagePreprocessAgent` (no plugin, not movie-only) | prompt tokens (tiktoken), gpt-image-1/-mini output-token table (`gptImageOutputTokens`) | google token heuristic; quality-unset table lookup |
| `htmlImage` | `beat.htmlPrompt` (early-return semantics preserved) | input tokens (system + user prompt, openai) | output tokens |
| `movie` | `beat.moviePrompt` | explicit `beat.duration` snapped via `getModelDuration` | duration derived from narration text |
| `soundEffect` / `lipSync` | same gates as the images action | lipSync with explicit duration | GPU-time-billed soundEffect |
| `translate` | per beat × targetLang, skips script language / empty text | input tokens (exact prompt template reconstruction) | output ≈ text tokens × 1.2 |
| `imageReference` / `movieReference` | `imageParams.images` + `beat.images` prompt entries | same as image/movie | same as image/movie |

Non-billable local renderers (textSlide, markdown, mermaid, chart, html_tailwind, slide, captions, …) produce no records. Mock providers are skipped. Estimates assume a fresh run (no cache awareness — documented; cache-aware mode listed as future work in the plan).

**Types** (`src/types/usage.ts`): `EstimatedMetric = { value, precision: "exact" | "estimated" }` per metric (a single record can mix, e.g. exact input + estimated output); field names mirror `UsageRecord` so estimates can be joined with runtime actuals per `provider:model`.

**Tokenizer**: `js-tiktoken/lite` + explicit `o200k_base` ranks import (pure JS, no WASM; was already a transitive dep). Lazily instantiated.

**Tests**: `test/utils/test_estimate_usage.ts` — 22 cases covering gating rules, precision flags, pricing (tiered google TTS voices, elevenlabs chars, replicate per-image/per-second), reference media, translate defaults, mock/unpriced edges. Full suite: 936 tests, 0 failures. `yarn lint` 0 errors, `yarn build` clean.

**Docs**: README § Usage estimation; docs/api.md § Pre-run estimation (+ Known-gaps entry updated to point at the estimator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-run usage estimate feature that shows expected resource usage before execution.
  * Estimates can include per-step usage, language-related output, and pricing when available.

* **Documentation**
  * Updated the docs and README with examples, supported outputs, and usage notes for the new estimator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->