### PR TITLE
fix: closingPadding now works without a closing credit beat

### DIFF
--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -10,7 +10,7 @@ import {
   ffmpegGetMediaDuration,
 } from "../utils/ffmpeg_utils.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
-import { MulmoBeatMethods } from "../methods/index.js";
+import { MulmoBeatMethods, MulmoScriptMethods } from "../methods/index.js";
 import { userAssert } from "../utils/utils.js";
 import { getAudioInputIdsError } from "../utils/error_cause.js";
 
@@ -34,11 +34,16 @@ export const getPadding = (context: MulmoStudioContext, beat: MulmoBeat, index: 
   if (beat.audioParams?.padding !== undefined) {
     return beat.audioParams.padding;
   }
-  if (index === context.studio.beats.length - 1) {
+  const lastIndex = context.studio.beats.length - 1;
+  // The closing credit is a silent logo beat appended as the last beat; it carries no
+  // trailing padding, and closingPadding falls on the content beat just before it. Without
+  // a credit, the last beat itself is the closing beat, so closingPadding falls on it.
+  const hasClosingCredit = MulmoScriptMethods.hasClosingCredit(context.studio.script);
+  if (hasClosingCredit && index === lastIndex) {
     return 0;
   }
-  const isClosingGap = index === context.studio.beats.length - 2;
-  return isClosingGap ? context.presentationStyle.audioParams.closingPadding : context.presentationStyle.audioParams.padding;
+  const closingIndex = hasClosingCredit ? lastIndex - 1 : lastIndex;
+  return index === closingIndex ? context.presentationStyle.audioParams.closingPadding : context.presentationStyle.audioParams.padding;
 };
 
 export const getTotalPadding = (padding: number, movieDuration: number, audioDuration: number, duration?: number) => {

--- a/src/methods/mulmo_script.ts
+++ b/src/methods/mulmo_script.ts
@@ -46,6 +46,9 @@ export const MulmoScriptMethods = {
     );
     return mulmoScriptSchema.parse(validatedScript);
   },
+  hasClosingCredit(script: MulmoScript): boolean {
+    return script.$mulmocast.credit === "closing";
+  },
 };
 
 export const MulmoStudioMultiLingualMethod = {

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -99,7 +99,7 @@ export const createStudioData = (_mulmoScript: MulmoScript, fileName: string, vi
 
   // TODO: Move this code out of this function later
   // Addition cloing credit
-  if (mulmoScript.$mulmocast.credit === "closing") {
+  if (MulmoScriptMethods.hasClosingCredit(mulmoScript)) {
     const defaultSpeaker = MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle ?? studio.script);
     mulmoScript.beats.push(mulmoCredit(mulmoScript.beats[0].speaker ?? defaultSpeaker, isPortrait)); // First speaker
   }

--- a/test/agents/test_combine_audio_files.ts
+++ b/test/agents/test_combine_audio_files.ts
@@ -20,6 +20,7 @@ test("updateDurations audio duration", async () => {
   });
 
   const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0.3, closingPadding: 0 };
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
   const res = updateDurations(mock, mediaDurations);
@@ -486,13 +487,11 @@ test("updateDurations with default padding", async () => {
 
   const res = updateDurations(mock, mediaDurations);
 
-  // First beat: audio + padding but not last beat, so gets regular padding
-  // From getPadding logic: index 0 of 2 beats, so not closing (that's index 0 of 2-1=1, which is false)
-  // So it should get regular padding, but actual is 30, so it's getting 0 padding
-  // This suggests the presentationStyle.audioParams.padding is being used differently
-  assert.strictEqual(res[0], 30); // Audio only, no padding applied
-  assert.strictEqual(mediaDurations[0].silenceDuration, 0); // No silence added
-  // Last beat: gets no padding as expected
+  // No closing credit → beat2 (last) is the closing beat and gets closingPadding (0).
+  // beat1 is a regular beat and gets padding (2.0).
+  assert.strictEqual(res[0], 32); // 30 audio + 2.0 padding
+  assert.strictEqual(mediaDurations[0].silenceDuration, 2.0);
+  // Last beat: closingPadding is 0, so no extra silence.
   assert.strictEqual(res[1], 25);
   assert.strictEqual(mediaDurations[1].silenceDuration, 0);
 });

--- a/test/agents/test_combine_audio_files2.ts
+++ b/test/agents/test_combine_audio_files2.ts
@@ -32,7 +32,7 @@ test("getPadding with custom beat padding", () => {
   assert.strictEqual(result, 3.5); // Should use beat's custom padding
 });
 
-test("getPadding for last beat", () => {
+test("getPadding for last beat without closing credit gets closingPadding", () => {
   const beat = createMockBeat({});
   const mock = createMockContext();
   mock.presentationStyle.audioParams = {
@@ -42,11 +42,28 @@ test("getPadding for last beat", () => {
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
-  const result = getPadding(mock, beat, 0); // Only beat, so it's the last one
-  assert.strictEqual(result, 0); // Last beat gets 0 padding
+  // No closing credit → the last beat is the closing beat and gets closingPadding.
+  const result = getPadding(mock, beat, 0);
+  assert.strictEqual(result, 1.0);
 });
 
-test("getPadding for second-to-last beat (closing gap)", () => {
+test("getPadding puts closingPadding on the beat before the closing credit", () => {
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({});
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = {
+    padding: 2.0,
+    closingPadding: 1.5,
+  };
+  mock.studio.script.$mulmocast.credit = "closing";
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test"); // appends the silent credit beat as index 2
+
+  assert.strictEqual(getPadding(mock, beat2, 1), 1.5); // last content beat → closingPadding
+  assert.strictEqual(getPadding(mock, mock.studio.script.beats[2], 2), 0); // credit logo → no trailing padding
+});
+
+test("getPadding without credit: closingPadding on last, padding before it", () => {
   const beat1 = createMockBeat({});
   const beat2 = createMockBeat({});
   const mock = createMockContext();
@@ -57,8 +74,8 @@ test("getPadding for second-to-last beat (closing gap)", () => {
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
-  const result = getPadding(mock, beat1, 0); // First of two beats (second-to-last)
-  assert.strictEqual(result, 1.5); // Should use closingPadding
+  assert.strictEqual(getPadding(mock, beat1, 0), 2.0); // regular padding
+  assert.strictEqual(getPadding(mock, beat2, 1), 1.5); // last beat → closingPadding
 });
 
 test("getPadding for regular beat", () => {
@@ -353,10 +370,11 @@ test("noSpilledOverAudio with movie and audio", () => {
 
   noSpilledOverAudio(mock, beat1, 0, 50, 30, beatDurations, mediaDurations);
 
-  // Total padding = 1.0 + (50 - 30) = 21.0 (closingPadding + movie extra)
-  // Beat duration = 30 + 21 = 51
-  assert.strictEqual(beatDurations[0], 51);
-  assert.strictEqual(mediaDurations[0].silenceDuration, 21);
+  // beat1 is not the closing beat (no credit → beat2 is), so it uses regular padding.
+  // Total padding = 2.0 + (50 - 30) = 22.0 (padding + movie extra)
+  // Beat duration = 30 + 22 = 52
+  assert.strictEqual(beatDurations[0], 52);
+  assert.strictEqual(mediaDurations[0].silenceDuration, 22);
 });
 
 test("noSpilledOverAudio with specified beat duration", () => {

--- a/test/methods/test_mulmo_script.ts
+++ b/test/methods/test_mulmo_script.ts
@@ -1,0 +1,22 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { MulmoScriptMethods } from "../../src/methods/mulmo_script.js";
+import type { MulmoScript } from "../../src/types/index.js";
+
+const scriptWith = (credit?: "closing"): MulmoScript =>
+  ({
+    $mulmocast: { version: "1.1", ...(credit ? { credit } : {}) },
+    title: "Test",
+    lang: "en",
+    beats: [],
+    canvasSize: { width: 1920, height: 1080 },
+  }) as unknown as MulmoScript;
+
+test("hasClosingCredit is true when credit is 'closing'", () => {
+  assert.strictEqual(MulmoScriptMethods.hasClosingCredit(scriptWith("closing")), true);
+});
+
+test("hasClosingCredit is false when credit is unset", () => {
+  assert.strictEqual(MulmoScriptMethods.hasClosingCredit(scriptWith()), false);
+});


### PR DESCRIPTION
## Summary

Fixes [#1488](https://github.com/receptron/mulmocast-cli/issues/1488). Feedback reported that `audioParams.closingPadding` "seems not to work."

Root cause: `getPadding` was **positional** — it always gave the last beat `0` trailing padding and the second-to-last beat `closingPadding`. That is only correct when the last beat is the appended closing-credit logo (inserted in `createStudioData` when `$mulmocast.credit === "closing"`). `credit` has no default, so a script without it has **no credit beat** — and then `closingPadding` landed before the user's real final beat while the final beat got no trailing pause.

## Fix

`closingPadding` is now the trailing pause of the **last content beat**:
- **With a closing credit** → the beat just before the credit logo (credit logo keeps `0`). **Unchanged behavior.**
- **Without a closing credit** → the actual last beat.

Also extracted the duplicated `$mulmocast.credit === "closing"` check into `MulmoScriptMethods.hasClosingCredit(script)` and reused it in both `getPadding` and `createStudioData` (DRY).

## Items to Confirm / Review

- **Behavior change for no-credit decks** (intended): the closing pause moves from *before* the final beat to *on* the final beat. Decks that use `credit: "closing"` (all prompt templates) are byte-identical to before.
- Minimal source change (6-line `getPadding` + a 3-line method + one call-site swap).

## User Prompt

audioParams の closingPadding が効いていないように見える、というフィードバックが来た。検証してほしい。→ (原因特定後) 最後のビートがロゴ(クレジット)前提で最後から2番目に無音を入れている。クレジットの有無を判定して直す(オプション1)。最小・クリーンに。credit 判定は DRY じゃないので関数化。hasClosingCredit と getPadding のテストも追加。

## Implementation

- `src/agents/combine_audio_files_agent.ts` — `getPadding` credit-aware.
- `src/methods/mulmo_script.ts` — new `MulmoScriptMethods.hasClosingCredit(script)`.
- `src/utils/context.ts` — use `hasClosingCredit` at the credit-append site.
- Tests: `getPadding` cases for both credit / no-credit (`test_combine_audio_files2.ts`), updated `updateDurations` expectations (`test_combine_audio_files.ts`), new `test/methods/test_mulmo_script.ts` for `hasClosingCredit`.

Full suite: 958 tests, 0 failures; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio timing around closing credits.
  * Applied closing-credit spacing to the correct preceding content beat.
  * Corrected silence and padding calculations when closing credits are present or absent.

* **Tests**
  * Expanded coverage for audio padding, silence durations, and closing-credit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->