### PR TITLE
refactor: extract helpers in image_agents / movie to cut function size

### DIFF
--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -72,72 +72,80 @@ type ImagePreprocessAgentResponse =
   | ImageOnlyMoviePreprocessAgentResponse
   | ImageGenearalPreprocessAgentResponse;
 
-export const imagePreprocessAgent = async (namedInputs: {
-  context: MulmoStudioContext;
-  beat: MulmoBeat;
-  index: number;
-  imageRefs?: Record<string, string>;
-}): Promise<ImagePreprocessAgentResponse> => {
-  const { context, beat, index, imageRefs } = namedInputs;
+const buildHtmlPromptResponse = (context: MulmoStudioContext, beat: MulmoBeat, imagePath: string, htmlImageFile: string): ImagePreprocessAgentResponse => {
+  const htmlPrompt = MulmoBeatMethods.getHtmlPrompt(beat);
+  const htmlPath = imagePath.replace(/\.[^/.]+$/, ".html");
+  // ImageHtmlPreprocessAgentResponse
+  return { imagePath, htmlPrompt, htmlImageFile, htmlPath, htmlImageSystemPrompt: htmlImageSystemPrompt(context.presentationStyle.canvasSize) };
+};
 
-  const studioBeat = context.studio.beats[index];
-  const { imagePath, htmlImageFile } = getBeatPngImagePath(context, index);
-  if (beat.htmlPrompt) {
-    const htmlPrompt = MulmoBeatMethods.getHtmlPrompt(beat);
-    const htmlPath = imagePath.replace(/\.[^/.]+$/, ".html");
-    // ImageHtmlPreprocessAgentResponse
-    return { imagePath, htmlPrompt, htmlImageFile, htmlPath, htmlImageSystemPrompt: htmlImageSystemPrompt(context.presentationStyle.canvasSize) };
+const applySoundEffect = (
+  returnValue: ImagePreprocessAgentReturnValue,
+  params: { context: MulmoStudioContext; beat: MulmoBeat; index: number; isMovie: boolean; moviePaths: ReturnType<typeof getBeatMoviePaths> },
+): void => {
+  const { context, beat, index, isMovie, moviePaths } = params;
+  if (isMovie) {
+    returnValue.soundEffectAgentInfo = MulmoPresentationStyleMethods.getSoundEffectAgentInfo(context.presentationStyle, beat);
+    returnValue.soundEffectModel =
+      beat.soundEffectParams?.model ?? context.presentationStyle.soundEffectParams?.model ?? returnValue.soundEffectAgentInfo.defaultModel;
+    returnValue.soundEffectFile = moviePaths.soundEffectFile;
+    returnValue.soundEffectPrompt = beat.soundEffectPrompt;
+  } else {
+    GraphAILogger.warn(`soundEffectPrompt is set, but there is no video. beat: ${index}`);
   }
+};
 
-  const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(context.presentationStyle, beat);
-  const moviePaths = getBeatMoviePaths(context, index);
-  const returnValue: ImagePreprocessAgentReturnValue = {
-    imageParams: imageAgentInfo.imageParams,
-    movieFile: beat.moviePrompt ? moviePaths.movieFile : undefined,
-    beatDuration: beat.duration ?? studioBeat?.duration,
-  };
-
-  const isMovie = Boolean(beat.moviePrompt || beat?.image?.type === "movie");
-  if (beat.soundEffectPrompt) {
-    if (isMovie) {
-      returnValue.soundEffectAgentInfo = MulmoPresentationStyleMethods.getSoundEffectAgentInfo(context.presentationStyle, beat);
-      returnValue.soundEffectModel =
-        beat.soundEffectParams?.model ?? context.presentationStyle.soundEffectParams?.model ?? returnValue.soundEffectAgentInfo.defaultModel;
-      returnValue.soundEffectFile = moviePaths.soundEffectFile;
-      returnValue.soundEffectPrompt = beat.soundEffectPrompt;
-    } else {
-      GraphAILogger.warn(`soundEffectPrompt is set, but there is no video. beat: ${index}`);
-    }
+const applyLipSync = (
+  returnValue: ImagePreprocessAgentReturnValue,
+  params: {
+    context: MulmoStudioContext;
+    beat: MulmoBeat;
+    index: number;
+    studioBeat: MulmoStudioContext["studio"]["beats"][number];
+    moviePaths: ReturnType<typeof getBeatMoviePaths>;
+  },
+): void => {
+  const { context, beat, index, studioBeat, moviePaths } = params;
+  const lipSyncAgentInfo = MulmoPresentationStyleMethods.getLipSyncAgentInfo(context.presentationStyle, beat);
+  returnValue.lipSyncAgentName = lipSyncAgentInfo.agentName;
+  returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
+  returnValue.lipSyncFile = moviePaths.lipSyncFile;
+  if (context.studio.script.audioParams?.suppressSpeech) {
+    // studio beat may ot have startAt and duration yet, in case of API call from the app.
+    returnValue.startAt = context.studio.script.beats.filter((_, i) => i < index).reduce((acc, curr) => acc + (curr.duration ?? 0), 0);
+    returnValue.duration = beat.duration ?? 0;
+    returnValue.lipSyncTrimAudio = true;
+    returnValue.bgmFile = MulmoMediaSourceMethods.resolve(context.studio.script.audioParams.bgm, context);
+    const folderName = MulmoStudioContextMethods.getFileName(context);
+    const audioDirPath = MulmoStudioContextMethods.getAudioDirPath(context);
+    const trimmedName = `${beatId(beat.id, index)}_trimmed`;
+    returnValue.audioFile = context.fileDirs.grouped
+      ? getGroupedAudioFilePath(audioDirPath, trimmedName)
+      : getAudioFilePath(audioDirPath, folderName, trimmedName);
+  } else {
+    // Audio file will be set from the beat's audio file when available
+    const lang = context.lang ?? context.studio.script.lang;
+    returnValue.audioFile = studioBeat?.audioFile ?? localizedPath(context, beat, index, lang);
   }
+};
 
-  if (beat.enableLipSync) {
-    const lipSyncAgentInfo = MulmoPresentationStyleMethods.getLipSyncAgentInfo(context.presentationStyle, beat);
-    returnValue.lipSyncAgentName = lipSyncAgentInfo.agentName;
-    returnValue.lipSyncModel = beat.lipSyncParams?.model ?? context.presentationStyle.lipSyncParams?.model ?? lipSyncAgentInfo.defaultModel;
-    returnValue.lipSyncFile = moviePaths.lipSyncFile;
-    if (context.studio.script.audioParams?.suppressSpeech) {
-      // studio beat may ot have startAt and duration yet, in case of API call from the app.
-      returnValue.startAt = context.studio.script.beats.filter((_, i) => i < index).reduce((acc, curr) => acc + (curr.duration ?? 0), 0);
-      returnValue.duration = beat.duration ?? 0;
-      returnValue.lipSyncTrimAudio = true;
-      returnValue.bgmFile = MulmoMediaSourceMethods.resolve(context.studio.script.audioParams.bgm, context);
-      const folderName = MulmoStudioContextMethods.getFileName(context);
-      const audioDirPath = MulmoStudioContextMethods.getAudioDirPath(context);
-      const trimmedName = `${beatId(beat.id, index)}_trimmed`;
-      returnValue.audioFile = context.fileDirs.grouped
-        ? getGroupedAudioFilePath(audioDirPath, trimmedName)
-        : getAudioFilePath(audioDirPath, folderName, trimmedName);
-    } else {
-      // Audio file will be set from the beat's audio file when available
-      const lang = context.lang ?? context.studio.script.lang;
-      returnValue.audioFile = studioBeat?.audioFile ?? localizedPath(context, beat, index, lang);
-    }
-  }
+const resolveMovieReferenceImages = (
+  referenceImages: NonNullable<MulmoMovieParams["referenceImages"]>,
+  imageRefs: Record<string, string>,
+): { imagePath: string; referenceType: "ASSET" | "STYLE" }[] => {
+  return referenceImages
+    .map((ref) => {
+      const refPath = imageRefs[ref.imageName];
+      return refPath ? { imagePath: refPath, referenceType: ref.referenceType } : undefined;
+    })
+    .filter((r): r is { imagePath: string; referenceType: "ASSET" | "STYLE" } => r !== undefined);
+};
 
-  returnValue.movieAgentInfo = MulmoPresentationStyleMethods.getMovieAgentInfo(context.presentationStyle, beat);
-
-  // Resolve movie reference images from imageRefs
-  const movieParams = beat.movieParams ?? context.presentationStyle.movieParams;
+const applyMovieReferenceImages = (
+  returnValue: ImagePreprocessAgentReturnValue,
+  movieParams: MulmoMovieParams | undefined,
+  imageRefs?: Record<string, string>,
+): void => {
   if (movieParams?.firstFrameImageName && imageRefs) {
     const firstFramePath = imageRefs[movieParams.firstFrameImageName];
     if (firstFramePath) {
@@ -151,73 +159,125 @@ export const imagePreprocessAgent = async (namedInputs: {
     }
   }
   if (movieParams?.referenceImages && imageRefs) {
-    returnValue.movieReferenceImages = movieParams.referenceImages
-      .map((ref) => {
-        const refPath = imageRefs[ref.imageName];
-        return refPath ? { imagePath: refPath, referenceType: ref.referenceType } : undefined;
-      })
-      .filter((r): r is { imagePath: string; referenceType: "ASSET" | "STYLE" } => r !== undefined);
+    returnValue.movieReferenceImages = resolveMovieReferenceImages(movieParams.referenceImages, imageRefs);
+  }
+};
+
+const buildImagePluginResponse = async (
+  returnValue: ImagePreprocessAgentReturnValue,
+  params: { context: MulmoStudioContext; beat: MulmoBeat; image: NonNullable<MulmoBeat["image"]>; index: number; imagePath: string },
+): Promise<ImagePreprocessAgentResponse> => {
+  const { context, beat, image, index, imagePath } = params;
+  const plugin = MulmoBeatMethods.getPlugin(beat);
+  const pluginPath = plugin.path({ beat, context, imagePath, ...htmlStyle(context, beat) });
+
+  const markdown = plugin.markdown ? plugin.markdown({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
+  const html = plugin.html ? await plugin.html({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
+
+  const isTypeMovie = image.type === "movie";
+  const isAnimatedHtml = MulmoBeatMethods.isAnimatedHtmlTailwind(beat);
+
+  // animation and moviePrompt cannot be used together
+  if (isAnimatedHtml && beat.moviePrompt) {
+    throw new Error("html_tailwind animation and moviePrompt cannot be used together on the same beat. Use either animation or moviePrompt, not both.");
   }
 
-  if (beat.image) {
-    const plugin = MulmoBeatMethods.getPlugin(beat);
-    const pluginPath = plugin.path({ beat, context, imagePath, ...htmlStyle(context, beat) });
-
-    const markdown = plugin.markdown ? plugin.markdown({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
-    const html = plugin.html ? await plugin.html({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
-
-    const isTypeMovie = beat.image.type === "movie";
-    const isAnimatedHtml = MulmoBeatMethods.isAnimatedHtmlTailwind(beat);
-
-    // animation and moviePrompt cannot be used together
-    if (isAnimatedHtml && beat.moviePrompt) {
-      throw new Error("html_tailwind animation and moviePrompt cannot be used together on the same beat. Use either animation or moviePrompt, not both.");
-    }
-
-    if (isAnimatedHtml) {
-      const animatedVideoPath = getBeatAnimatedVideoPath(context, index);
-      // ImagePluginPreprocessAgentResponse
-      // imageFromMovie is false: the plugin generates both the .mp4 video AND
-      // a high-quality final-frame PNG directly from HTML (better than extracting from compressed video).
-      return {
-        ...returnValue,
-        imagePath, // static final-frame PNG (generated by the plugin)
-        movieFile: animatedVideoPath, // .mp4 path for the pipeline
-        referenceImageForMovie: pluginPath,
-        markdown,
-        html,
-      };
-    }
-
-    // undefined prompt indicates that image generation is not needed
+  if (isAnimatedHtml) {
+    const animatedVideoPath = getBeatAnimatedVideoPath(context, index);
     // ImagePluginPreprocessAgentResponse
+    // imageFromMovie is false: the plugin generates both the .mp4 video AND
+    // a high-quality final-frame PNG directly from HTML (better than extracting from compressed video).
     return {
       ...returnValue,
-      // imagePath: isTypeMovie ? undefined : pluginPath,
-      imagePath: isTypeMovie ? imagePath : pluginPath,
-      movieFile: isTypeMovie ? pluginPath : returnValue.movieFile,
-      imageFromMovie: isTypeMovie,
+      imagePath, // static final-frame PNG (generated by the plugin)
+      movieFile: animatedVideoPath, // .mp4 path for the pipeline
       referenceImageForMovie: pluginPath,
       markdown,
       html,
     };
   }
 
-  if (beat.moviePrompt && !beat.imagePrompt) {
-    // ImageOnlyMoviePreprocessAgentResponse
-    // If firstFrameImageName is specified, use the resolved ref image as the movie's first frame
-    const base = { ...returnValue, imagePath, imageFromMovie: true };
-    return returnValue.firstFrameImagePath ? { ...base, referenceImageForMovie: returnValue.firstFrameImagePath } : base;
-  }
+  // undefined prompt indicates that image generation is not needed
+  // ImagePluginPreprocessAgentResponse
+  return {
+    ...returnValue,
+    // imagePath: isTypeMovie ? undefined : pluginPath,
+    imagePath: isTypeMovie ? imagePath : pluginPath,
+    movieFile: isTypeMovie ? pluginPath : returnValue.movieFile,
+    imageFromMovie: isTypeMovie,
+    referenceImageForMovie: pluginPath,
+    markdown,
+    html,
+  };
+};
 
+const buildMovieOnlyResponse = (returnValue: ImagePreprocessAgentReturnValue, imagePath: string): ImagePreprocessAgentResponse => {
+  // ImageOnlyMoviePreprocessAgentResponse
+  // If firstFrameImageName is specified, use the resolved ref image as the movie's first frame
+  const base = { ...returnValue, imagePath, imageFromMovie: true };
+  return returnValue.firstFrameImagePath ? { ...base, referenceImageForMovie: returnValue.firstFrameImagePath } : base;
+};
+
+const buildGeneralResponse = (
+  returnValue: ImagePreprocessAgentReturnValue,
+  params: { beat: MulmoBeat; imageAgentInfo: Text2ImageAgentInfo; imageRefs?: Record<string, string>; imagePath: string },
+): ImagePreprocessAgentResponse => {
+  const { beat, imageAgentInfo, imageRefs, imagePath } = params;
   // referenceImages for "edit_image", openai agent.
   const referenceImages = MulmoBeatMethods.getImageReferenceForImageGenerator(beat, imageRefs ?? {});
-
   const prompt = imagePrompt(beat, imageAgentInfo.imageParams.style);
   // ImageGenearalPreprocessAgentResponse
   // firstFrameImagePath (from movieParams.firstFrameImageName) takes precedence over generated image
   const movieFirstFramePath = returnValue.firstFrameImagePath ?? imagePath;
   return { ...returnValue, imagePath, referenceImageForMovie: movieFirstFramePath, imageAgentInfo, prompt, referenceImages };
+};
+
+export const imagePreprocessAgent = async (namedInputs: {
+  context: MulmoStudioContext;
+  beat: MulmoBeat;
+  index: number;
+  imageRefs?: Record<string, string>;
+}): Promise<ImagePreprocessAgentResponse> => {
+  const { context, beat, index, imageRefs } = namedInputs;
+
+  const studioBeat = context.studio.beats[index];
+  const { imagePath, htmlImageFile } = getBeatPngImagePath(context, index);
+  if (beat.htmlPrompt) {
+    return buildHtmlPromptResponse(context, beat, imagePath, htmlImageFile);
+  }
+
+  const imageAgentInfo = MulmoPresentationStyleMethods.getImageAgentInfo(context.presentationStyle, beat);
+  const moviePaths = getBeatMoviePaths(context, index);
+  const returnValue: ImagePreprocessAgentReturnValue = {
+    imageParams: imageAgentInfo.imageParams,
+    movieFile: beat.moviePrompt ? moviePaths.movieFile : undefined,
+    beatDuration: beat.duration ?? studioBeat?.duration,
+  };
+
+  const isMovie = Boolean(beat.moviePrompt || beat?.image?.type === "movie");
+  if (beat.soundEffectPrompt) {
+    applySoundEffect(returnValue, { context, beat, index, isMovie, moviePaths });
+  }
+
+  if (beat.enableLipSync) {
+    applyLipSync(returnValue, { context, beat, index, studioBeat, moviePaths });
+  }
+
+  returnValue.movieAgentInfo = MulmoPresentationStyleMethods.getMovieAgentInfo(context.presentationStyle, beat);
+
+  // Resolve movie reference images from imageRefs
+  const movieParams = beat.movieParams ?? context.presentationStyle.movieParams;
+  applyMovieReferenceImages(returnValue, movieParams, imageRefs);
+
+  if (beat.image) {
+    return buildImagePluginResponse(returnValue, { context, beat, image: beat.image, index, imagePath });
+  }
+
+  if (beat.moviePrompt && !beat.imagePrompt) {
+    return buildMovieOnlyResponse(returnValue, imagePath);
+  }
+
+  return buildGeneralResponse(returnValue, { beat, imageAgentInfo, imageRefs, imagePath });
 };
 
 export const imagePluginAgent = async (namedInputs: {

--- a/src/actions/movie.ts
+++ b/src/actions/movie.ts
@@ -194,6 +194,117 @@ export const getInOverlayCoords = (transitionType: string, d: number, t: number)
   throw new Error(`Unknown transition type: ${transitionType}`);
 };
 
+const addFadeTransition = (
+  ffmpegContext: FfmpegContext,
+  prevVideoId: string,
+  transitionVideoId: string,
+  processedVideoId: string,
+  outputVideoId: string,
+  startAt: number,
+  duration: number,
+): string => {
+  // Fade out the previous beat's last frame
+  ffmpegContext.filterComplex.push(
+    `[${transitionVideoId}]format=yuva420p,fade=t=out:d=${duration}:alpha=1,setpts=PTS-STARTPTS+${startAt}/TB[${processedVideoId}]`,
+  );
+  ffmpegContext.filterComplex.push(`[${prevVideoId}][${processedVideoId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`);
+  return outputVideoId;
+};
+
+const addSlideoutTransition = (
+  ffmpegContext: FfmpegContext,
+  prevVideoId: string,
+  transitionVideoId: string,
+  processedVideoId: string,
+  outputVideoId: string,
+  transitionType: string,
+  startAt: number,
+  duration: number,
+): string => {
+  // Slideout: previous beat's last frame slides out
+  ffmpegContext.filterComplex.push(`[${transitionVideoId}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${processedVideoId}]`);
+  ffmpegContext.filterComplex.push(
+    `[${prevVideoId}][${processedVideoId}]overlay=${getOutOverlayCoords(transitionType, duration, startAt)}:enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`,
+  );
+  return outputVideoId;
+};
+
+const addSlideinTransition = (
+  ffmpegContext: FfmpegContext,
+  prevVideoId: string,
+  nextVideoId: VideoId,
+  outputVideoId: string,
+  videoIdsForBeats: VideoId[],
+  beatIndex: number,
+  transitionType: string,
+  startAt: number,
+  duration: number,
+): string => {
+  // Slidein: this beat's first frame slides in over the previous beat's last frame
+  if (!nextVideoId) {
+    // Cannot apply slidein without first frame
+    return prevVideoId;
+  }
+
+  // Get previous beat's last frame for background
+  const prevVideoSourceId = videoIdsForBeats[beatIndex - 1];
+  // Both movie and image beats now have _last
+  const prevLastFrame = `${prevVideoSourceId}_last`;
+
+  // Prepare background (last frame of previous beat)
+  const backgroundVideoId = `${prevLastFrame}_bg`;
+  ffmpegContext.filterComplex.push(`[${prevLastFrame}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${backgroundVideoId}]`);
+  // Prepare sliding frame (first frame of this beat)
+  const slideinFrameId = `${nextVideoId}_f`;
+  ffmpegContext.filterComplex.push(`[${nextVideoId}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${slideinFrameId}]`);
+  // First overlay: put background on top of concat video
+  const bgOutputId = `${prevLastFrame}_bg_o`;
+  ffmpegContext.filterComplex.push(`[${prevVideoId}][${backgroundVideoId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${bgOutputId}]`);
+  // Second overlay: slide in the new frame on top of background
+  ffmpegContext.filterComplex.push(
+    `[${bgOutputId}][${slideinFrameId}]overlay=${getInOverlayCoords(transitionType, duration, startAt)}:enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`,
+  );
+  return outputVideoId;
+};
+
+const addWipeTransition = (
+  ffmpegContext: FfmpegContext,
+  prevVideoId: string,
+  transitionVideoId: string,
+  nextVideoId: VideoId,
+  outputVideoId: string,
+  transitionType: string,
+  startAt: number,
+  duration: number,
+): string => {
+  // Wipe transition: use xfade filter between previous beat's last frame and this beat's first frame
+  if (!nextVideoId) {
+    // Cannot apply wipe without first frame
+    return prevVideoId;
+  }
+
+  // For wipe transitions, use offset=0 so transition starts immediately and completes within duration
+  // This ensures 0-100% wipe happens exactly during the transition duration
+  const xfadeOffset = 0;
+
+  // Apply xfade with offset=0 for complete 0-100% transition
+  // Both input videos should be at least duration seconds long (ensured by static frame generation)
+  const xfadeOutputId = `${transitionVideoId}_xfade`;
+  ffmpegContext.filterComplex.push(`[${transitionVideoId}]format=yuv420p[${transitionVideoId}_fmt]`);
+  ffmpegContext.filterComplex.push(`[${nextVideoId}]format=yuv420p[${nextVideoId}_fmt]`);
+  ffmpegContext.filterComplex.push(
+    `[${transitionVideoId}_fmt][${nextVideoId}_fmt]xfade=transition=${transitionType}:duration=${duration}:offset=${xfadeOffset}[${xfadeOutputId}]`,
+  );
+
+  // Set PTS for overlay timing
+  const xfadeTimedId = `${xfadeOutputId}_t`;
+  ffmpegContext.filterComplex.push(`[${xfadeOutputId}]setpts=PTS-STARTPTS+${startAt}/TB[${xfadeTimedId}]`);
+
+  // Overlay the xfade result on the concat video
+  ffmpegContext.filterComplex.push(`[${prevVideoId}][${xfadeTimedId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`);
+  return outputVideoId;
+};
+
 const addTransitionEffects = (
   ffmpegContext: FfmpegContext,
   captionedVideoId: string,
@@ -224,72 +335,15 @@ const addTransitionEffects = (
     const processedVideoId = `${transitionVideoId}_f`;
 
     if (transition.type === "fade") {
-      // Fade out the previous beat's last frame
-      ffmpegContext.filterComplex.push(
-        `[${transitionVideoId}]format=yuva420p,fade=t=out:d=${duration}:alpha=1,setpts=PTS-STARTPTS+${startAt}/TB[${processedVideoId}]`,
-      );
-      ffmpegContext.filterComplex.push(`[${prevVideoId}][${processedVideoId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`);
+      return addFadeTransition(ffmpegContext, prevVideoId, transitionVideoId, processedVideoId, outputVideoId, startAt, duration);
     } else if (transition.type.startsWith("slideout_")) {
-      // Slideout: previous beat's last frame slides out
-      ffmpegContext.filterComplex.push(`[${transitionVideoId}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${processedVideoId}]`);
-      ffmpegContext.filterComplex.push(
-        `[${prevVideoId}][${processedVideoId}]overlay=${getOutOverlayCoords(transition.type, duration, startAt)}:enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`,
-      );
+      return addSlideoutTransition(ffmpegContext, prevVideoId, transitionVideoId, processedVideoId, outputVideoId, transition.type, startAt, duration);
     } else if (transition.type.startsWith("slidein_")) {
-      // Slidein: this beat's first frame slides in over the previous beat's last frame
-      if (!nextVideoId) {
-        // Cannot apply slidein without first frame
-        return prevVideoId;
-      }
-
-      // Get previous beat's last frame for background
-      const prevVideoSourceId = videoIdsForBeats[beatIndex - 1];
-      // Both movie and image beats now have _last
-      const prevLastFrame = `${prevVideoSourceId}_last`;
-
-      // Prepare background (last frame of previous beat)
-      const backgroundVideoId = `${prevLastFrame}_bg`;
-      ffmpegContext.filterComplex.push(`[${prevLastFrame}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${backgroundVideoId}]`);
-      // Prepare sliding frame (first frame of this beat)
-      const slideinFrameId = `${nextVideoId}_f`;
-      ffmpegContext.filterComplex.push(`[${nextVideoId}]format=yuva420p,setpts=PTS-STARTPTS+${startAt}/TB[${slideinFrameId}]`);
-      // First overlay: put background on top of concat video
-      const bgOutputId = `${prevLastFrame}_bg_o`;
-      ffmpegContext.filterComplex.push(`[${prevVideoId}][${backgroundVideoId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${bgOutputId}]`);
-      // Second overlay: slide in the new frame on top of background
-      ffmpegContext.filterComplex.push(
-        `[${bgOutputId}][${slideinFrameId}]overlay=${getInOverlayCoords(transition.type, duration, startAt)}:enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`,
-      );
+      return addSlideinTransition(ffmpegContext, prevVideoId, nextVideoId, outputVideoId, videoIdsForBeats, beatIndex, transition.type, startAt, duration);
     } else if (transition.type.startsWith("wipe")) {
-      // Wipe transition: use xfade filter between previous beat's last frame and this beat's first frame
-      if (!nextVideoId) {
-        // Cannot apply wipe without first frame
-        return prevVideoId;
-      }
-
-      // For wipe transitions, use offset=0 so transition starts immediately and completes within duration
-      // This ensures 0-100% wipe happens exactly during the transition duration
-      const xfadeOffset = 0;
-
-      // Apply xfade with offset=0 for complete 0-100% transition
-      // Both input videos should be at least duration seconds long (ensured by static frame generation)
-      const xfadeOutputId = `${transitionVideoId}_xfade`;
-      ffmpegContext.filterComplex.push(`[${transitionVideoId}]format=yuv420p[${transitionVideoId}_fmt]`);
-      ffmpegContext.filterComplex.push(`[${nextVideoId}]format=yuv420p[${nextVideoId}_fmt]`);
-      ffmpegContext.filterComplex.push(
-        `[${transitionVideoId}_fmt][${nextVideoId}_fmt]xfade=transition=${transition.type}:duration=${duration}:offset=${xfadeOffset}[${xfadeOutputId}]`,
-      );
-
-      // Set PTS for overlay timing
-      const xfadeTimedId = `${xfadeOutputId}_t`;
-      ffmpegContext.filterComplex.push(`[${xfadeOutputId}]setpts=PTS-STARTPTS+${startAt}/TB[${xfadeTimedId}]`);
-
-      // Overlay the xfade result on the concat video
-      ffmpegContext.filterComplex.push(`[${prevVideoId}][${xfadeTimedId}]overlay=enable='between(t,${startAt},${startAt + duration})'[${outputVideoId}]`);
-    } else {
-      throw new Error(`Unknown transition type: ${transition.type}`);
+      return addWipeTransition(ffmpegContext, prevVideoId, transitionVideoId, nextVideoId, outputVideoId, transition.type, startAt, duration);
     }
-    return outputVideoId;
+    throw new Error(`Unknown transition type: ${transition.type}`);
   }, captionedVideoId);
 };
 
@@ -508,6 +562,104 @@ const findMissingIndex = (context: MulmoStudioContext) => {
   });
 };
 
+const isMovieBeat = (studioBeat: MulmoStudioContext["studio"]["beats"][number], context: MulmoStudioContext, beat: MulmoBeat): boolean => {
+  return !!(studioBeat.lipSyncFile || studioBeat.movieFile || MulmoPresentationStyleMethods.getImageType(context.presentationStyle, beat) === "movie");
+};
+
+const pushTransitionVideoId = (
+  context: MulmoStudioContext,
+  beat: MulmoBeat,
+  videoIdsForBeats: VideoId[],
+  index: number,
+  transitionVideoIds: { videoId: string; nextVideoId: VideoId; beatIndex: number }[],
+): void => {
+  const transition = MulmoPresentationStyleMethods.getMovieTransition(context, beat);
+  if (transition && index > 0) {
+    const transitionVideoId = getTransitionVideoId(transition, videoIdsForBeats, index);
+    transitionVideoIds.push(transitionVideoId);
+  }
+};
+
+const pushMovieBeatAudio = (
+  ffmpegContext: FfmpegContext,
+  studioBeat: MulmoStudioContext["studio"]["beats"][number],
+  beat: MulmoBeat,
+  context: MulmoStudioContext,
+  inputIndex: number,
+  duration: number,
+  timestamp: number,
+  speed: number,
+  audioIdsFromMovieBeats: string[],
+): void => {
+  const movieVolume = resolveMovieVolume(beat, context);
+  if (studioBeat.hasMovieAudio && movieVolume > 0.0 && speed === 1.0) {
+    // TODO: Handle a special case where it has lipSyncFile AND hasMovieAudio is on (the source file has an audio, such as sound effect).
+    const { audioId, audioPart } = getAudioPart(inputIndex, duration, timestamp, movieVolume);
+    audioIdsFromMovieBeats.push(audioId);
+    ffmpegContext.filterComplex.push(audioPart);
+  }
+};
+
+const addBeatInputs = (
+  ffmpegContext: FfmpegContext,
+  context: MulmoStudioContext,
+  canvasInfo: MulmoCanvasDimension,
+  isTest: boolean,
+  needsFirstFrame: boolean[],
+  needsLastFrame: boolean[],
+  videoIdsForBeats: VideoId[],
+  audioIdsFromMovieBeats: string[],
+  transitionVideoIds: { videoId: string; nextVideoId: VideoId; beatIndex: number }[],
+  beatTimestamps: number[],
+): void => {
+  let cumulativeFrames = 0;
+  context.studio.beats.reduce((timestamp, studioBeat, index) => {
+    const beat = context.studio.script.beats[index];
+    if (beat.image?.type === "voice_over") {
+      videoIdsForBeats.push(undefined);
+      beatTimestamps.push(timestamp);
+      return timestamp; // Skip voice-over beats.
+    }
+
+    const sourceFile = isTest ? "/test/dummy.mp4" : validateBeatSource(studioBeat, index);
+
+    // The movie duration is bigger in case of voice-over.
+    const duration = Math.max(studioBeat.duration! + getExtraPadding(context, index), studioBeat.movieDuration ?? 0);
+
+    // Use cumulative frame tracking to prevent audio-video drift from frame quantization.
+    // trim=duration=X rounds up to the next frame boundary (~0.03s per beat at 30fps),
+    // causing cumulative drift. Instead, compute exact frame counts per beat.
+    const targetEndFrame = Math.round((timestamp + duration) * VIDEO_FPS);
+    const frameCount = targetEndFrame - cumulativeFrames;
+    cumulativeFrames = targetEndFrame;
+
+    const inputIndex = FfmpegContextAddInput(ffmpegContext, sourceFile);
+    const isMovie = isMovieBeat(studioBeat, context, beat);
+    const speed = beat.movieParams?.speed ?? 1.0;
+    const filters = beat.movieParams?.filters;
+    const { videoId, videoPart } = getVideoPart(inputIndex, isMovie, duration, canvasInfo, getFillOption(context, beat), speed, filters, frameCount);
+    ffmpegContext.filterComplex.push(videoPart);
+
+    // for transition
+    const needFirst = needsFirstFrame[index]; // This beat has slidein
+    const needLast = needsLastFrame[index]; // Next beat has transition
+
+    videoIdsForBeats.push(videoId);
+    if (needFirst || needLast) {
+      const { firstDuration, lastDuration } = getTransitionFrameDurations(context, index);
+      addSplitAndExtractFrames(ffmpegContext, videoId, firstDuration, lastDuration, isMovie, needFirst, needLast, canvasInfo);
+    }
+
+    // Record transition info if this beat has a transition
+    pushTransitionVideoId(context, beat, videoIdsForBeats, index, transitionVideoIds);
+
+    // NOTE: We don't support audio if the speed is not 1.0.
+    pushMovieBeatAudio(ffmpegContext, studioBeat, beat, context, inputIndex, duration, timestamp, speed, audioIdsFromMovieBeats);
+    beatTimestamps.push(timestamp);
+    return timestamp + duration;
+  }, 0);
+};
+
 export const createVideo = async (audioArtifactFilePath: string, outputVideoPath: string, context: MulmoStudioContext, isTest: boolean = false) => {
   const caption = MulmoStudioContextMethods.getCaption(context);
   const start = performance.now();
@@ -533,66 +685,18 @@ export const createVideo = async (audioArtifactFilePath: string, outputVideoPath
   // Check which beats need _last (for any transition on next beat - they all need previous beat's last frame)
   const needsLastFrame: boolean[] = getNeedLastFrame(context);
 
-  let cumulativeFrames = 0;
-  context.studio.beats.reduce((timestamp, studioBeat, index) => {
-    const beat = context.studio.script.beats[index];
-    if (beat.image?.type === "voice_over") {
-      videoIdsForBeats.push(undefined);
-      beatTimestamps.push(timestamp);
-      return timestamp; // Skip voice-over beats.
-    }
-
-    const sourceFile = isTest ? "/test/dummy.mp4" : validateBeatSource(studioBeat, index);
-
-    // The movie duration is bigger in case of voice-over.
-    const duration = Math.max(studioBeat.duration! + getExtraPadding(context, index), studioBeat.movieDuration ?? 0);
-
-    // Use cumulative frame tracking to prevent audio-video drift from frame quantization.
-    // trim=duration=X rounds up to the next frame boundary (~0.03s per beat at 30fps),
-    // causing cumulative drift. Instead, compute exact frame counts per beat.
-    const targetEndFrame = Math.round((timestamp + duration) * VIDEO_FPS);
-    const frameCount = targetEndFrame - cumulativeFrames;
-    cumulativeFrames = targetEndFrame;
-
-    const inputIndex = FfmpegContextAddInput(ffmpegContext, sourceFile);
-    const isMovie = !!(
-      studioBeat.lipSyncFile ||
-      studioBeat.movieFile ||
-      MulmoPresentationStyleMethods.getImageType(context.presentationStyle, beat) === "movie"
-    );
-    const speed = beat.movieParams?.speed ?? 1.0;
-    const filters = beat.movieParams?.filters;
-    const { videoId, videoPart } = getVideoPart(inputIndex, isMovie, duration, canvasInfo, getFillOption(context, beat), speed, filters, frameCount);
-    ffmpegContext.filterComplex.push(videoPart);
-
-    // for transition
-    const needFirst = needsFirstFrame[index]; // This beat has slidein
-    const needLast = needsLastFrame[index]; // Next beat has transition
-
-    videoIdsForBeats.push(videoId);
-    if (needFirst || needLast) {
-      const { firstDuration, lastDuration } = getTransitionFrameDurations(context, index);
-      addSplitAndExtractFrames(ffmpegContext, videoId, firstDuration, lastDuration, isMovie, needFirst, needLast, canvasInfo);
-    }
-
-    // Record transition info if this beat has a transition
-    const transition = MulmoPresentationStyleMethods.getMovieTransition(context, beat);
-    if (transition && index > 0) {
-      const transitionVideoId = getTransitionVideoId(transition, videoIdsForBeats, index);
-      transitionVideoIds.push(transitionVideoId);
-    }
-
-    // NOTE: We don't support audio if the speed is not 1.0.
-    const movieVolume = resolveMovieVolume(beat, context);
-    if (studioBeat.hasMovieAudio && movieVolume > 0.0 && speed === 1.0) {
-      // TODO: Handle a special case where it has lipSyncFile AND hasMovieAudio is on (the source file has an audio, such as sound effect).
-      const { audioId, audioPart } = getAudioPart(inputIndex, duration, timestamp, movieVolume);
-      audioIdsFromMovieBeats.push(audioId);
-      ffmpegContext.filterComplex.push(audioPart);
-    }
-    beatTimestamps.push(timestamp);
-    return timestamp + duration;
-  }, 0);
+  addBeatInputs(
+    ffmpegContext,
+    context,
+    canvasInfo,
+    isTest,
+    needsFirstFrame,
+    needsLastFrame,
+    videoIdsForBeats,
+    audioIdsFromMovieBeats,
+    transitionVideoIds,
+    beatTimestamps,
+  );
 
   assert(videoIdsForBeats.length === context.studio.beats.length, "videoIds.length !== studio.beats.length");
   assert(beatTimestamps.length === context.studio.beats.length, "beatTimestamps.length !== studio.beats.length");


### PR DESCRIPTION
Small refactor PR (no behavior change). Clears the `max-lines-per-function` + `sonarjs/cognitive-complexity` warnings on the two most complex source functions by extracting cohesive blocks into named helpers — the top-level control flow, conditions, values, and ffmpeg command construction are untouched.

- `image_agents.ts`: `imagePreprocessAgent` (116 lines, **complexity 41**) now delegates to seven helpers (html-prompt / sound-effect / lip-sync / movie-reference / image-plugin / movie-only / general response builders). The if/else-if chain and all `return` sites stay in the orchestrator.
- `movie.ts`: `addTransitionEffects` split into per-transition-type helpers (fade/slideout/slidein/wipe); `createVideo` split into beat-input / transition-record / movie-audio helpers.

## Why this is safe
Both functions are covered by **golden `assert.deepStrictEqual` tests** on their exact output:
- `test_image_preprocess_agent.ts` / `test_image_preprocess_agent_plugin.ts` (35 pass) — exact preprocess result.
- `test_create_video.ts` (54 pass) — exact ffmpeg filter-complex output.

Any behavior change would fail these. `yarn build` / `yarn lint` (both files now clean) / `yarn ci_test` (943 pass, 0 fail) green. No `eslint-disable` / `any` / `as` added. Excludes files touched by #1476.