### PR TITLE
docs: clarify closingPadding vs outroPadding

### DIFF
--- a/docs/feature.md
+++ b/docs/feature.md
@@ -325,8 +325,8 @@ Fine-tune timing between beats and silence at audio start/end.
 **グローバル設定 / Global Settings:**
 - `introPadding`: 音声開始前の無音時間（秒、デフォルト: 1.0）/ Silence before first audio
 - `padding`: Beat間の無音時間（秒、デフォルト: 0.3）/ Silence between beats
-- `closingPadding`: 最終Beat前の無音時間（秒、デフォルト: 0.8）/ Silence before last beat
-- `outroPadding`: 音声終了後の無音時間（秒、デフォルト: 1.0）/ Silence after last audio
+- `closingPadding`: 最終Beat（通常はクロージングクレジット）の**前**の無音時間（秒、デフォルト: 0.8）。最終Beatの後ろは `outroPadding` を使う / Silence before the last beat (typically the closing credit); for padding after the last beat use outroPadding
+- `outroPadding`: 音声**末尾**（最終Beatの後・BGMフェードアウト）の無音時間（秒、デフォルト: 1.0）。`closingPadding` とは別 / Silence after the last beat at the very end of the audio, where the BGM fades out (distinct from closingPadding)
 - `suppressSpeech`: 音声生成の抑制（デフォルト: false）/ Suppress speech generation
 
 **Beat個別設定 / Per-Beat Settings:**

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -488,8 +488,18 @@ export const audioParamsSchema = z
   .object({
     padding: z.number().optional().default(0.3).describe("Padding between beats"), // seconds
     introPadding: z.number().optional().default(1.0).describe("Padding at the beginning of the audio"), // seconds
-    closingPadding: z.number().optional().default(0.8).describe("Padding before the last beat"), // seconds
-    outroPadding: z.number().optional().default(1.0).describe("Padding at the end of the audio"), // seconds
+    closingPadding: z
+      .number()
+      .optional()
+      .default(0.8)
+      .describe("Padding before the last beat (typically the closing credit). For padding after the last beat, use outroPadding"), // seconds
+    outroPadding: z
+      .number()
+      .optional()
+      .default(1.0)
+      .describe(
+        "Padding after the last beat, at the very end of the audio where the BGM fades out (distinct from closingPadding, which comes before the last beat)",
+      ), // seconds
     bgm: mediaSourceSchema.optional(),
     bgmVolume: z.number().optional().default(0.2).describe("Volume of the background music"),
     audioVolume: z.number().optional().default(1.0).describe("Volume of the audio"),


### PR DESCRIPTION
## Summary

Documentation-only clarification of the two easily-confused audio padding params (from the discussion on [#1488](https://github.com/receptron/mulmocast-cli/issues/1488) — the `closingPadding` "not working" feedback). **No behavior change, non-breaking.**

The padding timeline:

```
[introPadding] beat0 [padding] beat1 … beat[N-2] [closingPadding] beat[N-1] [outroPadding]
```

- **`closingPadding`** — pause **before** the last beat (typically the closing credit logo). Baked into `beat.duration` in `combine_audio_files_agent`.
- **`outroPadding`** — padding **after** the last beat, at the very end of the audio where the BGM fades out. Added at the BGM/mix stage (`add_bgm_agent`).

Both names connote "the end," so they were easy to conflate. This PR cross-references them in:
- the zod `.describe()` strings (`src/types/schema.ts`)
- `docs/feature.md`

## Note

`src/types/schema.ts` is touched, but only the runtime `.describe()` metadata (no type-shape change), so no urgent `@mulmocast/types` release is required — it rides the next publish.

## Context

Supersedes the behavior-change approach in #1489 (closed). On reflection, `closingPadding` is the pre-credit pause by design, and the "closing pause" a credit-less deck wants is already served by `outroPadding` — so this is a docs issue, not a bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between `closingPadding` and `outroPadding` in the audio timing settings.
  * Documented that `closingPadding` applies before the final beat, while `outroPadding` applies after the final beat as the audio ends.
  * Updated in-app field descriptions to match the revised guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->