### PR TITLE
fix: timeout for replicate.run() (3/6)

### DIFF
--- a/src/utils/replicate_usage.ts
+++ b/src/utils/replicate_usage.ts
@@ -1,19 +1,38 @@
 import type Replicate from "replicate";
 import type { Prediction } from "replicate";
 
+// Generous safety net against a stalled run — video models (seedance/kling)
+// legitimately run for minutes — not a tight deadline.
+const REPLICATE_RUN_TIMEOUT_MS = 600_000;
+
 // Capture Replicate's exact billed seconds (`metrics.predict_time`) via the
 // progress callback on `replicate.run()`. Avoids switching the four
 // replicate agents from `.run()` to `predictions.create()` + poll, which
 // would be a much bigger blast radius.
+//
+// A timeout aborts the run so a stalled job rejects (and the caller's GraphAI
+// `retry` can recover) instead of hanging forever. An optional caller `signal`
+// is composed with the timeout so upstream cancellation still works.
 export const runReplicateWithMetrics = async (
   replicate: Replicate,
   identifier: `${string}/${string}` | `${string}/${string}:${string}`,
   input: object,
-  signal?: AbortSignal,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {},
 ): Promise<{ output: unknown; predictSec?: number }> => {
+  const { timeoutMs = REPLICATE_RUN_TIMEOUT_MS, signal: externalSignal } = options;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const forwardAbort = () => controller.abort();
+  externalSignal?.addEventListener("abort", forwardAbort, { once: true });
+  if (externalSignal?.aborted) controller.abort();
   let lastPrediction: Prediction | undefined;
-  const output = await replicate.run(identifier, { input, signal }, (prediction) => {
-    lastPrediction = prediction;
-  });
-  return { output, predictSec: lastPrediction?.metrics?.predict_time };
+  try {
+    const output = await replicate.run(identifier, { input, signal: controller.signal }, (prediction) => {
+      lastPrediction = prediction;
+    });
+    return { output, predictSec: lastPrediction?.metrics?.predict_time };
+  } finally {
+    clearTimeout(timeoutId);
+    externalSignal?.removeEventListener("abort", forwardAbort);
+  }
 };


### PR DESCRIPTION
## Summary

Part 3 of 6 splitting #1475 (superseded). Umbrella issue: #1474.

`runReplicateWithMetrics` awaited `replicate.run()` with no timeout, so a stalled Replicate job (image/movie/lipsync/sound-effect) never rejects and the caller's GraphAI `retry` cannot recover.

## What this PR does

- Adds an internal `AbortController` timeout (**600s** — generous, since seedance/kling video jobs legitimately run for minutes) so a stall rejects.
- Accepts an optional caller `signal` and composes it with the timeout, preserving upstream cancellation composability.
- Existing 3-arg call sites (the four replicate agents) are unchanged — `options` defaults to `{}`.

Timeout constant is defined locally in this file so the PR is independent of the other timeout PRs.

## Testing
`yarn lint` (0 errors), `yarn build`. One-file change; backward-compatible signature.

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection for Replicate operations, preventing runs from hanging indefinitely.
  * External cancellation requests are now handled reliably.
  * Captures final prediction usage metrics when available.
  * Improves cleanup after completed, cancelled, or timed-out operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->