### PR TITLE
fix: per-request timeout for GenAI (Gemini) TTS (5/6)

### DIFF
--- a/src/agents/tts_gemini_agent.ts
+++ b/src/agents/tts_gemini_agent.ts
@@ -13,6 +13,10 @@ import {
 } from "../utils/error_cause.js";
 import { pcmToMp3 } from "../utils/ffmpeg_utils.js";
 
+// Per-request timeout so a stalled GenAI TTS call rejects (and GraphAI retry can
+// recover) instead of hanging. Generous vs. normal generation time.
+const GENAI_REQUEST_TIMEOUT_MS = 120_000;
+
 import type { GoogleTTSAgentParams, AgentBufferResult, AgentTextInputs, AgentErrorResult } from "../types/agent.js";
 import type { AgentUsage } from "../types/usage.js";
 
@@ -41,7 +45,7 @@ export const ttsGeminiAgent: AgentFunction<GoogleTTSAgentParams, AgentBufferResu
 
   const geminiResult: { rawPcm: Buffer; sampleRate: number; usage: AgentUsage | undefined } | AgentErrorResult = await (async () => {
     try {
-      const ai = new GoogleGenAI({ apiKey });
+      const ai = new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
       const response = await ai.models.generateContent({
         model: model ?? provider2TTSAgent.gemini.defaultModel,
         contents: [{ parts: [{ text: getPrompt(text, instructions) }] }],


### PR DESCRIPTION
## Summary

Part 5 of 6 splitting #1475 (superseded). Umbrella issue: #1474.

`new GoogleGenAI(...)` in the Gemini TTS agent had no `httpOptions.timeout`, so a stalled `generateContent` call could hang without rejecting, defeating GraphAI's `retry`.

## What this PR does

Adds `httpOptions: { timeout: 120s }` to the `GoogleGenAI` client in `tts_gemini_agent.ts`. Constant defined locally so the PR is independent.

## Testing
`yarn lint` (0 errors), `yarn build`. One-file change.

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)