### PR TITLE
fix: keep image_plugins out of the browser bundle chain

### DIFF
--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -1,5 +1,7 @@
 export * from "./mulmo_presentation_style.js";
 export * from "./mulmo_studio_context.js";
 export * from "./mulmo_media_source.js";
-export * from "./mulmo_beat.js";
+// Node-only MulmoBeatMethods (includes getPlugin). The browser-safe subset lives in
+// ./mulmo_beat.js and is re-exported by ../index.common.js for mulmocast/browser.
+export * from "./mulmo_beat_node.js";
 export * from "./mulmo_script.js";

--- a/src/methods/mulmo_beat.ts
+++ b/src/methods/mulmo_beat.ts
@@ -1,7 +1,5 @@
 import { MulmoBeat } from "../types/index.js";
 
-import { findImagePlugin } from "../utils/image_plugins/index.js";
-
 type AnimationConfig = { fps?: number; movie?: boolean };
 
 /** Type guard: checks if animation value is an object config like { fps: 30 } */
@@ -36,13 +34,6 @@ export const MulmoBeatMethods = {
       return beat.htmlPrompt.prompt + "\n\n[data]\n" + JSON.stringify(beat.htmlPrompt.data, null, 2);
     }
     return beat?.htmlPrompt?.prompt;
-  },
-  getPlugin(beat: MulmoBeat) {
-    const plugin = findImagePlugin(beat?.image?.type);
-    if (!plugin) {
-      throw new Error(`invalid beat image type: ${beat.image}`); // TODO: cause
-    }
-    return plugin;
   },
   getImageReferenceForImageGenerator(beat: MulmoBeat, imageRefs: Record<string, string>) {
     const imageNames = beat.imageNames ?? Object.keys(imageRefs); // use all images if imageNames is not specified

--- a/src/methods/mulmo_beat_node.ts
+++ b/src/methods/mulmo_beat_node.ts
@@ -1,0 +1,12 @@
+import { MulmoBeat } from "../types/index.js";
+import { MulmoBeatMethods as MulmoBeatMethodsBrowser } from "./mulmo_beat.js";
+import { getBeatPlugin } from "../utils/image_plugins/index.js";
+
+// Node-only extension of MulmoBeatMethods. Kept out of methods/mulmo_beat.ts so
+// browser bundles (mulmocast/browser) do not pull in image_plugins → mulmocast-vision → puppeteer.
+export const MulmoBeatMethods = {
+  ...MulmoBeatMethodsBrowser,
+  getPlugin(beat: MulmoBeat) {
+    return getBeatPlugin(beat);
+  },
+};

--- a/src/utils/image_plugins/index.ts
+++ b/src/utils/image_plugins/index.ts
@@ -9,7 +9,7 @@ import * as pluginBeat from "./beat.js";
 import * as pluginVoiceOver from "./voice_over.js";
 import * as pluginVision from "./vision.js";
 import * as pluginSlide from "./slide.js";
-import { ImageProcessorParams } from "../../types/index.js";
+import { ImageProcessorParams, MulmoBeat } from "../../types/index.js";
 
 const imagePlugins: {
   imageType: string;
@@ -33,4 +33,12 @@ const imagePlugins: {
 
 export const findImagePlugin = (imageType?: string) => {
   return imagePlugins.find((plugin) => plugin.imageType === imageType);
+};
+
+export const getBeatPlugin = (beat: MulmoBeat) => {
+  const plugin = findImagePlugin(beat?.image?.type);
+  if (!plugin) {
+    throw new Error(`invalid beat image type: ${beat.image}`);
+  }
+  return plugin;
 };

--- a/test/methods/test_mulmo_beat_entry_split.ts
+++ b/test/methods/test_mulmo_beat_entry_split.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression test for the browser-safe / Node-augmented split of MulmoBeatMethods
+// introduced to keep utils/image_plugins (and its puppeteer/mulmocast-vision chain)
+// out of the mulmocast/browser bundle.
+//
+// If this test fails, mulmocast/browser will start pulling puppeteer into browser
+// bundles again and Vite consumers will hit
+// `TypeError: import_browser_external_node_util$1.debuglog is not a function`.
+
+test("methods/mulmo_beat.ts stays browser-safe: no getPlugin", async () => {
+  const { MulmoBeatMethods } = await import("../../src/methods/mulmo_beat.js");
+  assert.equal(typeof MulmoBeatMethods.isAnimationEnabled, "function");
+  assert.equal(typeof MulmoBeatMethods.getHtmlPrompt, "function");
+  assert.equal(
+    (MulmoBeatMethods as unknown as Record<string, unknown>).getPlugin,
+    undefined,
+    "getPlugin must not exist on the browser-safe MulmoBeatMethods — it would drag image_plugins into mulmocast/browser",
+  );
+});
+
+test("methods/index.ts (Node entry) exposes getPlugin on MulmoBeatMethods", async () => {
+  const { MulmoBeatMethods } = await import("../../src/methods/index.js");
+  assert.equal(typeof MulmoBeatMethods.getPlugin, "function");
+  // The Node version must still carry the browser-safe methods (spread contract).
+  assert.equal(typeof MulmoBeatMethods.isAnimationEnabled, "function");
+  assert.equal(typeof MulmoBeatMethods.getHtmlPrompt, "function");
+});
+
+test("mulmo_beat.ts source does not import image_plugins", async () => {
+  const fs = await import("node:fs/promises");
+  const url = await import("node:url");
+  const source = await fs.readFile(url.fileURLToPath(new URL("../../src/methods/mulmo_beat.ts", import.meta.url)), "utf8");
+  assert.equal(
+    /from ["'][^"']*image_plugins/.test(source),
+    false,
+    "src/methods/mulmo_beat.ts must not import from image_plugins — that pulls puppeteer into mulmocast/browser",
+  );
+});


### PR DESCRIPTION
## Summary

\`mulmocast/browser\` を import すると renderer bundle に \`@puppeteer/browsers\` が引き込まれ、Vite 環境で以下のランタイムエラーが出る問題を修正します:

\`\`\`
TypeError: (0 , import_browser_external_node_util$1.debuglog) is not a function
    at debug node_modules/@puppeteer/browsers/lib/debug.js:8:25
    at node_modules/@puppeteer/browsers/lib/Cache.js:12:19
    ...
    at node_modules/.vite/deps/mulmocast_browser.js
\`\`\`

## 原因

2.7.0 で \`index.common.js\` (mulmocast/browser から再 export される) に \`estimate_usage.js\` が追加されたのを起点に、以下の chain が発生:

\`\`\`
mulmocast/browser
 -> index.common.js が estimate_usage.js を re-export
 -> estimate_usage.ts が methods/mulmo_beat.ts の MulmoBeatMethods を import
 -> mulmo_beat.ts が top-level で utils/image_plugins/index.ts の findImagePlugin を import
 -> image_plugins/index.ts が全 plugin を eager import (image_plugins/vision.ts 含む)
 -> vision.ts が mulmocast-vision を import
 -> mulmocast-vision が puppeteer を import
 -> puppeteer が @puppeteer/browsers を import
 -> @puppeteer/browsers/debug.js が node:util.debuglog を module load 時に呼ぶ
 -> ブラウザでは node:util が externalize されていて .debuglog は関数でない -> throw
\`\`\`

\`estimate_usage.ts\` が実際に使うのは \`MulmoBeatMethods.getHtmlPrompt\` だけで plugin 参照は不要なのに、\`mulmo_beat.ts\` の getPlugin 実装のために findImagePlugin が top-level import されており、tree-shake できない構造になっていました。

## Fix

\`MulmoBeatMethods\` を「browser-safe な純粋関数群」と「plugin 参照が必要な Node 用の \`getPlugin\`」に分割:

- **\`methods/mulmo_beat.ts\`**: \`findImagePlugin\` の import と \`getPlugin\` を削除。以降 browser-safe。
- **\`methods/mulmo_beat_node.ts\` (新規)**: \`mulmo_beat.ts\` の \`MulmoBeatMethods\` を spread し、\`getPlugin\` を継ぎ足した Node 版を export。
- **\`methods/index.ts\`**: \`mulmo_beat.js\` の代わりに \`mulmo_beat_node.js\` を re-export。
- **\`utils/image_plugins/index.ts\`**: 新たに \`getBeatPlugin(beat)\` を export (\`mulmo_beat_node.ts\` から利用 + 直接 import 用の代替 API)。

## 互換性

- ✅ **Node consumer** (\`import { MulmoBeatMethods } from "mulmocast"\`): shape 完全維持 (\`getPlugin\` を含む)。動作も従来通り。
- ✅ **Browser consumer** (\`mulmocast/browser\` 経由): puppeteer chain が解消され、エラーが消える。
- ⚠️ 内部パス \`mulmocast/lib/methods/mulmo_beat.js\` を直接 import しているコードが仮にあれば \`getPlugin\` は無い。公式 public path ではないため通常影響なし。

## Test plan

- [x] \`yarn build\` パス
- [x] \`yarn lint\` 0 errors
- [x] mulmocast-app の renderer で puppeteer chain が消え、\`debuglog is not a function\` エラーが解消することを実機で確認
- [ ] \`MulmoBeatMethods.getPlugin\` を使う従来の \`image_agents.ts\` の image preprocessing が引き続き動くこと (次の movie / image 生成で確認)

## User Prompt

> import_browser_external_node_util\$1.debuglog is not a function ってなに？ package あげたらエラー出た。
> ...
> 1で、estimate_usage.js/estimate_usage_format.js が壊れる原因の理由を特定して直してほしい
> ...
> 削除せず Node専用の形で残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving image plugins from beat image types.
  * Node-based usage now includes image plugin lookup capabilities.

* **Bug Fixes**
  * Improved handling of invalid or unsupported beat image types with clear errors.
  * Browser builds no longer include Node-specific image/plugin dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->