### PR TITLE
fix: explicit request timeout on OpenAI client (2/6)

### DIFF
--- a/src/utils/openai_client.ts
+++ b/src/utils/openai_client.ts
@@ -1,5 +1,10 @@
 import OpenAI, { AzureOpenAI } from "openai";
 
+// Explicit per-request timeout so a stalled connection rejects (and the SDK's
+// default maxRetries=2 re-issues it) instead of hanging on the SDK's 10-minute
+// default. gpt-image-1 generation is typically well under this.
+const OPENAI_REQUEST_TIMEOUT_MS = 120_000;
+
 export interface OpenAIClientOptions {
   apiKey?: string;
   baseURL?: string;
@@ -33,11 +38,13 @@ export const createOpenAIClient = (options: OpenAIClientOptions): OpenAI => {
       apiKey,
       endpoint: baseURL,
       apiVersion: apiVersion ?? "2025-04-01-preview",
+      timeout: OPENAI_REQUEST_TIMEOUT_MS,
     });
   }
 
   return new OpenAI({
     apiKey,
     baseURL,
+    timeout: OPENAI_REQUEST_TIMEOUT_MS,
   });
 };


### PR DESCRIPTION
## Summary

Part 2 of 6 splitting #1475 (superseded). Umbrella issue: #1474.

**This is the direct fix for the reported bug.** `movie`/`images` with the default OpenAI image model (`gpt-image-1`) could hang partway through image generation with no error; killing + restarting completed it from cache.

## What this PR does

`createOpenAIClient` created the client with no explicit `timeout`, so it relied on the OpenAI SDK's 10-minute default. When `openai.images.generate(...)` stalls on a dead socket, the request neither resolves nor rejects promptly, so GraphAI's `retry: 2` (which only fires on rejection) never recovers. This sets an explicit **120s** request timeout (keeping the SDK default `maxRetries: 2`) so a stall rejects and is retried. Applies to both the standard and Azure clients (image + TTS).

`gpt-image-1` generation is typically well under 120s; with the SDK's retries the effective ceiling is higher.

## Testing
`yarn lint` (0 errors), `yarn build`. One-file, low-risk change (a client option).

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)