### PR TITLE
fix: bound GenAI video generation — request timeout + poll cap + error detail (6/6)

### DIFF
--- a/src/agents/movie_genai_agent.ts
+++ b/src/agents/movie_genai_agent.ts
@@ -20,6 +20,11 @@ import type { AgentBufferResult, GenAIImageAgentConfig, GoogleMovieAgentParams, 
 import type { AgentUsage } from "../types/usage.js";
 import { getModelDuration, provider2MovieAgent, AUDIO_MODE_NEVER, AUDIO_MODE_ALWAYS } from "../types/provider2agent.js";
 
+// Per-request timeout so a stalled GenAI video API call rejects instead of hanging.
+const GENAI_REQUEST_TIMEOUT_MS = 120_000;
+// Wall-clock cap on the long-running video operation poll loop (Veo runs minutes).
+const VIDEO_POLL_TIMEOUT_MS = 1_200_000;
+
 type ImagePayload = { imageBytes: string; mimeType: string };
 
 type VideoPayload = {
@@ -40,7 +45,13 @@ type VideoPayload = {
 
 const pollUntilDone = async (ai: GoogleGenAI, operation: GenerateVideosOperation) => {
   const response = { operation };
+  const deadline = Date.now() + VIDEO_POLL_TIMEOUT_MS;
   while (!response.operation.done) {
+    if (Date.now() > deadline) {
+      throw new Error(`Video generation did not complete within ${VIDEO_POLL_TIMEOUT_MS}ms`, {
+        cause: agentGenerationError("movieGenAIAgent", imageAction, movieFileTarget),
+      });
+    }
     await sleep(5000);
     response.operation = await ai.operations.getVideosOperation(response);
   }
@@ -278,6 +289,7 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
           vertexai: true,
           project: params.vertexai_project,
           location: params.vertexai_location ?? "us-central1",
+          httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS },
         })
       : (() => {
           if (!apiKey) {
@@ -288,7 +300,7 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
               },
             );
           }
-          return new GoogleGenAI({ apiKey });
+          return new GoogleGenAI({ apiKey, httpOptions: { timeout: GENAI_REQUEST_TIMEOUT_MS } });
         })();
 
     // Veo 3.1: Video extension mode for videos longer than 8s
@@ -299,11 +311,14 @@ export const movieGenAIAgent: AgentFunction<GoogleMovieAgentParams, AgentBufferR
     // Standard mode
     return generateStandardVideo(ai, model, prompt, aspectRatio, imagePath, lastFrameImagePath, referenceImages, duration, movieFile, isVertexAI);
   } catch (error) {
-    GraphAILogger.info("Failed to generate movie:", (error as Error).message);
     if (hasCause(error) && error.cause) {
       throw error;
     }
-    throw new Error("Failed to generate movie with Google GenAI", {
+    GraphAILogger.info("Failed to generate movie:", (error as Error).message);
+    // Preserve the underlying message (e.g. a timeout/abort deadline) instead of
+    // collapsing every failure to a static label. (Same template as #1452.)
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to generate movie with Google GenAI: ${detail}`, {
       cause: agentGenerationError("movieGenAIAgent", imageAction, movieFileTarget),
     });
   }


### PR DESCRIPTION
## Summary

Part 6 of 6 splitting #1475 (superseded). Umbrella issue: #1474.

`movie_genai_agent.ts` had three hang / observability gaps around Google Veo video generation.

## What this PR does

- **Per-request timeout**: `new GoogleGenAI(...)` had no `httpOptions.timeout` → add `{ timeout: 120s }` to both the Vertex AI and Gemini API clients (bounds each `generateVideos` / `getVideosOperation` call).
- **Poll wall-clock cap**: `pollUntilDone` looped forever if the operation never reported `done` → add a **1200s** cap that throws a labeled error (with a structured cause, so it is surfaced rather than collapsed).
- **Error detail**: the generic catch collapsed a timeout/abort into a static label → include the underlying message so a deadline is not lost (`#1452` pattern used by sibling agents).

Constants defined locally so the PR is independent.

## Items to Confirm / Review
- Video-generation timeout values: `GENAI_REQUEST_TIMEOUT_MS = 120s` per API call, `VIDEO_POLL_TIMEOUT_MS = 1200s` overall poll cap — generous vs. real Veo run times.

## Testing
`yarn lint` (0 errors), `yarn build`. One-file change.

Part of #1474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)