### PR TITLE
chore: reduce test function length (data extraction + split)

### DIFF
--- a/test/actions/run_audio.ts
+++ b/test/actions/run_audio.ts
@@ -10,101 +10,102 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const getContext = () => {
-  const fileDirs = getFileObject({ file: "hello.yaml" });
-  const mulmoScript = {
-    $mulmocast: {
-      version: "1.0",
-      credit: "closing",
-    },
-    title: "MASAI: A Modular Future for Software Engineering AI",
-    description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
-    beats: [
-      {
-        id: "beat1",
-        text: "This is a bulleted list in text slide format.",
-        image: {
-          type: "textSlide",
-          slide: {
-            title: "Human Evolution",
-            bullets: [
-              "Early Primates",
-              "Hominids and Hominins",
-              "Australopithecus",
-              "Genus Homo Emerges",
-              "Homo erectus and Migration",
-              "Neanderthals and Other Archaic Humans",
-              "Homo sapiens",
-            ],
-          },
-        },
-      },
-      {
-        text: "This is a table in markdown format.",
-        image: {
-          type: "markdown",
-          markdown: [
-            "# Markdown Table Example",
-            "### Table",
-            "| Item              | In Stock | Price |",
-            "| :---------------- | :------: | ----: |",
-            "| Python Hat        |   True   | 23.99 |",
-            "| SQL Hat           |   True   | 23.99 |",
-            "| Codecademy Tee    |  False   | 19.99 |",
-            "| Codecademy Hoodie |  False   | 42.99 |",
-            "### Paragraph",
-            "This is a paragraph.",
+const testMulmoScript = {
+  $mulmocast: {
+    version: "1.0",
+    credit: "closing",
+  },
+  title: "MASAI: A Modular Future for Software Engineering AI",
+  description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
+  beats: [
+    {
+      id: "beat1",
+      text: "This is a bulleted list in text slide format.",
+      image: {
+        type: "textSlide",
+        slide: {
+          title: "Human Evolution",
+          bullets: [
+            "Early Primates",
+            "Hominids and Hominins",
+            "Australopithecus",
+            "Genus Homo Emerges",
+            "Homo erectus and Migration",
+            "Neanderthals and Other Archaic Humans",
+            "Homo sapiens",
           ],
         },
       },
-      {
-        text: "This is a chart in chart format.",
-        image: {
-          type: "chart",
-          title: "Sales and Profits (from Jan to June)",
-          chartData: {
-            type: "bar",
-            data: {
-              labels: ["January", "February", "March", "April", "May", "June"],
-              datasets: [
-                {
-                  label: "Revenue ($1000s)",
-                  data: [120, 135, 180, 155, 170, 190],
-                  backgroundColor: "rgba(54, 162, 235, 0.5)",
-                  borderColor: "rgba(54, 162, 235, 1)",
-                  borderWidth: 1,
-                },
-                {
-                  label: "Profit ($1000s)",
-                  data: [45, 52, 68, 53, 61, 73],
-                  backgroundColor: "rgba(75, 192, 192, 0.5)",
-                  borderColor: "rgba(75, 192, 192, 1)",
-                  borderWidth: 1,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              animation: false,
-            },
+    },
+    {
+      text: "This is a table in markdown format.",
+      image: {
+        type: "markdown",
+        markdown: [
+          "# Markdown Table Example",
+          "### Table",
+          "| Item              | In Stock | Price |",
+          "| :---------------- | :------: | ----: |",
+          "| Python Hat        |   True   | 23.99 |",
+          "| SQL Hat           |   True   | 23.99 |",
+          "| Codecademy Tee    |  False   | 19.99 |",
+          "| Codecademy Hoodie |  False   | 42.99 |",
+          "### Paragraph",
+          "This is a paragraph.",
+        ],
+      },
+    },
+    {
+      text: "This is a chart in chart format.",
+      image: {
+        type: "chart",
+        title: "Sales and Profits (from Jan to June)",
+        chartData: {
+          type: "bar",
+          data: {
+            labels: ["January", "February", "March", "April", "May", "June"],
+            datasets: [
+              {
+                label: "Revenue ($1000s)",
+                data: [120, 135, 180, 155, 170, 190],
+                backgroundColor: "rgba(54, 162, 235, 0.5)",
+                borderColor: "rgba(54, 162, 235, 1)",
+                borderWidth: 1,
+              },
+              {
+                label: "Profit ($1000s)",
+                data: [45, 52, 68, 53, 61, 73],
+                backgroundColor: "rgba(75, 192, 192, 0.5)",
+                borderColor: "rgba(75, 192, 192, 1)",
+                borderWidth: 1,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            animation: false,
           },
         },
       },
-      {
-        speaker: "Presenter",
-        text: "This is a diagram in mermaid format.",
-        image: {
-          type: "mermaid",
-          title: "Business Process Flow",
-          code: {
-            kind: "text",
-            text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
-          },
+    },
+    {
+      speaker: "Presenter",
+      text: "This is a diagram in mermaid format.",
+      image: {
+        type: "mermaid",
+        title: "Business Process Flow",
+        code: {
+          kind: "text",
+          text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
         },
       },
-    ],
-  };
-  const studio = createStudioData(mulmoScript, "hello");
+    },
+  ],
+};
+
+const getContext = () => {
+  const fileDirs = getFileObject({ file: "hello.yaml" });
+  const studio = createStudioData(testMulmoScript, "hello");
   const context = {
     studio,
     fileDirs,

--- a/test/actions/run_translate.ts
+++ b/test/actions/run_translate.ts
@@ -10,101 +10,102 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const getContext = () => {
-  const fileDirs = getFileObject({ file: "hello.yaml" });
-  const mulmoScript = {
-    $mulmocast: {
-      version: "1.0",
-      credit: "closing",
-    },
-    title: "MASAI: A Modular Future for Software Engineering AI",
-    description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
-    beats: [
-      {
-        text: "This is a bulleted list in text slide format.",
-        image: {
-          type: "textSlide",
-          slide: {
-            title: "Human Evolution",
-            bullets: [
-              "Early Primates",
-              "Hominids and Hominins",
-              "Australopithecus",
-              "Genus Homo Emerges",
-              "Homo erectus and Migration",
-              "Neanderthals and Other Archaic Humans",
-              "Homo sapiens",
-            ],
-          },
-        },
-      },
-      {
-        text: "This is a table in markdown format.",
-        image: {
-          type: "markdown",
-          markdown: [
-            "# Markdown Table Example",
-            "### Table",
-            "| Item              | In Stock | Price |",
-            "| :---------------- | :------: | ----: |",
-            "| Python Hat        |   True   | 23.99 |",
-            "| SQL Hat           |   True   | 23.99 |",
-            "| Codecademy Tee    |  False   | 19.99 |",
-            "| Codecademy Hoodie |  False   | 42.99 |",
-            "### Paragraph",
-            "This is a paragraph.",
+const testMulmoScript = {
+  $mulmocast: {
+    version: "1.0",
+    credit: "closing",
+  },
+  title: "MASAI: A Modular Future for Software Engineering AI",
+  description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
+  beats: [
+    {
+      text: "This is a bulleted list in text slide format.",
+      image: {
+        type: "textSlide",
+        slide: {
+          title: "Human Evolution",
+          bullets: [
+            "Early Primates",
+            "Hominids and Hominins",
+            "Australopithecus",
+            "Genus Homo Emerges",
+            "Homo erectus and Migration",
+            "Neanderthals and Other Archaic Humans",
+            "Homo sapiens",
           ],
         },
       },
-      {
-        text: "This is a chart in chart format.",
-        image: {
-          type: "chart",
-          title: "Sales and Profits (from Jan to June)",
-          chartData: {
-            type: "bar",
-            data: {
-              labels: ["January", "February", "March", "April", "May", "June"],
-              datasets: [
-                {
-                  label: "Revenue ($1000s)",
-                  data: [120, 135, 180, 155, 170, 190],
-                  backgroundColor: "rgba(54, 162, 235, 0.5)",
-                  borderColor: "rgba(54, 162, 235, 1)",
-                  borderWidth: 1,
-                },
-                {
-                  label: "Profit ($1000s)",
-                  data: [45, 52, 68, 53, 61, 73],
-                  backgroundColor: "rgba(75, 192, 192, 0.5)",
-                  borderColor: "rgba(75, 192, 192, 1)",
-                  borderWidth: 1,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              animation: false,
-            },
+    },
+    {
+      text: "This is a table in markdown format.",
+      image: {
+        type: "markdown",
+        markdown: [
+          "# Markdown Table Example",
+          "### Table",
+          "| Item              | In Stock | Price |",
+          "| :---------------- | :------: | ----: |",
+          "| Python Hat        |   True   | 23.99 |",
+          "| SQL Hat           |   True   | 23.99 |",
+          "| Codecademy Tee    |  False   | 19.99 |",
+          "| Codecademy Hoodie |  False   | 42.99 |",
+          "### Paragraph",
+          "This is a paragraph.",
+        ],
+      },
+    },
+    {
+      text: "This is a chart in chart format.",
+      image: {
+        type: "chart",
+        title: "Sales and Profits (from Jan to June)",
+        chartData: {
+          type: "bar",
+          data: {
+            labels: ["January", "February", "March", "April", "May", "June"],
+            datasets: [
+              {
+                label: "Revenue ($1000s)",
+                data: [120, 135, 180, 155, 170, 190],
+                backgroundColor: "rgba(54, 162, 235, 0.5)",
+                borderColor: "rgba(54, 162, 235, 1)",
+                borderWidth: 1,
+              },
+              {
+                label: "Profit ($1000s)",
+                data: [45, 52, 68, 53, 61, 73],
+                backgroundColor: "rgba(75, 192, 192, 0.5)",
+                borderColor: "rgba(75, 192, 192, 1)",
+                borderWidth: 1,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            animation: false,
           },
         },
       },
-      {
-        speaker: "Presenter",
-        text: "This is a diagram in mermaid format.",
-        image: {
-          type: "mermaid",
-          title: "Business Process Flow",
-          code: {
-            kind: "text",
-            text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
-          },
+    },
+    {
+      speaker: "Presenter",
+      text: "This is a diagram in mermaid format.",
+      image: {
+        type: "mermaid",
+        title: "Business Process Flow",
+        code: {
+          kind: "text",
+          text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
         },
       },
-    ],
-  };
+    },
+  ],
+};
+
+const getContext = () => {
+  const fileDirs = getFileObject({ file: "hello.yaml" });
   // context.
-  const studio = createStudioData(mulmoScript, "hello");
+  const studio = createStudioData(testMulmoScript, "hello");
   const multiLingual = getMultiLingual("", studio.beats);
   const context = {
     multiLingual,

--- a/test/actions/test_images.ts
+++ b/test/actions/test_images.ts
@@ -12,100 +12,101 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const getContext = () => {
-  const fileDirs = getFileObject({ file: "hello.yaml" });
-  const mulmoScript = {
-    $mulmocast: {
-      version: "1.0",
-      credit: "closing",
-    },
-    title: "MASAI: A Modular Future for Software Engineering AI",
-    description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
-    beats: [
-      {
-        text: "This is a bulleted list in text slide format.",
-        image: {
-          type: "textSlide",
-          slide: {
-            title: "Human Evolution",
-            bullets: [
-              "Early Primates",
-              "Hominids and Hominins",
-              "Australopithecus",
-              "Genus Homo Emerges",
-              "Homo erectus and Migration",
-              "Neanderthals and Other Archaic Humans",
-              "Homo sapiens",
-            ],
-          },
-        },
-      },
-      {
-        text: "This is a table in markdown format.",
-        image: {
-          type: "markdown",
-          markdown: [
-            "# Markdown Table Example",
-            "### Table",
-            "| Item              | In Stock | Price |",
-            "| :---------------- | :------: | ----: |",
-            "| Python Hat        |   True   | 23.99 |",
-            "| SQL Hat           |   True   | 23.99 |",
-            "| Codecademy Tee    |  False   | 19.99 |",
-            "| Codecademy Hoodie |  False   | 42.99 |",
-            "### Paragraph",
-            "This is a paragraph.",
+const testMulmoScript = {
+  $mulmocast: {
+    version: "1.0",
+    credit: "closing",
+  },
+  title: "MASAI: A Modular Future for Software Engineering AI",
+  description: "Exploring MASAI, a modular approach for AI agents in software engineering that revolutionizes how complex coding issues are tackled.",
+  beats: [
+    {
+      text: "This is a bulleted list in text slide format.",
+      image: {
+        type: "textSlide",
+        slide: {
+          title: "Human Evolution",
+          bullets: [
+            "Early Primates",
+            "Hominids and Hominins",
+            "Australopithecus",
+            "Genus Homo Emerges",
+            "Homo erectus and Migration",
+            "Neanderthals and Other Archaic Humans",
+            "Homo sapiens",
           ],
         },
       },
-      {
-        text: "This is a chart in chart format.",
-        image: {
-          type: "chart",
-          title: "Sales and Profits (from Jan to June)",
-          chartData: {
-            type: "bar",
-            data: {
-              labels: ["January", "February", "March", "April", "May", "June"],
-              datasets: [
-                {
-                  label: "Revenue ($1000s)",
-                  data: [120, 135, 180, 155, 170, 190],
-                  backgroundColor: "rgba(54, 162, 235, 0.5)",
-                  borderColor: "rgba(54, 162, 235, 1)",
-                  borderWidth: 1,
-                },
-                {
-                  label: "Profit ($1000s)",
-                  data: [45, 52, 68, 53, 61, 73],
-                  backgroundColor: "rgba(75, 192, 192, 0.5)",
-                  borderColor: "rgba(75, 192, 192, 1)",
-                  borderWidth: 1,
-                },
-              ],
-            },
-            options: {
-              responsive: true,
-              animation: false,
-            },
+    },
+    {
+      text: "This is a table in markdown format.",
+      image: {
+        type: "markdown",
+        markdown: [
+          "# Markdown Table Example",
+          "### Table",
+          "| Item              | In Stock | Price |",
+          "| :---------------- | :------: | ----: |",
+          "| Python Hat        |   True   | 23.99 |",
+          "| SQL Hat           |   True   | 23.99 |",
+          "| Codecademy Tee    |  False   | 19.99 |",
+          "| Codecademy Hoodie |  False   | 42.99 |",
+          "### Paragraph",
+          "This is a paragraph.",
+        ],
+      },
+    },
+    {
+      text: "This is a chart in chart format.",
+      image: {
+        type: "chart",
+        title: "Sales and Profits (from Jan to June)",
+        chartData: {
+          type: "bar",
+          data: {
+            labels: ["January", "February", "March", "April", "May", "June"],
+            datasets: [
+              {
+                label: "Revenue ($1000s)",
+                data: [120, 135, 180, 155, 170, 190],
+                backgroundColor: "rgba(54, 162, 235, 0.5)",
+                borderColor: "rgba(54, 162, 235, 1)",
+                borderWidth: 1,
+              },
+              {
+                label: "Profit ($1000s)",
+                data: [45, 52, 68, 53, 61, 73],
+                backgroundColor: "rgba(75, 192, 192, 0.5)",
+                borderColor: "rgba(75, 192, 192, 1)",
+                borderWidth: 1,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            animation: false,
           },
         },
       },
-      {
-        speaker: "Presenter",
-        text: "This is a diagram in mermaid format.",
-        image: {
-          type: "mermaid",
-          title: "Business Process Flow",
-          code: {
-            kind: "text",
-            text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
-          },
+    },
+    {
+      speaker: "Presenter",
+      text: "This is a diagram in mermaid format.",
+      image: {
+        type: "mermaid",
+        title: "Business Process Flow",
+        code: {
+          kind: "text",
+          text: "graph LR\n    A[Market Research] --> B[Product Planning]\n    B --> C[Development]\n    C --> D[Testing]\n    D --> E[Manufacturing]\n    E --> F[Marketing]\n    F --> G[Sales]\n    G --> H[Customer Support]\n    H --> A",
         },
       },
-    ],
-  };
-  const studio = createStudioData(mulmoScript, "hello");
+    },
+  ],
+};
+
+const getContext = () => {
+  const fileDirs = getFileObject({ file: "hello.yaml" });
+  const studio = createStudioData(testMulmoScript, "hello");
   const context = {
     studio,
     fileDirs,

--- a/test/actions/test_images_error.ts
+++ b/test/actions/test_images_error.ts
@@ -12,62 +12,62 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const testMulmoScript = {
+  $mulmocast: {
+    version: "1.1",
+  },
+  canvasSize: {
+    width: 1280,
+    height: 720,
+  },
+  speechParams: {
+    speakers: {
+      Presenter: {
+        displayName: {
+          en: "Presenter",
+        },
+        voiceId: "shimmer",
+      },
+    },
+  },
+  imageParams: {
+    provider: "openai",
+    images: {},
+  },
+  soundEffectParams: {
+    provider: "replicate",
+  },
+  audioParams: {
+    padding: 0.3,
+    introPadding: 1,
+    closingPadding: 0.8,
+    outroPadding: 1,
+    bgmVolume: 0.2,
+    audioVolume: 1,
+    suppressSpeech: false,
+  },
+  title: "(無題)",
+  description: "mulmocast",
+  lang: "en",
+  beats: [
+    {
+      speaker: "Presenter",
+      text: "",
+      id: "a7105c4e-8614-4028-9ea6-3492a1f55d6d",
+      image: {
+        type: "image",
+        source: {
+          kind: "path",
+          path: ".",
+        },
+      },
+    },
+  ],
+};
+
 const getContext = () => {
   const fileDirs = getFileObject({ file: "hello.yaml" });
-  const mulmoScript = {
-    $mulmocast: {
-      version: "1.1",
-    },
-    canvasSize: {
-      width: 1280,
-      height: 720,
-    },
-    speechParams: {
-      speakers: {
-        Presenter: {
-          displayName: {
-            en: "Presenter",
-          },
-          voiceId: "shimmer",
-        },
-      },
-    },
-    imageParams: {
-      provider: "openai",
-      images: {},
-    },
-    soundEffectParams: {
-      provider: "replicate",
-    },
-    audioParams: {
-      padding: 0.3,
-      introPadding: 1,
-      closingPadding: 0.8,
-      outroPadding: 1,
-      bgmVolume: 0.2,
-      audioVolume: 1,
-      suppressSpeech: false,
-    },
-    title: "(無題)",
-    description: "mulmocast",
-    lang: "en",
-    beats: [
-      {
-        speaker: "Presenter",
-        text: "",
-        id: "a7105c4e-8614-4028-9ea6-3492a1f55d6d",
-        image: {
-          type: "image",
-          source: {
-            kind: "path",
-            path: ".",
-          },
-        },
-      },
-    ],
-  };
-
-  const studio = createStudioData(mulmoScript, "hello");
+  const studio = createStudioData(testMulmoScript, "hello");
   const context = {
     studio,
     fileDirs,

--- a/test/utils/test_utils.ts
+++ b/test/utils/test_utils.ts
@@ -85,7 +85,9 @@ test("test settings2GraphAIConfig", async () => {
     ttsOpenaiAgent: { apiKey: "openai_env" },
     imageOpenaiAgent: { apiKey: "openai_env" },
   });
+});
 
+test("test settings2GraphAIConfig (setting/env precedence)", async () => {
   const res5 = settings2GraphAIConfig(
     {
       LLM_OPENAI_API_KEY: "llm_setting",


### PR DESCRIPTION
Small lint-cleanup PR (no behavior change). Clears `max-lines-per-function` warnings in 5 test files:

- `test_images` / `test_images_error` / `run_audio` / `run_translate`: hoist the large fixture `MulmoScript` literal out of `getContext()` into a module-scope const (function shrinks; the literal is data, not a function).
- `test_utils`: split the long `settings2GraphAIConfig` test into two independent `test()` blocks.

Excludes files touched by #1476 (fetch layer). `yarn build` / `yarn lint` (these 5 now clean) / `yarn ci_test` (943 pass, 0 fail) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test setup data for improved consistency and maintainability.
  * Split configuration coverage into separate tests, including environment and setting precedence scenarios.
  * Preserved existing image, audio, translation, and error-handling test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->