### PR TITLE
mulmocast@2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.7.2](https://github.com/receptron/mulmocast-cli/releases/tag/2.7.2) (2026-07-12)
+
+- **Fix `mulmocast/browser` puppeteer bleed-through** ([#1491](https://github.com/receptron/mulmocast-cli/pull/1491)): since 2.7.0, importing `mulmocast/browser` in a Vite/Rollup renderer pulled `utils/image_plugins` → `mulmocast-vision` → `puppeteer` → `@puppeteer/browsers/debug.js` into the browser bundle, which hit `node:util.debuglog` at module load and threw `TypeError: import_browser_external_node_util$1.debuglog is not a function`. Split `MulmoBeatMethods` into a browser-safe subset (`methods/mulmo_beat.ts`, no `getPlugin`) and a Node-only extension (`methods/mulmo_beat_node.ts`, adds `getPlugin`). `methods/index.ts` now re-exports the Node version so `import { MulmoBeatMethods } from "mulmocast"` keeps `getPlugin` intact.
+- No public API change for Node consumers; no `src/types/` change (so `@mulmocast/types` stays at 2.7.0).
+
+📦 **npm**: [`mulmocast@2.7.2`](https://www.npmjs.com/package/mulmocast/v/2.7.2)
+
 ## [2.7.1](https://github.com/receptron/mulmocast-cli/releases/tag/2.7.1) (2026-07-12)
 
 - **Network timeout hardening** (6-part series, [#1476](https://github.com/receptron/mulmocast-cli/pull/1476)–[#1481](https://github.com/receptron/mulmocast-cli/pull/1481)): every outbound network call now has an explicit timeout, so a hung connection fails fast with a clear error instead of stalling the pipeline (or CI) indefinitely:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "",
   "type": "module",
   "main": "lib/index.node.js",


### PR DESCRIPTION
Release version bump for `mulmocast@2.7.2`.

## Changes since 2.7.1

- **Fix `mulmocast/browser` puppeteer bleed-through** (#1491): Vite renderers importing `mulmocast/browser` no longer crash at module load with `TypeError: import_browser_external_node_util$1.debuglog is not a function`.

## Files

- `package.json`: 2.7.1 → 2.7.2
- `types/package.json`: unchanged (no `src/types/` change)
- `CHANGELOG.md`: add 2.7.2 entry

## Test plan

- [x] `yarn install` pass
- [x] `yarn lint` 0 errors
- [x] `yarn build` pass

After merge: publish `mulmocast@2.7.2` to npm, tag `2.7.2`, GitHub release with `--latest=false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed browser renderer compatibility by preventing Node-only functionality from being included in Vite/Rollup builds.
  * Preserved plugin access for Node.js consumers.

* **Release**
  * Updated the package to version 2.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->