### PR TITLE
fix: add timeouts to network calls so stalled generation rejects instead of hanging (#1474)

### DIFF
--- a/docs/plans/plan_network_timeout_hardening.md
+++ b/docs/plans/plan_network_timeout_hardening.md
@@ -1,0 +1,102 @@
+# Network Timeout Hardening Plan (silent-hang fix)
+
+Issue: #1474
+Supersedes / implements: `plan_fetch_error_handling.md`
+
+## Problem
+
+`movie` / `images` generation can hang **indefinitely with no error** during image
+generation. Restarting completes it (cached beats skipped; the stalled beat succeeds
+on a fresh connection).
+
+Root cause: several network calls in the model/media agents have **no timeout**, so a
+stalled socket yields a promise that neither resolves nor rejects. GraphAI's
+`imageGenerator` node has `retry: 2` (`src/actions/images.ts`), but retry only fires on
+**rejection** — a hang never rejects, so the `concurrency: 4` map waits forever.
+
+## Principle
+
+Bound every network wait so a stall becomes a **rejection** (which triggers the existing
+`retry`). Do **not** change the normal success path. Use **generous, category-appropriate,
+named** timeouts so legitimate long-running generation (esp. video) is never interrupted.
+
+## Design
+
+### 1. Shared helper — `src/utils/fetch.ts`
+
+```ts
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+// Returns the Response; callers do their own .ok / .arrayBuffer() / .json().
+// Converts an AbortController timeout into a rejected promise (never hangs).
+export const safeFetch = async (url, init?, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response>
+```
+
+- AbortController + `setTimeout(abort)`, cleared in `finally`.
+- On `AbortError` → throw `Fetch timeout after <ms>ms: <url>`.
+- Merges caller `signal` is out of scope (no caller passes one today).
+
+### 2. Replace all bare `fetch()` with `safeFetch`
+
+| File | Purpose | Timeout const |
+|------|---------|---------------|
+| image_openai_agent.ts | DALL·E URL download | DOWNLOAD |
+| image_replicate_agent.ts | image download | DOWNLOAD |
+| movie_replicate_agent.ts | video download | MEDIA_DOWNLOAD |
+| lipsync_replicate_agent.ts | video download | MEDIA_DOWNLOAD |
+| sound_effect_replicate_agent.ts | audio/video download | MEDIA_DOWNLOAD |
+| tts_elevenlabs_agent.ts | TTS API POST | API |
+| tts_kotodama_agent.ts | TTS API POST | API |
+| media_mock_agent.ts | mock movie download | DOWNLOAD |
+| utils/file.ts | fetch remote MulmoScript | DEFAULT |
+| methods/mulmo_media_source.ts | 4 sites: reference image, mermaid text, image-plugin, url→dataURL | DEFAULT |
+| actions/pdf.ts | remote image for PDF | DOWNLOAD |
+| actions/bundle.ts | BGM download | MEDIA_DOWNLOAD |
+
+Error semantics preserved: each site keeps its existing `assert(response.ok, …, cause)` /
+`throw new Error(…, { cause })`. `safeFetch` only replaces the raw `fetch` call.
+
+### 3. Consolidate hand-rolled wrappers (DRY)
+
+- `bg_image_util.ts` `fetchUrlAsDataUrl` → use `safeFetch`.
+- `mulmo_media_source.ts` `urlToDataUrl` → use `safeFetch`.
+  (Both already implement the same pattern with a local `DEFAULT_FETCH_TIMEOUT_MS`.)
+
+### 4. SDK generation timeouts
+
+- **OpenAI** (`src/utils/openai_client.ts`): add `timeout: OPENAI_REQUEST_TIMEOUT_MS`
+  (keep SDK default `maxRetries: 2`). Covers `image_openai` + `tts_openai`. This is the
+  direct fix for the reported `gpt-image-1` stall.
+- **Google GenAI**: add `httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS }` to every
+  `new GoogleGenAI({...})` (`image_genai`, `tts_gemini`, `movie_genai`). Applies to each
+  individual API call (kick-off + each poll), not the whole video job.
+- **Replicate**: thread an `AbortSignal` (with timeout) into the existing
+  `runReplicateWithMetrics(…, signal)` from all 4 replicate agents.
+- **`pollUntilDone`** (`movie_genai_agent.ts`): add an overall wall-clock cap
+  (`VIDEO_POLL_TIMEOUT_MS`); throw a labeled error if exceeded so it can't loop forever.
+
+### 5. Timeout constants (generous safety nets, not tight deadlines)
+
+| Const | Value | Rationale |
+|-------|-------|-----------|
+| DEFAULT_FETCH_TIMEOUT_MS | 30 s | small assets (ref/bg images, JSON) — matches existing |
+| FETCH_DOWNLOAD_TIMEOUT_MS | 60 s | generated image download |
+| FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS | 180 s | large video/audio download |
+| FETCH_API_TIMEOUT_MS | 120 s | TTS text→audio POST |
+| OPENAI_REQUEST_TIMEOUT_MS | 120 s | gpt-image-1 typ. <60 s; ×(1+2 retries) ceiling |
+| GENAI_REQUEST_TIMEOUT_MS | 120 s | per API call (not the whole video job) |
+| REPLICATE_RUN_TIMEOUT_MS | 600 s | seedance/kling video jobs run minutes |
+| VIDEO_POLL_TIMEOUT_MS | 1200 s | Veo long-running op wall-clock cap |
+
+All values are named constants (no magic numbers) and easy to tune in review.
+
+## Out of scope
+- Puppeteer `protocolTimeout` (#1366) — rendering-side, separate.
+
+## Tests
+- Unit test `safeFetch`: resolves on fast response; rejects with timeout error when the
+  server never responds (mock `fetch` / slow local handler); passes through non-timeout
+  errors. No network/API keys required.
+
+## Gates
+`yarn format` → `yarn lint` → `yarn build` → `yarn typecheck` (if present) → `yarn ci_test`.

--- a/src/actions/bundle.ts
+++ b/src/actions/bundle.ts
@@ -8,9 +8,10 @@ import { ZipBuilder } from "../utils/zip.js";
 import { bundleTargetLang } from "../types/const.js";
 import { createSilentAudio } from "../utils/ffmpeg_utils.js";
 import { silentMp3 } from "../utils/context.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 const downloadFile = async (url: string, destPath: string): Promise<void> => {
-  const response = await fetch(url);
+  const response = await safeFetch(url, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
   if (!response.ok) {
     throw new Error(`Failed to download file from ${url}: ${response.statusText}`);
   }

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -7,6 +7,7 @@ import { MulmoPresentationStyleMethods } from "../methods/index.js";
 import { localizedText, isHttp } from "../utils/utils.js";
 import { getOutputPdfFilePath, writingMessage, getHTMLFile, mulmoCreditPath } from "../utils/file.js";
 import { interpolate } from "../utils/html_render.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
 const isCI = process.env.CI === "true";
@@ -30,7 +31,9 @@ const getPdfSize = (pdfSize: PDFSize) => {
 
 const loadImage = async (imagePath: string, index: number): Promise<string> => {
   try {
-    const imageData = isHttp(imagePath) ? Buffer.from(await (await fetch(imagePath)).arrayBuffer()) : fs.readFileSync(imagePath);
+    const imageData = isHttp(imagePath)
+      ? Buffer.from(await (await safeFetch(imagePath, {}, FETCH_DOWNLOAD_TIMEOUT_MS)).arrayBuffer())
+      : fs.readFileSync(imagePath);
     const ext = path.extname(imagePath).toLowerCase().replace(".", "");
     const mimeType = ext === "jpg" ? "jpeg" : ext;
     return `data:image/${mimeType};base64,${imageData.toString("base64")}`;

--- a/src/agents/image_genai_agent.ts
+++ b/src/agents/image_genai_agent.ts
@@ -24,6 +24,7 @@ import { ASPECT_RATIOS, PRO_ASPECT_RATIOS } from "../types/const.js";
 import type { AgentBufferResult, ImageAgentInputs, ImageAgentParams, GenAIImageAgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { GoogleGenAI, PersonGeneration, GenerateContentResponse } from "@google/genai";
+import { GENAI_REQUEST_TIMEOUT_MS } from "../utils/sdk_timeout.js";
 
 const isDeprecatedGoogleImageModel = (model: string): model is DeprecatedGoogleImageModel => model in deprecatedGoogleImageModelHints;
 
@@ -116,7 +117,7 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
             `imageGenAIAgent: model "${model}" on Vertex AI is only available in location "global", but got "${location}". Set imageParams.vertexai_location to "global".`,
           );
         }
-        return new GoogleGenAI({ vertexai: true, project: params.vertexai_project, location });
+        return new GoogleGenAI({ vertexai: true, project: params.vertexai_project, location, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       })()
     : (() => {
         if (!apiKey) {
@@ -127,7 +128,7 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
             },
           );
         }
-        return new GoogleGenAI({ apiKey });
+        return new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       })();
 
   if (model === "gemini-2.5-flash-image" || model === "gemini-3.1-flash-image-preview" || model === "gemini-3-pro-image-preview") {

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { AgentFunction, AgentFunctionInfo, GraphAILogger } from "graphai";
 import { toFile, AuthenticationError, RateLimitError, APIError } from "openai";
 import { createOpenAIClient } from "../utils/openai_client.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 import { provider2ImageAgent, gptImages, deprecatedOpenAIImageModelHints, type DeprecatedOpenAIImageModel } from "../types/provider2agent.js";
 import {
   apiKeyMissingError,
@@ -159,7 +160,7 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
   }
 
   // URL response handling (legacy OpenAI image API response format)
-  const res = await fetch(url);
+  const res = await safeFetch(url, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`, {
       cause: agentGenerationError("imageOpenaiAgent", imageAction, imageFileTarget),

--- a/src/agents/image_replicate_agent.ts
+++ b/src/agents/image_replicate_agent.ts
@@ -17,6 +17,7 @@ import type { AgentBufferResult, ImageAgentInputs, AgentConfig } from "../types/
 import type { AgentUsage } from "../types/usage.js";
 import { provider2ImageAgent } from "../types/provider2agent.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export type ReplicateImageAgentConfig = AgentConfig;
 
@@ -73,7 +74,7 @@ export const imageReplicateAgent: AgentFunction<ReplicateImageAgentParams, Agent
       });
     }
 
-    const imageResponse = await fetch(imageUrl);
+    const imageResponse = await safeFetch(imageUrl, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
     if (!imageResponse.ok) {
       throw new Error(`Error downloading image: ${imageResponse.status} - ${imageResponse.statusText}`, {
         cause: agentGenerationError("imageReplicateAgent", imageAction, imageFileTarget),

--- a/src/agents/lipsync_replicate_agent.ts
+++ b/src/agents/lipsync_replicate_agent.ts
@@ -16,6 +16,7 @@ import {
 import type { AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentParams, ReplicateLipSyncAgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentConfig> = async ({
   namedInputs,
@@ -90,7 +91,7 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
 
     if (output && typeof output === "object" && "url" in output) {
       const videoUrl = ((output as { url: unknown }).url as () => URL)();
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/media_mock_agent.ts
+++ b/src/agents/media_mock_agent.ts
@@ -1,6 +1,7 @@
 import { AgentFunction, AgentFunctionInfo, GraphAILogger } from "graphai";
 import fs from "fs";
 import { silent60secPath, mulmoCreditPath } from "../utils/file.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const mediaMockAgent: AgentFunction = async ({ namedInputs }) => {
   if (namedInputs.media === "audio") {
@@ -13,7 +14,7 @@ export const mediaMockAgent: AgentFunction = async ({ namedInputs }) => {
   }
   if (namedInputs.media === "movie") {
     const url = "https://github.com/receptron/mulmocast-media/raw/refs/heads/main/test/pingpong.mov";
-    const res = await fetch(url);
+    const res = await safeFetch(url, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
     if (!res.ok) {
       throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
     }

--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -19,6 +19,7 @@ import { ASPECT_RATIOS } from "../types/const.js";
 import type { AgentBufferResult, GenAIImageAgentConfig, GoogleMovieAgentParams, MovieAgentInputs, MovieReferenceImage } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { getModelDuration, provider2MovieAgent, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
+import { GENAI_REQUEST_TIMEOUT_MS, VIDEO_POLL_TIMEOUT_MS } from "../utils/sdk_timeout.js";
 
 type ImagePayload = { imageBytes: string; mimeType: string };
 
@@ -40,7 +41,13 @@ type VideoPayload = {
 
 const pollUntilDone = async (ai: GoogleGenAI, operation: GenerateVideosOperation) => {
   const response = { operation };
+  const deadline = Date.now() + VIDEO_POLL_TIMEOUT_MS;
   while (!response.operation.done) {
+    if (Date.now() > deadline) {
+      throw new Error(`Video generation did not complete within ${VIDEO_POLL_TIMEOUT_MS}ms`, {
+        cause: agentGenerationError("movieGenAIAgent", imageAction, movieFileTarget),
+      });
+    }
     await sleep(5000);
     response.operation = await ai.operations.getVideosOperation(response);
   }
@@ -278,6 +285,7 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
           vertexai: true,
           project: params.vertexai_project,
           location: params.vertexai_location ?? "us-central1",
+          httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS },
         })
       : (() => {
           if (!apiKey) {
@@ -288,7 +296,7 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
               },
             );
           }
-          return new GoogleGenAI({ apiKey });
+          return new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
         })();
 
     // Veo 3.1: Video extension mode for videos longer than 8s

--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -307,11 +307,14 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
     // Standard mode
     return generateStandardVideo(ai, model, prompt, aspectRatio, imagePath, lastFrameImagePath, referenceImages, duration, movieFile, isVertexAI);
   } catch (error) {
-    GraphAILogger.info("Failed to generate movie:", (error as Error).message);
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to generate movie with Google GenAI", {
+    GraphAILogger.info("Failed to generate movie:", (error as Error).message);
+    // Preserve the underlying message (e.g. a timeout/abort deadline) instead of
+    // collapsing every failure to a static label. (Same template as #1452.)
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to generate movie with Google GenAI: ${detail}`, {
       cause: agentGenerationError("movieGenAIAgent", imageAction, movieFileTarget),
     });
   }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -17,6 +17,7 @@ import type { AgentBufferResult, MovieAgentInputs, ReplicateMovieAgentParams, Re
 import type { AgentUsage } from "../types/usage.js";
 import { provider2MovieAgent, getModelDuration, AUDIO_MODE_OPTIONAL, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 function replicate_get_videoUrl(output: unknown): string | URL | undefined {
   if (typeof output === "string") return output;
@@ -122,7 +123,7 @@ async function generateMovie(
     // Some models return a FileOutput object with a url() method; others return a plain string URL.
     const videoUrl = replicate_get_videoUrl(output);
     if (videoUrl) {
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/sound_effect_replicate_agent.ts
+++ b/src/agents/sound_effect_replicate_agent.ts
@@ -8,6 +8,7 @@ import { apiKeyMissingError, agentGenerationError, imageAction, movieFileTarget,
 import type { AgentBufferResult, SoundEffectAgentInputs, ReplicateSoundEffectAgentParams, ReplicateSoundEffectAgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const soundEffectReplicateAgent: AgentFunction<
   ReplicateSoundEffectAgentParams,
@@ -48,7 +49,7 @@ export const soundEffectReplicateAgent: AgentFunction<
 
     if (output && typeof output === "object" && "url" in output) {
       const videoUrl = ((output as { url: unknown }).url as () => URL)();
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -11,6 +11,7 @@ import {
 } from "../utils/error_cause.js";
 import type { ElevenlabsTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
+import { safeFetch, FETCH_API_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -46,15 +47,19 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
 
   const response = await (async () => {
     try {
-      return await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voice}`, {
-        method: "POST",
-        headers: {
-          Accept: "audio/mpeg",
-          "Content-Type": "application/json",
-          "xi-api-key": apiKey,
+      return await safeFetch(
+        `https://api.elevenlabs.io/v1/text-to-speech/${voice}`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "audio/mpeg",
+            "Content-Type": "application/json",
+            "xi-api-key": apiKey,
+          },
+          body: JSON.stringify(requestBody),
         },
-        body: JSON.stringify(requestBody),
-      });
+        FETCH_API_TIMEOUT_MS,
+      );
     } catch (e) {
       if (suppressError) {
         return {

--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -1,6 +1,7 @@
 import { GraphAILogger } from "graphai";
 import type { AgentFunction, AgentFunctionInfo } from "graphai";
 import { GoogleGenAI } from "@google/genai";
+import { GENAI_REQUEST_TIMEOUT_MS } from "../utils/sdk_timeout.js";
 
 import { provider2TTSAgent } from "../types/provider2agent.js";
 import {
@@ -41,7 +42,7 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
 
   const geminiResult: { rawPcm: Buffer; sampleRate: number; usage: AgentUsage | undefined } | AgentErrorResult = await (async () => {
     try {
-      const ai = new GoogleGenAI({ apiKey });
+      const ai = new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       const response = await ai.models.generateContent({
         model: model ?? provider2TTSAgent.gemini.defaultModel,
         contents: [{ parts: [{ text: getPrompt(text, instructions) }] }],

--- a/src/agents/tts_kotodama_agent.ts
+++ b/src/agents/tts_kotodama_agent.ts
@@ -4,6 +4,7 @@ import { provider2TTSAgent } from "../types/provider2agent.js";
 import { apiKeyMissingError, agentIncorrectAPIKeyError, agentGenerationError, audioAction, audioFileTarget } from "../utils/error_cause.js";
 import type { KotodamaTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
+import { safeFetch, FETCH_API_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -29,14 +30,18 @@ export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBuffer
   };
 
   try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
+    const response = await safeFetch(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
+        body: JSON.stringify(body),
       },
-      body: JSON.stringify(body),
-    });
+      FETCH_API_TIMEOUT_MS,
+    );
 
     if (!response.ok) {
       if (response.status === 401) {

--- a/src/methods/mulmo_media_source.ts
+++ b/src/methods/mulmo_media_source.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { GraphAILogger, assert } from "graphai";
 import type { MulmoMediaSource, MulmoMediaMermaidSource, MulmoStudioContext, ImageType } from "../types/index.js";
 import { getFullPath, getReferenceImagePath, resolveAssetPath } from "../utils/file.js";
+import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../utils/fetch.js";
 import {
   downLoadReferenceImageError,
   getTextError,
@@ -29,7 +30,7 @@ export const getExtention = (contentType: string | null, url: string) => {
 };
 
 const downLoadReferenceImage = async (context: MulmoStudioContext, key: string, url: string) => {
-  const response = await fetch(url);
+  const response = await safeFetch(url);
 
   assert(response.ok, `Failed to download reference image: ${url}`, false, downLoadReferenceImageError(key, url));
   const buffer = Buffer.from(await response.arrayBuffer());
@@ -54,26 +55,20 @@ function pluginSourceFixExtention(path: string, imageType: ImageType) {
 
 // end of util
 
-const DEFAULT_FETCH_TIMEOUT_MS = 30000;
-
 // Convert URL to data URL (base64 encoded)
 const urlToDataUrl = async (url: string, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<string> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await safeFetch(url, {}, timeoutMs);
     assert(response.ok, `Failed to fetch: ${url}`, false, mediaSourceToDataUrlError(url));
     const buffer = Buffer.from(await response.arrayBuffer());
     const contentType = response.headers.get("content-type") || "image/png";
     return `data:${contentType};base64,${buffer.toString("base64")}`;
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Fetch timeout: ${url}`, { cause: mediaSourceToDataUrlError(url) });
+    // assert() failures already carry the structured cause — keep it as-is.
+    if (error instanceof Error && error.cause) {
+      throw error;
     }
-    throw new Error(`Fetch failed: ${url}`, { cause: mediaSourceToDataUrlError(url) });
-  } finally {
-    clearTimeout(timeoutId);
+    throw new Error(`Fetch failed: ${url}: ${error instanceof Error ? error.message : String(error)}`, { cause: mediaSourceToDataUrlError(url) });
   }
 };
 
@@ -112,7 +107,7 @@ export const MulmoMediaSourceMethods = {
       return mediaSource.text;
     }
     if (mediaSource.kind === "url") {
-      const response = await fetch(mediaSource.url);
+      const response = await safeFetch(mediaSource.url);
       assert(response.ok, `Failed to download mermaid code text: ${mediaSource.url}`, false, getTextError(mediaSource.url)); // TODO: index
       return await response.text();
     }
@@ -145,7 +140,7 @@ export const MulmoMediaSourceMethods = {
 
   async imagePluginSource(mediaSource: MulmoMediaSource, context: MulmoStudioContext, expectImagePath: string, imageType: ImageType) {
     if (mediaSource.kind === "url") {
-      const response = await fetch(mediaSource.url);
+      const response = await safeFetch(mediaSource.url);
       assert(response.ok, `Failed to download image plugin: ${imageType} ${mediaSource.url}`, false, downloadImagePluginError(mediaSource.url, imageType)); // TODO: key, id, index
       const buffer = Buffer.from(await response.arrayBuffer());
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -6,20 +6,32 @@ export const FETCH_DOWNLOAD_TIMEOUT_MS = 60_000; // generated image download
 export const FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS = 180_000; // large video/audio download
 export const FETCH_API_TIMEOUT_MS = 120_000; // generation API POST (e.g. TTS text -> audio)
 
+// Statuses whose Response must not carry a body (constructing one with a body throws).
+const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+
 /**
- * fetch() with an AbortController timeout.
+ * fetch() with an AbortController timeout that covers the whole exchange —
+ * headers AND body.
  *
  * A stalled connection otherwise yields a promise that never resolves or
  * rejects; callers relying on GraphAI `retry` never recover because retry only
- * fires on rejection. This converts a timeout into a thrown error so the caller
- * (and its retry) can react. The success path is unchanged — the returned
- * Response is the raw fetch Response.
+ * fires on rejection. The body is buffered under the same deadline (callers
+ * already read it eagerly via arrayBuffer()/json()/text(), so memory behavior
+ * is unchanged) — otherwise a server that sends headers and then stalls
+ * mid-body would hang the caller's body read instead. Returns a Response backed
+ * by the buffered bytes so callers keep using .ok/.status/.headers/.arrayBuffer().
  */
 export const safeFetch = async (url: string | URL, init: Parameters<typeof fetch>[1] = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    const body = await response.arrayBuffer();
+    return new Response(NULL_BODY_STATUSES.has(response.status) ? null : body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`Fetch timeout after ${timeoutMs}ms: ${url}`);

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,31 @@
+// Timeout budgets for the different kinds of network waits. Generous safety
+// nets against a stalled socket — NOT tight deadlines — so legitimate slow
+// responses still succeed while a genuine hang becomes a rejection.
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000; // small assets (reference/background images, JSON)
+export const FETCH_DOWNLOAD_TIMEOUT_MS = 60_000; // generated image download
+export const FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS = 180_000; // large video/audio download
+export const FETCH_API_TIMEOUT_MS = 120_000; // generation API POST (e.g. TTS text -> audio)
+
+/**
+ * fetch() with an AbortController timeout.
+ *
+ * A stalled connection otherwise yields a promise that never resolves or
+ * rejects; callers relying on GraphAI `retry` never recover because retry only
+ * fires on rejection. This converts a timeout into a thrown error so the caller
+ * (and its retry) can react. The success path is unchanged — the returned
+ * Response is the raw fetch Response.
+ */
+export const safeFetch = async (url: string | URL, init: Parameters<typeof fetch>[1] = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Fetch timeout after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -6,8 +6,11 @@ export const FETCH_DOWNLOAD_TIMEOUT_MS = 60_000; // generated image download
 export const FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS = 180_000; // large video/audio download
 export const FETCH_API_TIMEOUT_MS = 120_000; // generation API POST (e.g. TTS text -> audio)
 
-// Statuses whose Response must not carry a body (constructing one with a body throws).
-const NULL_BODY_STATUSES = new Set([101, 103, 204, 205, 304]);
+// Statuses that fetch can surface whose Response must not carry a body
+// (constructing `new Response(body, { status })` with a body throws). 1xx
+// statuses are excluded: fetch never surfaces them as a final response, and
+// `new Response(null, { status: 101 })` itself throws (valid range is 200-599).
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
 
 /**
  * fetch() with an AbortController timeout that covers the whole exchange —

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -11,6 +11,7 @@ import { PDFMode } from "../types/index.js";
 import { z, ZodSchema, ZodType } from "zod";
 import { getMulmoScriptTemplateSystemPrompt } from "./prompt.js";
 import { resolveAssetFile } from "./asset_import.js";
+import { safeFetch } from "./fetch.js";
 
 const promptTemplateDirName = "./assets/templates";
 const scriptTemplateDirName = "./scripts/templates";
@@ -75,7 +76,7 @@ export function readMulmoScriptFile<T = MulmoScript>(
 }
 export const fetchMulmoScriptFile = async (url: string): Promise<{ result: boolean; script?: MulmoScript; status: string | number }> => {
   try {
-    const res = await fetch(url);
+    const res = await safeFetch(url);
     if (!res.ok) {
       return { result: false, status: res.status };
     }

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -1,8 +1,7 @@
 import { BackgroundImage, MulmoStudioContext, ImageProcessorParams } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 import { resolveStyle } from "./utils.js";
-
-const DEFAULT_FETCH_TIMEOUT_MS = 30000;
+import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../fetch.js";
 
 /**
  * Resolve background image from beat level and global level settings.
@@ -32,25 +31,13 @@ export const resolveBackgroundImage = (
  * Fetch URL and convert to data URL with timeout
  */
 const fetchUrlAsDataUrl = async (url: string, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<string> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch background image: ${url} (${response.status})`);
-    }
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const contentType = response.headers.get("content-type") || "image/png";
-    return `data:${contentType};base64,${buffer.toString("base64")}`;
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Fetch timeout for background image: ${url}`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
+  const response = await safeFetch(url, {}, timeoutMs);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch background image: ${url} (${response.status})`);
   }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const contentType = response.headers.get("content-type") || "image/png";
+  return `data:${contentType};base64,${buffer.toString("base64")}`;
 };
 
 /**

--- a/src/utils/openai_client.ts
+++ b/src/utils/openai_client.ts
@@ -1,5 +1,10 @@
 import OpenAI, { AzureOpenAI } from "openai";
 
+// Explicit per-request timeout so a stalled connection rejects (and the SDK's
+// default maxRetries=2 re-issues it) instead of hanging on the SDK's 10-minute
+// default. gpt-image-1 generation is typically well under this.
+const OPENAI_REQUEST_TIMEOUT_MS = 120_000;
+
 export interface OpenAIClientOptions {
   apiKey?: string;
   baseURL?: string;
@@ -33,11 +38,13 @@ export const createOpenAIClient = (options: OpenAIClientOptions): OpenAI => {
       apiKey,
       endpoint: baseURL,
       apiVersion: apiVersion ?? "2025-04-01-preview",
+      timeout: OPENAI_REQUEST_TIMEOUT_MS,
     });
   }
 
   return new OpenAI({
     apiKey,
     baseURL,
+    timeout: OPENAI_REQUEST_TIMEOUT_MS,
   });
 };

--- a/src/utils/replicate_usage.ts
+++ b/src/utils/replicate_usage.ts
@@ -8,15 +8,20 @@ import { REPLICATE_RUN_TIMEOUT_MS } from "./sdk_timeout.js";
 // would be a much bigger blast radius.
 //
 // A timeout aborts the run so a stalled job rejects (and the caller's GraphAI
-// `retry` can recover) instead of hanging forever.
+// `retry` can recover) instead of hanging forever. An optional caller `signal`
+// is composed with the timeout so upstream cancellation still works.
 export const runReplicateWithMetrics = async (
   replicate: Replicate,
   identifier: `${string}/${string}` | `${string}/${string}:${string}`,
   input: object,
-  timeoutMs: number = REPLICATE_RUN_TIMEOUT_MS,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {},
 ): Promise<{ output: unknown; predictSec?: number }> => {
+  const { timeoutMs = REPLICATE_RUN_TIMEOUT_MS, signal: externalSignal } = options;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const forwardAbort = () => controller.abort();
+  externalSignal?.addEventListener("abort", forwardAbort, { once: true });
+  if (externalSignal?.aborted) controller.abort();
   let lastPrediction: Prediction | undefined;
   try {
     const output = await replicate.run(identifier, { input, signal: controller.signal }, (prediction) => {
@@ -25,5 +30,6 @@ export const runReplicateWithMetrics = async (
     return { output, predictSec: lastPrediction?.metrics?.predict_time };
   } finally {
     clearTimeout(timeoutId);
+    externalSignal?.removeEventListener("abort", forwardAbort);
   }
 };

--- a/src/utils/replicate_usage.ts
+++ b/src/utils/replicate_usage.ts
@@ -1,19 +1,29 @@
 import type Replicate from "replicate";
 import type { Prediction } from "replicate";
+import { REPLICATE_RUN_TIMEOUT_MS } from "./sdk_timeout.js";
 
 // Capture Replicate's exact billed seconds (`metrics.predict_time`) via the
 // progress callback on `replicate.run()`. Avoids switching the four
 // replicate agents from `.run()` to `predictions.create()` + poll, which
 // would be a much bigger blast radius.
+//
+// A timeout aborts the run so a stalled job rejects (and the caller's GraphAI
+// `retry` can recover) instead of hanging forever.
 export const runReplicateWithMetrics = async (
   replicate: Replicate,
   identifier: `${string}/${string}` | `${string}/${string}:${string}`,
   input: object,
-  signal?: AbortSignal,
+  timeoutMs: number = REPLICATE_RUN_TIMEOUT_MS,
 ): Promise<{ output: unknown; predictSec?: number }> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   let lastPrediction: Prediction | undefined;
-  const output = await replicate.run(identifier, { input, signal }, (prediction) => {
-    lastPrediction = prediction;
-  });
-  return { output, predictSec: lastPrediction?.metrics?.predict_time };
+  try {
+    const output = await replicate.run(identifier, { input, signal: controller.signal }, (prediction) => {
+      lastPrediction = prediction;
+    });
+    return { output, predictSec: lastPrediction?.metrics?.predict_time };
+  } finally {
+    clearTimeout(timeoutId);
+  }
 };

--- a/src/utils/sdk_timeout.ts
+++ b/src/utils/sdk_timeout.ts
@@ -1,0 +1,7 @@
+// Timeout budgets for provider SDK calls (OpenAI has its own in openai_client.ts).
+// Generous safety nets against a stalled connection or a never-completing
+// operation — NOT tight deadlines. A stall becomes a rejection so the caller's
+// GraphAI `retry` can recover instead of hanging forever.
+export const GENAI_REQUEST_TIMEOUT_MS = 120_000; // per @google/genai API call (kick-off / each poll)
+export const REPLICATE_RUN_TIMEOUT_MS = 600_000; // whole replicate.run() job (video models run minutes)
+export const VIDEO_POLL_TIMEOUT_MS = 1_200_000; // wall-clock cap for a long-running Veo video operation

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -1,0 +1,56 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { safeFetch } from "../../src/utils/fetch.js";
+
+let server: http.Server;
+let baseUrl: string;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url === "/fast") {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    }
+    // Any other path (e.g. "/hang"): intentionally never respond, to exercise the timeout path.
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test("safeFetch resolves on a normal response", async () => {
+  const res = await safeFetch(`${baseUrl}/fast`);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "ok");
+});
+
+test("safeFetch rejects with a timeout error when the server never responds", async () => {
+  await assert.rejects(
+    () => safeFetch(`${baseUrl}/hang`, {}, 100),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Fetch timeout after 100ms/);
+      return true;
+    },
+  );
+});
+
+test("safeFetch propagates non-timeout network errors (not as a timeout)", async () => {
+  // Nothing listening on port 1 -> connection refused, well before the timeout.
+  await assert.rejects(
+    () => safeFetch("http://127.0.0.1:1/nope", {}, 5000),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.doesNotMatch(error.message, /Fetch timeout/);
+      return true;
+    },
+  );
+});

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -22,6 +22,11 @@ before(async () => {
         res.writeHead(200, { "content-type": "text/plain" });
         res.end("slow-ok");
       }, SLOW_RESPONSE_MS);
+    } else if (req.url === "/headers-then-hang") {
+      // Send headers (promising a body via content-length) and a partial chunk,
+      // then never finish — exercises a mid-body stall.
+      res.writeHead(200, { "content-type": "application/octet-stream", "content-length": "1000" });
+      res.write("partial");
     }
     // Any other path (e.g. "/hang"): intentionally never respond, to exercise the timeout path.
   });
@@ -47,6 +52,17 @@ test("safeFetch rejects with a timeout error when the server never responds", as
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /Fetch timeout after 100ms/);
+      return true;
+    },
+  );
+});
+
+test("safeFetch times out when the body stalls after headers are sent", async () => {
+  await assert.rejects(
+    () => safeFetch(`${baseUrl}/headers-then-hang`, {}, 120),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Fetch timeout after 120ms/);
       return true;
     },
   );

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -5,6 +5,8 @@ import type { AddressInfo } from "node:net";
 
 import { safeFetch } from "../../src/utils/fetch.js";
 
+const SLOW_RESPONSE_MS = 250;
+
 let server: http.Server;
 let baseUrl: string;
 
@@ -13,6 +15,13 @@ before(async () => {
     if (req.url === "/fast") {
       res.writeHead(200, { "content-type": "text/plain" });
       res.end("ok");
+    } else if (req.url === "/slow") {
+      // Responds after a delay — used to prove one call's timeout abort does
+      // not cancel another concurrent, still-in-budget request.
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("slow-ok");
+      }, SLOW_RESPONSE_MS);
     }
     // Any other path (e.g. "/hang"): intentionally never respond, to exercise the timeout path.
   });
@@ -53,4 +62,42 @@ test("safeFetch propagates non-timeout network errors (not as a timeout)", async
       return true;
     },
   );
+});
+
+// --- Concurrency safety: each call owns its AbortController + timer, so calls
+// running in parallel (the image pipeline uses concurrency: 4) must not
+// interfere with one another. ---
+
+test("concurrent safeFetch timeouts each fire at their own budget (no cross-talk)", async () => {
+  const budgets = [60, 90, 120, 150, 180, 210];
+  const results = await Promise.allSettled(budgets.map((ms) => safeFetch(`${baseUrl}/hang`, {}, ms)));
+
+  results.forEach((result, index) => {
+    assert.equal(result.status, "rejected", `call ${index} should have timed out`);
+    const reason = (result as PromiseRejectedResult).reason;
+    assert.ok(reason instanceof Error);
+    // Each rejection must carry its OWN budget — proof the timers/controllers are independent.
+    assert.match(reason.message, new RegExp(`Fetch timeout after ${budgets[index]}ms`));
+  });
+});
+
+test("a concurrent timeout does not abort another in-flight request", async () => {
+  // The slow request (2s budget, responds at 250ms) runs alongside several
+  // short-budget hangs that abort at ~80ms. If aborts leaked across calls, the
+  // slow request would be cancelled too.
+  const slow = safeFetch(`${baseUrl}/slow`, {}, 2000);
+  const hangs = Array.from({ length: 4 }, () => safeFetch(`${baseUrl}/hang`, {}, 80));
+
+  const hangResults = await Promise.allSettled(hangs);
+  hangResults.forEach((result) => assert.equal(result.status, "rejected"));
+
+  const res = await slow;
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "slow-ok");
+});
+
+test("many concurrent successful fetches all resolve independently", async () => {
+  const responses = await Promise.all(Array.from({ length: 20 }, () => safeFetch(`${baseUrl}/fast`)));
+  const texts = await Promise.all(responses.map((r) => r.text()));
+  assert.ok(texts.every((t) => t === "ok"));
 });


### PR DESCRIPTION
## Summary

`movie` / `images` generation could **hang indefinitely with no error** partway through image generation. Root cause: several network calls in the model/media agents have **no timeout**, so a stalled socket yields a promise that never resolves *or* rejects. GraphAI's `imageGenerator` node has `retry: 2`, but retry only fires on **rejection** — a hang never rejects, so the `concurrency: 4` map waits forever ("stuck partway through image generation"). Killing + restarting works because cached beats are skipped and the stalled beat succeeds on a fresh connection.

This PR bounds **every** network wait so a stall surfaces as a rejection (which then triggers the existing `retry`), **without changing the normal success path**.

## Items to Confirm / Review

1. **Video-generation timeout values** — are these generous enough to never cut a legitimate long job? `REPLICATE_RUN_TIMEOUT_MS = 600s`, `VIDEO_POLL_TIMEOUT_MS = 1200s` (Veo poll cap), `GENAI_REQUEST_TIMEOUT_MS = 120s` (per API call), `OPENAI_REQUEST_TIMEOUT_MS = 120s`, download/API fetch 30–180s. All are named constants, easy to tune.
2. **`mulmo_media_source.ts` `urlToDataUrl` catch refactor** — the hand-rolled AbortController was removed in favor of `safeFetch`; the catch now rethrows when the error already carries a structured cause (from `assert`) and otherwise wraps with `mediaSourceToDataUrlError`. Please confirm the i18n `cause` is preserved as before.
3. **OpenAI timeout is client-level** (`createOpenAIClient`) so it applies to both image and TTS. gpt-image-1 is typically < 60s; with SDK `maxRetries: 2` the effective ceiling is higher. OK to share one value?

## Root cause detail

Reported case uses the default OpenAI image model `gpt-image-1`, so the stall is in `openai.images.generate(...)` — the client was created with no explicit `timeout`, relying on the SDK's 10-minute default, which users kill before it fires.

## Changes

**New shared helper (DRY)** — `src/utils/fetch.ts` `safeFetch(url, init?, timeoutMs?)`: `fetch` with an AbortController timeout that converts a stall into a thrown error. All bare `fetch()` calls (13 sites across agents / methods / utils / actions) now route through it, and the two previously hand-rolled timeout wrappers (`bg_image_util`, `mulmo_media_source`) were consolidated onto it.

**SDK generation timeouts**
- OpenAI (`openai_client.ts`): explicit `timeout` (covers image + TTS) — the direct fix for the reported stall.
- Google GenAI: `httpOptions.timeout` on every `new GoogleGenAI(...)` (image / tts / movie).
- `pollUntilDone` (`movie_genai_agent.ts`): wall-clock cap so it cannot loop forever.
- Replicate: internal timeout inside `runReplicateWithMetrics` — all 4 replicate agents benefit without call-site churn.
- Timeout budgets are generous, category-based **named constants** (`src/utils/fetch.ts`, `src/utils/sdk_timeout.ts`).

Already protected (unchanged): `tts_google_agent.ts` already passes `{ timeout }`.

## Testing

- New unit test `test/utils/test_fetch.ts` (local http server, no network/keys): resolves on normal response; rejects with a timeout error when the server never responds; propagates non-timeout errors as non-timeouts.
- `yarn lint` (0 errors), `yarn build` (tsc), `yarn ci_test` → **945 pass / 0 fail** (4 pre-existing skips).
- End-to-end: regenerated `the-assistant-you-nurture.json` images via the OpenAI path — generation still succeeds with the new client timeout.

## User Prompt

> From the receptron/presentations repo's `mulmoclaude/vision/the-assistant-you-nurture.json`, generating a movie with the `-group` option (`-g` / `--grouped`) stalls partway through image generation — it hangs with no error, and stopping then resuming lets it run to completion. This looks like a MulmoCast bug. Please build the video from scratch, and fix this. Beyond this spot, also fix any other places in the model-processing code where a failure produces no error (silent hang), while carefully considering side effects so nothing breaks. If similar code recurs, extract it into a shared function.

Closes #1474
Related: #1366 (puppeteer `protocolTimeout` — separate rendering-side hang, out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safer fetching utility with explicit timeout budgets for remote downloads and API calls across media generation (images/videos), text-to-speech, and provider requests.
  * Enforced hard deadlines for long-running video generation polling.
* **Bug Fixes**
  * Prevented indefinite hangs when network requests stall, including mid-response hangs, and improved propagation of underlying failure details.
* **Tests**
  * Expanded timeout and concurrency coverage, including mid-body stalls and parallel request isolation.
* **Documentation**
  * Added a Network Timeout Hardening plan with validation and CI guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->