### PR TITLE
fix: safeFetch timeout wrapper for all network downloads (1/6)

### DIFF
--- a/docs/plans/plan_network_timeout_hardening.md
+++ b/docs/plans/plan_network_timeout_hardening.md
@@ -1,0 +1,118 @@
+# Network Timeout Hardening Plan (silent-hang fix)
+
+Issue: #1474
+Supersedes / implements: `plan_fetch_error_handling.md`
+
+## Problem
+
+`movie` / `images` generation can hang **indefinitely with no error** during image
+generation. Restarting completes it (cached beats skipped; the stalled beat succeeds
+on a fresh connection).
+
+Root cause: several network calls in the model/media agents have **no timeout**, so a
+stalled socket yields a promise that neither resolves nor rejects. GraphAI's
+`imageGenerator` node has `retry: 2` (`src/actions/images.ts`), but retry only fires on
+**rejection** — a hang never rejects, so the `concurrency: 4` map waits forever.
+
+## Principle
+
+Bound every network wait so a stall becomes a **rejection** (which triggers the existing
+`retry`). Do **not** change the normal success path. Use **generous, category-appropriate,
+named** timeouts so legitimate long-running generation (esp. video) is never interrupted.
+
+## Design
+
+### 1. Shared helper — `src/utils/fetch.ts`
+
+```ts
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+
+// Returns the Response; callers do their own .ok / .arrayBuffer() / .json().
+// Converts an AbortController timeout into a rejected promise (never hangs).
+export const safeFetch = async (url, init?, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response>
+```
+
+- AbortController + `setTimeout(abort)`, cleared in `finally`.
+- On `AbortError` → throw `Fetch timeout after <ms>ms: <url>`.
+- Merges caller `signal` is out of scope (no caller passes one today).
+
+### 2. Replace all bare `fetch()` with `safeFetch`
+
+| File | Purpose | Timeout const |
+|------|---------|---------------|
+| image_openai_agent.ts | DALL·E URL download | DOWNLOAD |
+| image_replicate_agent.ts | image download | DOWNLOAD |
+| movie_replicate_agent.ts | video download | MEDIA_DOWNLOAD |
+| lipsync_replicate_agent.ts | video download | MEDIA_DOWNLOAD |
+| sound_effect_replicate_agent.ts | audio/video download | MEDIA_DOWNLOAD |
+| tts_elevenlabs_agent.ts | TTS API POST | API |
+| tts_kotodama_agent.ts | TTS API POST | API |
+| media_mock_agent.ts | mock movie download | DOWNLOAD |
+| utils/file.ts | fetch remote MulmoScript | DEFAULT |
+| methods/mulmo_media_source.ts | 4 sites: reference image, mermaid text, image-plugin, url→dataURL | DEFAULT |
+| actions/pdf.ts | remote image for PDF | DOWNLOAD |
+| actions/bundle.ts | BGM download | MEDIA_DOWNLOAD |
+
+Error semantics preserved: each site keeps its existing `assert(response.ok, …, cause)` /
+`throw new Error(…, { cause })`. `safeFetch` only replaces the raw `fetch` call.
+
+### 3. Consolidate hand-rolled wrappers (DRY)
+
+- `bg_image_util.ts` `fetchUrlAsDataUrl` → use `safeFetch`.
+- `mulmo_media_source.ts` `urlToDataUrl` → use `safeFetch`.
+  (Both already implement the same pattern with a local `DEFAULT_FETCH_TIMEOUT_MS`.)
+
+### 4. SDK generation timeouts
+
+- **OpenAI** (`src/utils/openai_client.ts`): add `timeout: OPENAI_REQUEST_TIMEOUT_MS`
+  (keep SDK default `maxRetries: 2`). Covers `image_openai` + `tts_openai`. This is the
+  direct fix for the reported `gpt-image-1` stall.
+- **Google GenAI**: add `httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS }` to every
+  `new GoogleGenAI({...})` (`image_genai`, `tts_gemini`, `movie_genai`). Applies to each
+  individual API call (kick-off + each poll), not the whole video job.
+- **Replicate**: thread an `AbortSignal` (with timeout) into the existing
+  `runReplicateWithMetrics(…, signal)` from all 4 replicate agents.
+- **`pollUntilDone`** (`movie_genai_agent.ts`): add an overall wall-clock cap
+  (`VIDEO_POLL_TIMEOUT_MS`); throw a labeled error if exceeded so it can't loop forever.
+
+### 5. Timeout constants (generous safety nets, not tight deadlines)
+
+| Const | Value | Rationale |
+|-------|-------|-----------|
+| DEFAULT_FETCH_TIMEOUT_MS | 30 s | small assets (ref/bg images, JSON) — matches existing |
+| FETCH_DOWNLOAD_TIMEOUT_MS | 60 s | generated image download |
+| FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS | 180 s | large video/audio download |
+| FETCH_API_TIMEOUT_MS | 120 s | TTS text→audio POST |
+| OPENAI_REQUEST_TIMEOUT_MS | 120 s | gpt-image-1 typ. <60 s; ×(1+2 retries) ceiling |
+| GENAI_REQUEST_TIMEOUT_MS | 120 s | per API call (not the whole video job) |
+| REPLICATE_RUN_TIMEOUT_MS | 600 s | seedance/kling video jobs run minutes |
+| VIDEO_POLL_TIMEOUT_MS | 1200 s | Veo long-running op wall-clock cap |
+
+All values are named constants (no magic numbers) and easy to tune in review.
+
+## PR breakdown (shipped as independent, file-disjoint PRs for review)
+
+To keep each PR small and independently reviewable/revertable, the work is split
+so no two PRs touch the same file. The SDK-timeout constants are defined locally
+in the file that uses them (rather than one shared module) so every PR is
+independent of the others and of `main`:
+
+| PR | Meaning | Files |
+|----|---------|-------|
+| A | fetch layer: `safeFetch` + route all bare `fetch()` through it + consolidate hand-rolled wrappers + tests | `utils/fetch.ts`, `test/utils/test_fetch.ts`, all fetch call sites, this plan |
+| B | OpenAI client request timeout (direct fix for the reported `gpt-image-1` stall) | `utils/openai_client.ts` |
+| C1 | Replicate `run()` timeout (+ compose caller signal) | `utils/replicate_usage.ts` |
+| C2 | GenAI image request timeout | `agents/image_genai_agent.ts` |
+| C3 | GenAI TTS request timeout | `agents/tts_gemini_agent.ts` |
+| C4 | GenAI video request timeout + poll wall-clock cap + error-detail preservation | `agents/movie_genai_agent.ts` |
+
+## Out of scope
+- Puppeteer `protocolTimeout` (#1366) — rendering-side, separate.
+
+## Tests
+- Unit test `safeFetch`: resolves on fast response; rejects with timeout error when the
+  server never responds (mock `fetch` / slow local handler); passes through non-timeout
+  errors. No network/API keys required.
+
+## Gates
+`yarn format` → `yarn lint` → `yarn build` → `yarn typecheck` (if present) → `yarn ci_test`.

--- a/src/actions/bundle.ts
+++ b/src/actions/bundle.ts
@@ -8,9 +8,10 @@ import { ZipBuilder } from "../utils/zip.js";
 import { bundleTargetLang } from "../types/const.js";
 import { createSilentAudio } from "../utils/ffmpeg_utils.js";
 import { silentMp3 } from "../utils/context.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 const downloadFile = async (url: string, destPath: string): Promise<void> => {
-  const response = await fetch(url);
+  const response = await safeFetch(url, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
   if (!response.ok) {
     throw new Error(`Failed to download file from ${url}: ${response.statusText}`);
   }

--- a/src/actions/pdf.ts
+++ b/src/actions/pdf.ts
@@ -7,6 +7,7 @@ import { MulmoPresentationStyleMethods } from "../methods/index.js";
 import { localizedText, isHttp } from "../utils/utils.js";
 import { getOutputPdfFilePath, writingMessage, getHTMLFile, mulmoCreditPath } from "../utils/file.js";
 import { interpolate } from "../utils/html_render.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
 const isCI = process.env.CI === "true";
@@ -30,7 +31,9 @@ const getPdfSize = (pdfSize: PDFSize) => {
 
 const loadImage = async (imagePath: string, index: number): Promise<string> => {
   try {
-    const imageData = isHttp(imagePath) ? Buffer.from(await (await fetch(imagePath)).arrayBuffer()) : fs.readFileSync(imagePath);
+    const imageData = isHttp(imagePath)
+      ? Buffer.from(await (await safeFetch(imagePath, {}, FETCH_DOWNLOAD_TIMEOUT_MS)).arrayBuffer())
+      : fs.readFileSync(imagePath);
     const ext = path.extname(imagePath).toLowerCase().replace(".", "");
     const mimeType = ext === "jpg" ? "jpeg" : ext;
     return `data:image/${mimeType};base64,${imageData.toString("base64")}`;

--- a/src/agents/image_openai_agent.ts
+++ b/src/agents/image_openai_agent.ts
@@ -3,6 +3,7 @@ import path from "path";
 import { AgentFunction, AgentFunctionInfo, GraphAILogger } from "graphai";
 import { toFile, AuthenticationError, RateLimitError, APIError } from "openai";
 import { createOpenAIClient } from "../utils/openai_client.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 import { provider2ImageAgent, gptImages, deprecatedOpenAIImageModelHints, type DeprecatedOpenAIImageModel } from "../types/provider2agent.js";
 import {
   apiKeyMissingError,
@@ -159,7 +160,7 @@ export const imageOpenaiAgent: AgentFunction<OpenAIImageAgentParams, AgentBuffer
   }
 
   // URL response handling (legacy OpenAI image API response format)
-  const res = await fetch(url);
+  const res = await safeFetch(url, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`, {
       cause: agentGenerationError("imageOpenaiAgent", imageAction, imageFileTarget),

--- a/src/agents/image_replicate_agent.ts
+++ b/src/agents/image_replicate_agent.ts
@@ -17,6 +17,7 @@ import type { AgentBufferResult, ImageAgentInputs, AgentConfig } from "../types/
 import type { AgentUsage } from "../types/usage.js";
 import { provider2ImageAgent } from "../types/provider2agent.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export type ReplicateImageAgentConfig = AgentConfig;
 
@@ -73,7 +74,7 @@ export const imageReplicateAgent: AgentFunction<ReplicateImageAgentParams, Agent
       });
     }
 
-    const imageResponse = await fetch(imageUrl);
+    const imageResponse = await safeFetch(imageUrl, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
     if (!imageResponse.ok) {
       throw new Error(`Error downloading image: ${imageResponse.status} - ${imageResponse.statusText}`, {
         cause: agentGenerationError("imageReplicateAgent", imageAction, imageFileTarget),

--- a/src/agents/lipsync_replicate_agent.ts
+++ b/src/agents/lipsync_replicate_agent.ts
@@ -16,6 +16,7 @@ import {
 import type { AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentParams, ReplicateLipSyncAgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, AgentBufferResult, LipSyncAgentInputs, ReplicateLipSyncAgentConfig> = async ({
   namedInputs,
@@ -90,7 +91,7 @@ export const lipSyncReplicateAgent: AgentFunction<ReplicateLipSyncAgentParams, A
 
     if (output && typeof output === "object" && "url" in output) {
       const videoUrl = ((output as { url: unknown }).url as () => URL)();
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/media_mock_agent.ts
+++ b/src/agents/media_mock_agent.ts
@@ -1,6 +1,7 @@
 import { AgentFunction, AgentFunctionInfo, GraphAILogger } from "graphai";
 import fs from "fs";
 import { silent60secPath, mulmoCreditPath } from "../utils/file.js";
+import { safeFetch, FETCH_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const mediaMockAgent: AgentFunction = async ({ namedInputs }) => {
   if (namedInputs.media === "audio") {
@@ -13,7 +14,7 @@ export const mediaMockAgent: AgentFunction = async ({ namedInputs }) => {
   }
   if (namedInputs.media === "movie") {
     const url = "https://github.com/receptron/mulmocast-media/raw/refs/heads/main/test/pingpong.mov";
-    const res = await fetch(url);
+    const res = await safeFetch(url, {}, FETCH_DOWNLOAD_TIMEOUT_MS);
     if (!res.ok) {
       throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
     }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -17,6 +17,7 @@ import type { AgentBufferResult, MovieAgentInputs, ReplicateMovieAgentParams, Re
 import type { AgentUsage } from "../types/usage.js";
 import { provider2MovieAgent, getModelDuration, AUDIO_MODE_OPTIONAL, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 function replicate_get_videoUrl(output: unknown): string | URL | undefined {
   if (typeof output === "string") return output;
@@ -122,7 +123,7 @@ async function generateMovie(
     // Some models return a FileOutput object with a url() method; others return a plain string URL.
     const videoUrl = replicate_get_videoUrl(output);
     if (videoUrl) {
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/sound_effect_replicate_agent.ts
+++ b/src/agents/sound_effect_replicate_agent.ts
@@ -67,7 +67,10 @@ export const soundEffectReplicateAgent: AgentFunction<
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to generate sound effect with Replicate", {
+    // Preserve the underlying message (e.g. a safeFetch timeout) rather than
+    // collapsing every failure to a static label. (Same template as #1452.)
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to generate sound effect with Replicate: ${detail}`, {
       cause: agentGenerationError("soundEffectReplicateAgent", imageAction, movieFileTarget),
     });
   }

--- a/src/agents/sound_effect_replicate_agent.ts
+++ b/src/agents/sound_effect_replicate_agent.ts
@@ -8,6 +8,7 @@ import { apiKeyMissingError, agentGenerationError, imageAction, movieFileTarget,
 import type { AgentBufferResult, SoundEffectAgentInputs, ReplicateSoundEffectAgentParams, ReplicateSoundEffectAgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 import { runReplicateWithMetrics } from "../utils/replicate_usage.js";
+import { safeFetch, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const soundEffectReplicateAgent: AgentFunction<
   ReplicateSoundEffectAgentParams,
@@ -48,7 +49,7 @@ export const soundEffectReplicateAgent: AgentFunction<
 
     if (output && typeof output === "object" && "url" in output) {
       const videoUrl = ((output as { url: unknown }).url as () => URL)();
-      const videoResponse = await fetch(videoUrl);
+      const videoResponse = await safeFetch(videoUrl, {}, FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS);
 
       if (!videoResponse.ok) {
         throw new Error(`Error downloading video: ${videoResponse.status} - ${videoResponse.statusText}`, {

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -11,6 +11,7 @@ import {
 } from "../utils/error_cause.js";
 import type { ElevenlabsTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
+import { safeFetch, FETCH_API_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -46,15 +47,19 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
 
   const response = await (async () => {
     try {
-      return await fetch(`https://api.elevenlabs.io/v1/text-to-speech/${voice}`, {
-        method: "POST",
-        headers: {
-          Accept: "audio/mpeg",
-          "Content-Type": "application/json",
-          "xi-api-key": apiKey,
+      return await safeFetch(
+        `https://api.elevenlabs.io/v1/text-to-speech/${voice}`,
+        {
+          method: "POST",
+          headers: {
+            Accept: "audio/mpeg",
+            "Content-Type": "application/json",
+            "xi-api-key": apiKey,
+          },
+          body: JSON.stringify(requestBody),
         },
-        body: JSON.stringify(requestBody),
-      });
+        FETCH_API_TIMEOUT_MS,
+      );
     } catch (e) {
       if (suppressError) {
         return {

--- a/src/agents/tts_elevenlabs_agent.ts
+++ b/src/agents/tts_elevenlabs_agent.ts
@@ -86,8 +86,8 @@ export const ttsElevenlabsAgent: AgentFunction<ElevenlabsTTSAgentParams, AgentBu
         cause: agentIncorrectAPIKeyError("ttsElevenlabsAgent", audioAction, audioFileTarget),
       });
     }
-    const errorDetail = await response.json();
-    if (errorDetail.detail.status === "voice_limit_reached") {
+    const errorDetail = await response.json<{ detail?: { status?: string } }>();
+    if (errorDetail.detail?.status === "voice_limit_reached") {
       throw new Error("Failed to generate audio: 400 You have reached your maximum amount of custom voices with ElevenLabs", {
         cause: agentVoiceLimitReachedError("ttsElevenlabsAgent", audioAction, audioFileTarget),
       });

--- a/src/agents/tts_kotodama_agent.ts
+++ b/src/agents/tts_kotodama_agent.ts
@@ -56,7 +56,7 @@ export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBuffer
     }
 
     // Response is JSON with base64-encoded audio in "audios" array
-    const json = await response.json();
+    const json = await response.json<{ audios?: string[] }>();
     if (!json.audios || !json.audios[0]) {
       throw new Error("TTS Kotodama Error: No audio data in response", {
         cause: agentGenerationError("ttsKotodamaAgent", audioAction, audioFileTarget),
@@ -85,7 +85,10 @@ export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBuffer
       throw error;
     }
 
-    throw new Error("TTS Kotodama Error", {
+    // Preserve the underlying message (e.g. a safeFetch timeout) rather than
+    // collapsing every failure to a static label. (Same template as #1452.)
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`TTS Kotodama Error: ${detail}`, {
       cause: agentGenerationError("ttsKotodamaAgent", audioAction, audioFileTarget),
     });
   }

--- a/src/agents/tts_kotodama_agent.ts
+++ b/src/agents/tts_kotodama_agent.ts
@@ -4,6 +4,7 @@ import { provider2TTSAgent } from "../types/provider2agent.js";
 import { apiKeyMissingError, agentIncorrectAPIKeyError, agentGenerationError, audioAction, audioFileTarget } from "../utils/error_cause.js";
 import type { KotodamaTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult, AgentConfig } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
+import { safeFetch, FETCH_API_TIMEOUT_MS } from "../utils/fetch.js";
 
 export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBufferResult | AgentErrorResult, AgentTextInputs, AgentConfig> = async ({
   namedInputs,
@@ -29,14 +30,18 @@ export const ttsKotodamaAgent: AgentFunction<KotodamaTTSAgentParams, AgentBuffer
   };
 
   try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-API-Key": apiKey,
+    const response = await safeFetch(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": apiKey,
+        },
+        body: JSON.stringify(body),
       },
-      body: JSON.stringify(body),
-    });
+      FETCH_API_TIMEOUT_MS,
+    );
 
     if (!response.ok) {
       if (response.status === 401) {

--- a/src/methods/mulmo_media_source.ts
+++ b/src/methods/mulmo_media_source.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import { GraphAILogger, assert } from "graphai";
 import type { MulmoMediaSource, MulmoMediaMermaidSource, MulmoStudioContext, ImageType } from "../types/index.js";
 import { getFullPath, getReferenceImagePath, resolveAssetPath } from "../utils/file.js";
+import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../utils/fetch.js";
 import {
   downLoadReferenceImageError,
   getTextError,
@@ -29,7 +30,7 @@ export const getExtention = (contentType: string | null, url: string) => {
 };
 
 const downLoadReferenceImage = async (context: MulmoStudioContext, key: string, url: string) => {
-  const response = await fetch(url);
+  const response = await safeFetch(url);
 
   assert(response.ok, `Failed to download reference image: ${url}`, false, downLoadReferenceImageError(key, url));
   const buffer = Buffer.from(await response.arrayBuffer());
@@ -54,26 +55,20 @@ function pluginSourceFixExtention(path: string, imageType: ImageType) {
 
 // end of util
 
-const DEFAULT_FETCH_TIMEOUT_MS = 30000;
-
 // Convert URL to data URL (base64 encoded)
 const urlToDataUrl = async (url: string, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<string> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
   try {
-    const response = await fetch(url, { signal: controller.signal });
+    const response = await safeFetch(url, {}, timeoutMs);
     assert(response.ok, `Failed to fetch: ${url}`, false, mediaSourceToDataUrlError(url));
     const buffer = Buffer.from(await response.arrayBuffer());
     const contentType = response.headers.get("content-type") || "image/png";
     return `data:${contentType};base64,${buffer.toString("base64")}`;
   } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Fetch timeout: ${url}`, { cause: mediaSourceToDataUrlError(url) });
+    // assert() failures already carry the structured cause — keep it as-is.
+    if (error instanceof Error && error.cause) {
+      throw error;
     }
-    throw new Error(`Fetch failed: ${url}`, { cause: mediaSourceToDataUrlError(url) });
-  } finally {
-    clearTimeout(timeoutId);
+    throw new Error(`Fetch failed: ${url}: ${error instanceof Error ? error.message : String(error)}`, { cause: mediaSourceToDataUrlError(url) });
   }
 };
 
@@ -112,7 +107,7 @@ export const MulmoMediaSourceMethods = {
       return mediaSource.text;
     }
     if (mediaSource.kind === "url") {
-      const response = await fetch(mediaSource.url);
+      const response = await safeFetch(mediaSource.url);
       assert(response.ok, `Failed to download mermaid code text: ${mediaSource.url}`, false, getTextError(mediaSource.url)); // TODO: index
       return await response.text();
     }
@@ -145,7 +140,7 @@ export const MulmoMediaSourceMethods = {
 
   async imagePluginSource(mediaSource: MulmoMediaSource, context: MulmoStudioContext, expectImagePath: string, imageType: ImageType) {
     if (mediaSource.kind === "url") {
-      const response = await fetch(mediaSource.url);
+      const response = await safeFetch(mediaSource.url);
       assert(response.ok, `Failed to download image plugin: ${imageType} ${mediaSource.url}`, false, downloadImagePluginError(mediaSource.url, imageType)); // TODO: key, id, index
       const buffer = Buffer.from(await response.arrayBuffer());
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,46 @@
+// Timeout budgets for the different kinds of network waits. Generous safety
+// nets against a stalled socket — NOT tight deadlines — so legitimate slow
+// responses still succeed while a genuine hang becomes a rejection.
+export const DEFAULT_FETCH_TIMEOUT_MS = 30_000; // small assets (reference/background images, JSON)
+export const FETCH_DOWNLOAD_TIMEOUT_MS = 60_000; // generated image download
+export const FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS = 180_000; // large video/audio download
+export const FETCH_API_TIMEOUT_MS = 120_000; // generation API POST (e.g. TTS text -> audio)
+
+// Statuses that fetch can surface whose Response must not carry a body
+// (constructing `new Response(body, { status })` with a body throws). 1xx
+// statuses are excluded: fetch never surfaces them as a final response, and
+// `new Response(null, { status: 101 })` itself throws (valid range is 200-599).
+const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+
+/**
+ * fetch() with an AbortController timeout that covers the whole exchange —
+ * headers AND body.
+ *
+ * A stalled connection otherwise yields a promise that never resolves or
+ * rejects; callers relying on GraphAI `retry` never recover because retry only
+ * fires on rejection. The body is buffered under the same deadline (callers
+ * already read it eagerly via arrayBuffer()/json()/text(), so memory behavior
+ * is unchanged) — otherwise a server that sends headers and then stalls
+ * mid-body would hang the caller's body read instead. Returns a Response backed
+ * by the buffered bytes so callers keep using .ok/.status/.headers/.arrayBuffer().
+ */
+export const safeFetch = async (url: string | URL, init: Parameters<typeof fetch>[1] = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response> => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { ...init, signal: controller.signal });
+    const body = await response.arrayBuffer();
+    return new Response(NULL_BODY_STATUSES.has(response.status) ? null : body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Fetch timeout after ${timeoutMs}ms: ${url}`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -6,11 +6,19 @@ export const FETCH_DOWNLOAD_TIMEOUT_MS = 60_000; // generated image download
 export const FETCH_MEDIA_DOWNLOAD_TIMEOUT_MS = 180_000; // large video/audio download
 export const FETCH_API_TIMEOUT_MS = 120_000; // generation API POST (e.g. TTS text -> audio)
 
-// Statuses that fetch can surface whose Response must not carry a body
-// (constructing `new Response(body, { status })` with a body throws). 1xx
-// statuses are excluded: fetch never surfaces them as a final response, and
-// `new Response(null, { status: 101 })` itself throws (valid range is 200-599).
-const NULL_BODY_STATUSES = new Set([204, 205, 304]);
+// The subset of the fetch Response that callers use. The body is read once, up
+// front, so these accessors never touch the network again (no second download
+// or extra copy) — unlike reconstructing a `new Response(buffer)`, which would
+// buffer the payload a second time.
+export type SafeFetchResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: { get(name: string): string | null };
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+};
 
 /**
  * fetch() with an AbortController timeout that covers the whole exchange —
@@ -18,23 +26,36 @@ const NULL_BODY_STATUSES = new Set([204, 205, 304]);
  *
  * A stalled connection otherwise yields a promise that never resolves or
  * rejects; callers relying on GraphAI `retry` never recover because retry only
- * fires on rejection. The body is buffered under the same deadline (callers
- * already read it eagerly via arrayBuffer()/json()/text(), so memory behavior
- * is unchanged) — otherwise a server that sends headers and then stalls
- * mid-body would hang the caller's body read instead. Returns a Response backed
- * by the buffered bytes so callers keep using .ok/.status/.headers/.arrayBuffer().
+ * fires on rejection. The body is read once under the same deadline (a server
+ * that sends headers and then stalls mid-body would otherwise hang the caller's
+ * body read), and the bytes are handed back through a lightweight result so the
+ * caller does not buffer them a second time. An optional caller `signal` is
+ * composed with the timeout so upstream cancellation still works.
  */
-export const safeFetch = async (url: string | URL, init: Parameters<typeof fetch>[1] = {}, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<Response> => {
+export const safeFetch = async (
+  url: string | URL,
+  init: Parameters<typeof fetch>[1] = {},
+  timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
+): Promise<SafeFetchResponse> => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const externalSignal = init?.signal ?? undefined;
+  const forwardAbort = () => controller.abort();
+  externalSignal?.addEventListener("abort", forwardAbort, { once: true });
+  if (externalSignal?.aborted) controller.abort();
   try {
     const response = await fetch(url, { ...init, signal: controller.signal });
     const body = await response.arrayBuffer();
-    return new Response(NULL_BODY_STATUSES.has(response.status) ? null : body, {
+    const decode = () => new TextDecoder().decode(body);
+    return {
+      ok: response.ok,
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,
-    });
+      arrayBuffer: async () => body,
+      text: async () => decode(),
+      json: async <T = unknown>(): Promise<T> => JSON.parse(decode()),
+    };
   } catch (error) {
     if (error instanceof Error && error.name === "AbortError") {
       throw new Error(`Fetch timeout after ${timeoutMs}ms: ${url}`);
@@ -42,5 +63,6 @@ export const safeFetch = async (url: string | URL, init: Parameters<typeof fetch
     throw error;
   } finally {
     clearTimeout(timeoutId);
+    externalSignal?.removeEventListener("abort", forwardAbort);
   }
 };

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -11,6 +11,7 @@ import { PDFMode } from "../types/index.js";
 import { z, ZodSchema, ZodType } from "zod";
 import { getMulmoScriptTemplateSystemPrompt } from "./prompt.js";
 import { resolveAssetFile } from "./asset_import.js";
+import { safeFetch } from "./fetch.js";
 
 const promptTemplateDirName = "./assets/templates";
 const scriptTemplateDirName = "./scripts/templates";
@@ -75,7 +76,7 @@ export function readMulmoScriptFile<T = MulmoScript>(
 }
 export const fetchMulmoScriptFile = async (url: string): Promise<{ result: boolean; script?: MulmoScript; status: string | number }> => {
   try {
-    const res = await fetch(url);
+    const res = await safeFetch(url);
     if (!res.ok) {
       return { result: false, status: res.status };
     }

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -1,8 +1,7 @@
 import { BackgroundImage, MulmoStudioContext, ImageProcessorParams } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 import { resolveStyle } from "./utils.js";
-
-const DEFAULT_FETCH_TIMEOUT_MS = 30000;
+import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../fetch.js";
 
 /**
  * Resolve background image from beat level and global level settings.
@@ -32,25 +31,13 @@ export const resolveBackgroundImage = (
  * Fetch URL and convert to data URL with timeout
  */
 const fetchUrlAsDataUrl = async (url: string, timeoutMs = DEFAULT_FETCH_TIMEOUT_MS): Promise<string> => {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    const response = await fetch(url, { signal: controller.signal });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch background image: ${url} (${response.status})`);
-    }
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const contentType = response.headers.get("content-type") || "image/png";
-    return `data:${contentType};base64,${buffer.toString("base64")}`;
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") {
-      throw new Error(`Fetch timeout for background image: ${url}`);
-    }
-    throw error;
-  } finally {
-    clearTimeout(timeoutId);
+  const response = await safeFetch(url, {}, timeoutMs);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch background image: ${url} (${response.status})`);
   }
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const contentType = response.headers.get("content-type") || "image/png";
+  return `data:${contentType};base64,${buffer.toString("base64")}`;
 };
 
 /**

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -1,0 +1,119 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { safeFetch } from "../../src/utils/fetch.js";
+
+const SLOW_RESPONSE_MS = 250;
+
+let server: http.Server;
+let baseUrl: string;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url === "/fast") {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    } else if (req.url === "/slow") {
+      // Responds after a delay — used to prove one call's timeout abort does
+      // not cancel another concurrent, still-in-budget request.
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("slow-ok");
+      }, SLOW_RESPONSE_MS);
+    } else if (req.url === "/headers-then-hang") {
+      // Send headers (promising a body via content-length) and a partial chunk,
+      // then never finish — exercises a mid-body stall.
+      res.writeHead(200, { "content-type": "application/octet-stream", "content-length": "1000" });
+      res.write("partial");
+    }
+    // Any other path (e.g. "/hang"): intentionally never respond, to exercise the timeout path.
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test("safeFetch resolves on a normal response", async () => {
+  const res = await safeFetch(`${baseUrl}/fast`);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "ok");
+});
+
+test("safeFetch rejects with a timeout error when the server never responds", async () => {
+  await assert.rejects(
+    () => safeFetch(`${baseUrl}/hang`, {}, 100),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Fetch timeout after 100ms/);
+      return true;
+    },
+  );
+});
+
+test("safeFetch times out when the body stalls after headers are sent", async () => {
+  await assert.rejects(
+    () => safeFetch(`${baseUrl}/headers-then-hang`, {}, 120),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /Fetch timeout after 120ms/);
+      return true;
+    },
+  );
+});
+
+test("safeFetch propagates non-timeout network errors (not as a timeout)", async () => {
+  // Nothing listening on port 1 -> connection refused, well before the timeout.
+  await assert.rejects(
+    () => safeFetch("http://127.0.0.1:1/nope", {}, 5000),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.doesNotMatch(error.message, /Fetch timeout/);
+      return true;
+    },
+  );
+});
+
+// --- Concurrency safety: each call owns its AbortController + timer, so calls
+// running in parallel (the image pipeline uses concurrency: 4) must not
+// interfere with one another. ---
+
+test("concurrent safeFetch timeouts each fire at their own budget (no cross-talk)", async () => {
+  const budgets = [60, 90, 120, 150, 180, 210];
+  const results = await Promise.allSettled(budgets.map((ms) => safeFetch(`${baseUrl}/hang`, {}, ms)));
+
+  results.forEach((result, index) => {
+    assert.equal(result.status, "rejected", `call ${index} should have timed out`);
+    const reason = (result as PromiseRejectedResult).reason;
+    assert.ok(reason instanceof Error);
+    // Each rejection must carry its OWN budget — proof the timers/controllers are independent.
+    assert.match(reason.message, new RegExp(`Fetch timeout after ${budgets[index]}ms`));
+  });
+});
+
+test("a concurrent timeout does not abort another in-flight request", async () => {
+  // The slow request (2s budget, responds at 250ms) runs alongside several
+  // short-budget hangs that abort at ~80ms. If aborts leaked across calls, the
+  // slow request would be cancelled too.
+  const slow = safeFetch(`${baseUrl}/slow`, {}, 2000);
+  const hangs = Array.from({ length: 4 }, () => safeFetch(`${baseUrl}/hang`, {}, 80));
+
+  const hangResults = await Promise.allSettled(hangs);
+  hangResults.forEach((result) => assert.equal(result.status, "rejected"));
+
+  const res = await slow;
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), "slow-ok");
+});
+
+test("many concurrent successful fetches all resolve independently", async () => {
+  const responses = await Promise.all(Array.from({ length: 20 }, () => safeFetch(`${baseUrl}/fast`)));
+  const texts = await Promise.all(responses.map((r) => r.text()));
+  assert.ok(texts.every((t) => t === "ok"));
+});

--- a/test/utils/test_fetch.ts
+++ b/test/utils/test_fetch.ts
@@ -80,6 +80,13 @@ test("safeFetch propagates non-timeout network errors (not as a timeout)", async
   );
 });
 
+test("safeFetch honors a caller-provided abort signal (composition)", async () => {
+  const controller = new AbortController();
+  const pending = safeFetch(`${baseUrl}/hang`, { signal: controller.signal }, 5000);
+  controller.abort();
+  await assert.rejects(pending, (error: unknown) => error instanceof Error);
+});
+
 // --- Concurrency safety: each call owns its AbortController + timer, so calls
 // running in parallel (the image pipeline uses concurrency: 4) must not
 // interfere with one another. ---


### PR DESCRIPTION
## Summary

Part 1 of 6 splitting #1475 (superseded) into small, independently-reviewable PRs. Umbrella issue: #1474.

Bare `fetch()` calls have **no timeout**, so a stalled connection yields a promise that never resolves *or* rejects. GraphAI's image node has `retry: 2`, but retry only fires on **rejection** — a hang never rejects, so the whole pipeline waits forever ("stuck partway through image generation"; killing + restarting completes it from cache).

## What this PR does

- Adds `src/utils/fetch.ts` `safeFetch(url, init?, timeoutMs?)`: `fetch` bounded by an `AbortController` over the **whole exchange** — headers *and* body (the body is buffered under the same deadline, so a server that sends headers then stalls mid-body can't hang the caller's `arrayBuffer()`/`json()`/`text()`). Returns a `Response` backed by the buffered bytes.
- Routes **all 13 bare `fetch()`** call sites through it (image/movie/lipsync/sound-effect downloads, ElevenLabs/Kotodama TTS POSTs, reference-image / mermaid / image-plugin fetches, PDF image, BGM download, remote MulmoScript, mock).
- Consolidates the two hand-rolled timeout wrappers (`bg_image_util`, `mulmo_media_source`) onto `safeFetch` (DRY).

Category-based named timeout constants (30s small assets / 60s image download / 180s media download / 120s API POST) — generous safety nets, not tight deadlines. Normal success path unchanged.

## Items to Confirm / Review
- `safeFetch` buffers the body under the timeout (intentional: bounds the entire exchange; callers already read the body eagerly, so memory is unchanged).
- Error-cause / i18n preserved at each call site (each keeps its own `assert(response.ok, …, cause)` / `throw … { cause }`).

## Testing
`test/utils/test_fetch.ts` (local http server, no network/keys): normal response, header stall, **body stall after headers**, non-timeout error passthrough, and **concurrency** (staggered parallel timeouts each fire at their own budget; one timeout does not abort another in-flight request; many concurrent successes). `yarn lint` (0 errors), `yarn build`, fetch tests 7/7.

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added consistent, abort-based network timeouts for media downloads, remote image loading, and TTS requests.
  - Prevented stalled network operations from hanging indefinitely by converting timeouts into proper failures that trigger existing retry/error paths.
  - Improved error messaging and parsing for TTS edge cases and background-image fetch failures.

- **Documentation**
  - Added a plan detailing network-timeout hardening for media generation.

- **Tests**
  - Added a comprehensive test suite for the new safeFetch behavior, including success, timeouts, stalled responses, abort handling, and concurrent isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->