### PR TITLE
Add p-video & grok-1.5, refresh Replicate specs, silent-by-default audio, spill-over movies

### DIFF
--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -168,10 +168,18 @@ const getSpillOverGroup = (context: MulmoStudioContext, mediaDurations: MediaDur
   const group = [index];
   for (let i = index + 1; i < context.studio.beats.length; i++) {
     const media = mediaDurations[i];
-    // An empty-text beat continues the preceding narration (spill-over) even when it
-    // carries its own silent visuals (a moviePrompt or a movie without audio);
-    // only a beat with its own audio — TTS text or a movie soundtrack — ends the group.
-    const isSilentContinuation = !context.studio.script.beats[i].text?.trim() && media.audioDuration === 0 && !(media.movieDuration > 0 && media.hasMovieAudio);
+    // An empty-text beat with only a moviePrompt (no generated audio requested) continues
+    // the preceding narration (spill-over). Generated movies don't exist yet at this point,
+    // so movieDuration === 0; imported movies and animated html_tailwind beats have
+    // movieDuration > 0 and keep their own timeline, ending the group as before.
+    const beat = context.studio.script.beats[i];
+    const isSilentContinuation =
+      !beat.text?.trim() &&
+      media.audioDuration === 0 &&
+      media.movieDuration === 0 &&
+      Boolean(beat.moviePrompt) &&
+      !beat.soundEffectPrompt &&
+      beat.movieParams?.generateAudio !== true;
     if (media.hasMedia && !isSilentContinuation) {
       break;
     }

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -166,7 +166,15 @@ const getVoiceOverGroup = (context: MulmoStudioContext, index: number) => {
 
 const getSpillOverGroup = (context: MulmoStudioContext, mediaDurations: MediaDuration[], index: number) => {
   const group = [index];
-  for (let i = index + 1; i < context.studio.beats.length && !mediaDurations[i].hasMedia; i++) {
+  for (let i = index + 1; i < context.studio.beats.length; i++) {
+    const media = mediaDurations[i];
+    // An empty-text beat continues the preceding narration (spill-over) even when it
+    // carries its own silent visuals (a moviePrompt or a movie without audio);
+    // only a beat with its own audio — TTS text or a movie soundtrack — ends the group.
+    const isSilentContinuation = !context.studio.script.beats[i].text?.trim() && media.audioDuration === 0 && !(media.movieDuration > 0 && media.hasMovieAudio);
+    if (media.hasMedia && !isSilentContinuation) {
+      break;
+    }
     group.push(i);
   }
   return group;

--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -10,7 +10,7 @@ import {
   ffmpegGetMediaDuration,
 } from "../utils/ffmpeg_utils.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
-import { MulmoBeatMethods } from "../methods/index.js";
+import { MulmoBeatMethods, MulmoPresentationStyleMethods } from "../methods/index.js";
 import { userAssert } from "../utils/utils.js";
 import { getAudioInputIdsError } from "../utils/error_cause.js";
 
@@ -179,7 +179,7 @@ const getSpillOverGroup = (context: MulmoStudioContext, mediaDurations: MediaDur
       media.movieDuration === 0 &&
       Boolean(beat.moviePrompt) &&
       !beat.soundEffectPrompt &&
-      beat.movieParams?.generateAudio !== true;
+      !MulmoPresentationStyleMethods.generatedMovieHasAudio(context.presentationStyle, beat);
     if (media.hasMedia && !isSilentContinuation) {
       break;
     }

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -105,8 +105,9 @@ async function generateMovie(
   const audio = provider2MovieAgent.replicate.modelParams[model].audio;
 
   if (audio.mode === AUDIO_MODE_OPTIONAL) {
-    // Always send the flag: several models (e.g. seedance-2.0) default it to true,
-    // which silently embeds generated audio. Silent unless explicitly requested.
+    // Always send the flag: several models (e.g. seedance-2.0's generate_audio, p-video's
+    // save_audio) default it to true, which silently embeds generated audio.
+    // Silent unless explicitly requested.
     (input as Record<string, unknown>)[audio.param] = generateAudio ?? false;
   }
   if (generateAudio !== undefined) {
@@ -117,10 +118,6 @@ async function generateMovie(
     } else if (audio.mode === AUDIO_MODE_ALWAYS && generateAudio === false) {
       GraphAILogger.warn(`movieReplicateAgent: model ${model} always generates audio — ignoring generateAudio=false`);
     }
-  }
-  if (audio.mode === AUDIO_MODE_NEVER && audio.param) {
-    // The model embeds generated audio unless this input is explicitly disabled.
-    (input as Record<string, unknown>)[audio.param] = false;
   }
 
   try {

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -104,16 +104,23 @@ async function generateMovie(
   // Add generate_audio if the model supports it
   const audio = provider2MovieAgent.replicate.modelParams[model].audio;
 
+  if (audio.mode === AUDIO_MODE_OPTIONAL) {
+    // Always send the flag: several models (e.g. seedance-2.0) default it to true,
+    // which silently embeds generated audio. Silent unless explicitly requested.
+    (input as Record<string, unknown>)[audio.param] = generateAudio ?? false;
+  }
   if (generateAudio !== undefined) {
-    if (audio.mode === AUDIO_MODE_OPTIONAL) {
-      (input as Record<string, unknown>)[audio.param] = generateAudio;
-    } else if (audio.mode === AUDIO_MODE_NEVER && generateAudio === true) {
+    if (audio.mode === AUDIO_MODE_NEVER && generateAudio === true) {
       throw new Error(`Model ${model} does not support audio generation`, {
         cause: agentGenerationError("movieReplicateAgent", imageAction, unsupportedModelTarget),
       });
     } else if (audio.mode === AUDIO_MODE_ALWAYS && generateAudio === false) {
       GraphAILogger.warn(`movieReplicateAgent: model ${model} always generates audio — ignoring generateAudio=false`);
     }
+  }
+  if (audio.mode === AUDIO_MODE_NEVER && audio.param) {
+    // The model embeds generated audio unless this input is explicitly disabled.
+    (input as Record<string, unknown>)[audio.param] = false;
   }
 
   try {

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -38,6 +38,8 @@ import {
   provider2SoundEffectAgent,
   provider2LipSyncAgent,
   defaultProviders,
+  getModelAudio,
+  AUDIO_MODE_ALWAYS,
 } from "../types/provider2agent.js";
 
 const defaultTextSlideStyles = [
@@ -168,6 +170,17 @@ export const MulmoPresentationStyleMethods = {
       movieParams,
       keyName: agentInfo.keyName,
     };
+  },
+  // True when the movie generated for this beat will carry an audio track:
+  // the model always embeds audio, or audio generation is explicitly requested.
+  generatedMovieHasAudio(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat): boolean {
+    const movieParams = { ...presentationStyle.movieParams, ...beat.movieParams };
+    if (movieParams?.generateAudio === true) {
+      return true;
+    }
+    const provider = text2MovieProviderSchema.parse(movieParams?.provider ?? defaultProviders.text2movie) as keyof typeof provider2MovieAgent;
+    const model = movieParams?.model ?? provider2MovieAgent[provider].defaultModel;
+    return getModelAudio(provider, model)?.mode === AUDIO_MODE_ALWAYS;
   },
   getSoundEffectAgentInfo(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat) {
     const soundEffectProvider = (beat.soundEffectParams?.provider ??

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -124,10 +124,7 @@ export type ReplicateModel = `${string}/${string}`;
 export const AUDIO_MODE_NEVER = "never" as const;
 export const AUDIO_MODE_ALWAYS = "always" as const;
 export const AUDIO_MODE_OPTIONAL = "optional" as const;
-// For AUDIO_MODE_NEVER, an optional `param` names a model input that must be set to
-// false to keep the output silent (e.g. p-video's `save_audio`, which defaults to true).
-type MovieAudioSpec =
-  { mode: typeof AUDIO_MODE_NEVER; param?: string } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
+type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
@@ -380,14 +377,14 @@ export const provider2MovieAgent = {
         durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
         start_image: "image",
         last_image: "last_frame_image",
-        audio: { mode: AUDIO_MODE_NEVER, param: "save_audio" },
+        audio: { mode: AUDIO_MODE_OPTIONAL, param: "save_audio" },
         price_per_sec: 0.02, // 720p, draft mode off ($0.04 at 1080p)
       },
       "xai/grok-imagine-video-1.5": {
         durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",
         start_image_required: true,
-        audio: { mode: AUDIO_MODE_NEVER },
+        audio: { mode: AUDIO_MODE_ALWAYS },
         price_per_sec: 0.08,
       },
     } as Record<ReplicateModel, ReplicateMovieModelParams>,

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -124,7 +124,10 @@ export type ReplicateModel = `${string}/${string}`;
 export const AUDIO_MODE_NEVER = "never" as const;
 export const AUDIO_MODE_ALWAYS = "always" as const;
 export const AUDIO_MODE_OPTIONAL = "optional" as const;
-type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
+// For AUDIO_MODE_NEVER, an optional `param` names a model input that must be set to
+// false to keep the output silent (e.g. p-video's `save_audio`, which defaults to true).
+type MovieAudioSpec =
+  { mode: typeof AUDIO_MODE_NEVER; param?: string } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
@@ -177,10 +180,12 @@ export const provider2MovieAgent = {
       "minimax/hailuo-2.3",
       "minimax/hailuo-2.3-fast",
       "pixverse/pixverse-v5",
+      "prunaai/p-video",
+      "xai/grok-imagine-video-1.5",
     ],
     modelParams: {
       "bytedance/seedance-1-lite": {
-        durations: [5, 10],
+        durations: [4, 5, 6, 7, 8, 9, 10, 11, 12],
         start_image: "image",
         last_image: "last_frame_image",
         audio: { mode: AUDIO_MODE_NEVER },
@@ -292,10 +297,13 @@ export const provider2MovieAgent = {
         price_per_sec: 0.12,
       },
       "wan-video/wan-2.2-i2v-fast": {
+        // No duration input: length is num_frames (default 81) / frames_per_second (default 16) ≈ 5s.
         durations: [5],
         start_image: "image",
+        start_image_required: true,
+        last_image: "last_image",
         audio: { mode: AUDIO_MODE_NEVER },
-        price_per_sec: 0.012,
+        price_per_sec: 0.01, // $0.05 per 81-frame 480p video; up to $0.145 at 720p
       },
       "wan-video/wan-2.2-t2v-fast": {
         durations: [5],
@@ -328,7 +336,7 @@ export const provider2MovieAgent = {
         last_image: "end_image",
         reference_images_param: "reference_images",
         audio: { mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
-        price_per_sec: 0.3,
+        price_per_sec: 0.28, // 'pro' (1080p, default); 'standard' $0.168, '4k' $0.42
       },
       "kwaivgi/kling-v3-video": {
         durations: [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
@@ -367,6 +375,20 @@ export const provider2MovieAgent = {
         last_image: "last_frame_image",
         audio: { mode: AUDIO_MODE_NEVER },
         price_per_sec: 0.12,
+      },
+      "prunaai/p-video": {
+        durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+        start_image: "image",
+        last_image: "last_frame_image",
+        audio: { mode: AUDIO_MODE_NEVER, param: "save_audio" },
+        price_per_sec: 0.02, // 720p, draft mode off ($0.04 at 1080p)
+      },
+      "xai/grok-imagine-video-1.5": {
+        durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        start_image: "image",
+        start_image_required: true,
+        audio: { mode: AUDIO_MODE_NEVER },
+        price_per_sec: 0.08,
       },
     } as Record<ReplicateModel, ReplicateMovieModelParams>,
   },

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -124,7 +124,7 @@ export type ReplicateModel = `${string}/${string}`;
 export const AUDIO_MODE_NEVER = "never" as const;
 export const AUDIO_MODE_ALWAYS = "always" as const;
 export const AUDIO_MODE_OPTIONAL = "optional" as const;
-type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
+export type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
@@ -578,6 +578,11 @@ export const llm = Object.keys(provider2LLMAgent) as (keyof typeof provider2LLMA
 export type LLM = keyof typeof provider2LLMAgent;
 
 export const htmlLLMProvider = ["openai", "anthropic", "mock"];
+
+export const getModelAudio = (provider: keyof typeof provider2MovieAgent, model: string): MovieAudioSpec | undefined => {
+  const modelParams = provider2MovieAgent[provider]?.modelParams as Record<string, { audio?: MovieAudioSpec }>;
+  return modelParams?.[model]?.audio;
+};
 
 export const getModelDuration = (provider: keyof typeof provider2MovieAgent, model: string, movieDuration?: number) => {
   const modelParams = provider2MovieAgent[provider]?.modelParams as Record<string, { durations?: number[] }>;

--- a/test/utils/test_estimate_usage.ts
+++ b/test/utils/test_estimate_usage.ts
@@ -124,16 +124,16 @@ describe("estimateUsage: htmlPrompt beats", () => {
 
 describe("estimateUsage: movie / soundEffect / lipSync", () => {
   it("snaps an explicit beat duration to the model's supported durations as exact", () => {
-    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", moviePrompt: "wave", duration: 7 }]));
+    const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "", moviePrompt: "wave", duration: 7.5 }]));
     const movie = byProcess(records, "movie")[0];
     assert.equal(movie.model, "bytedance/seedance-1-lite");
-    assert.deepEqual(movie.predictSec, { value: 10, precision: "exact" }); // supported durations are [5, 10]
-    assert.ok(Math.abs((movie.costUSD ?? 0) - 10 * 0.036) < 1e-12);
+    assert.deepEqual(movie.predictSec, { value: 8, precision: "exact" }); // supported durations are [4..12]
+    assert.ok(Math.abs((movie.costUSD ?? 0) - 8 * 0.036) < 1e-12);
   });
 
   it("estimates the duration from the narration text when no duration is set", () => {
     const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "こんにちは。これはテストです。", moviePrompt: "city" }]));
-    assert.deepEqual(byProcess(records, "movie")[0].predictSec, { value: 5, precision: "estimated" });
+    assert.deepEqual(byProcess(records, "movie")[0].predictSec, { value: 4, precision: "estimated" });
   });
 
   it("emits soundEffect only for movie beats, and lipSync when enabled", () => {


### PR DESCRIPTION
Two related improvements to Replicate movie generation, motivated by building a whiteboard-animation deck where slides are drawn from a blank board to a `lastFrameImageName` target.

## 1. New models + spec refresh (`provider2agent`, `movie_replicate_agent`)

**New:**
- `prunaai/p-video` — durations 1–20s, start + last frame conditioning, $0.02/s (720p, draft off). The best drawing-animation results of the six models tested, at the lowest per-second price.
- `xai/grok-imagine-video-1.5` — 1–15s, start image required, $0.08/s.

**Refreshed against current Replicate schemas:**
- `seedance-1-lite`: durations 4–12s (was `[5, 10]`)
- `kling-v3-omni-video`: $0.28/s at the default `pro` mode (tiers noted in comment)
- `wan-2.2-i2v-fast`: now supports `last_image`; `image` is required; priced per video (~$0.05/480p)

**Silent by default:** several models embed generated audio unless told not to — p-video via `save_audio` (default true) and OPTIONAL-mode models like `seedance-2.0` via `generate_audio` (default true). This mixed unexpected music into narration-only beats. Now:
- `MovieAudioSpec`'s NEVER variant takes an optional `param` naming the disable switch, always sent as `false` (used by p-video)
- OPTIONAL-mode models always receive their flag as `generateAudio ?? false` — audio is opt-in via `generateAudio: true`

Replicate agent only; the GenAI agent is untouched (Google's API has no toggle).

## 2. Spill-over groups accept silent movie beats (`combine_audio_files_agent`)

An empty-text beat is the documented way to spill narration across slides, but adding a `moviePrompt` to such a beat flipped `hasMedia` and broke it out of the group — the narrated beat kept the entire narration and the movie beat collapsed to the 1-second minimum.

`getSpillOverGroup` now keeps a follower when it is a *silent continuation*: empty text, no own audio, no movie soundtrack. `hasMedia` itself is unchanged (per review feedback, the special-casing is localized to spill-over grouping), so `voice_over` grouping and other consumers are unaffected; a movie with its own audio still ends the group.

Verified with a 26-beat production script: one narration now flows across two slides that each draw themselves (16.3s + 16.3s even split, previously 32.9s + 1s).

## Testing

- `yarn ci_test`: 958 tests, 954 pass, 0 fail (2 estimate-usage expectations updated for the seedance duration change)
- `yarn lint`: 0 errors
- End-to-end: generated intros with p-video / wan / pixverse / veo-3.1-lite against real scripts; confirmed p-video output has no audio track and spill-over splits evenly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional movie-generation models and expanded duration/audio-mode configuration.
  * Improved detection of whether generated movies will include audio, enabling more accurate silent-segment handling.
* **Bug Fixes**
  * Spill-over audio groups now correctly extend across silent-visual segments and stop when real (non-silent-continuation) media appears.
  * Made optional audio mode parameter handling consistent for movie generation.
  * Refined movie model pricing/parameter metadata.
* **Tests**
  * Updated movie-duration estimation snapshots and associated cost calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->