### PR TITLE
fix: per-request timeout for GenAI image generation (4/6)

### DIFF
--- a/src/agents/image_genai_agent.ts
+++ b/src/agents/image_genai_agent.ts
@@ -25,6 +25,10 @@ import type { AgentBufferResult, ImageAgentInputs, ImageAgentParams, GenAIImageA
 import type { AgentUsage } from "../types/usage.js";
 import { GoogleGenAI, PersonGeneration, GenerateContentResponse } from "@google/genai";
 
+// Per-request timeout so a stalled GenAI image call rejects (and GraphAI retry
+// can recover) instead of hanging. Generous vs. normal generation time.
+const GENAI_REQUEST_TIMEOUT_MS = 120_000;
+
 const isDeprecatedGoogleImageModel = (model: string): model is DeprecatedGoogleImageModel => model in deprecatedGoogleImageModelHints;
 
 export const buildDeprecatedGoogleImageModelMessage = (model: string): string | null => {
@@ -116,7 +120,7 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
             `imageGenAIAgent: model "${model}" on Vertex AI is only available in location "global", but got "${location}". Set imageParams.vertexai_location to "global".`,
           );
         }
-        return new GoogleGenAI({ vertexai: true, project: params.vertexai_project, location });
+        return new GoogleGenAI({ vertexai: true, project: params.vertexai_project, location, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       })()
     : (() => {
         if (!apiKey) {
@@ -127,7 +131,7 @@ export const imageGenAIAgent: AgentFunction<ImageAgentParams, AgentBufferResult,
             },
           );
         }
-        return new GoogleGenAI({ apiKey });
+        return new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       })();
 
   if (model === "gemini-2.5-flash-image" || model === "gemini-3.1-flash-image-preview" || model === "gemini-3-pro-image-preview") {


### PR DESCRIPTION
## Summary

Part 4 of 6 splitting #1475 (superseded). Umbrella issue: #1474.

`new GoogleGenAI(...)` in the image agent had no `httpOptions.timeout`, so a stalled Gemini/Imagen image call could hang without rejecting, defeating GraphAI's `retry`.

## What this PR does

Adds `httpOptions: { timeout: 120s }` to both the Vertex AI and Gemini API `GoogleGenAI` clients in `image_genai_agent.ts`. Bounds each individual API call. Constant defined locally so the PR is independent.

## Testing
`yarn lint` (0 errors), `yarn build`. One-file change.

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)