### PR TITLE
fix: spill-over silent-continuation rule + p-video/grok audio modes (follow-up to #1493 review)

### DIFF
--- a/src/agents/combine_audio_files_agent.ts
+++ b/src/agents/combine_audio_files_agent.ts
@@ -10,7 +10,7 @@ import {
   ffmpegGetMediaDuration,
 } from "../utils/ffmpeg_utils.js";
 import { MulmoMediaSourceMethods } from "../methods/mulmo_media_source.js";
-import { MulmoBeatMethods } from "../methods/index.js";
+import { MulmoBeatMethods, MulmoPresentationStyleMethods } from "../methods/index.js";
 import { userAssert } from "../utils/utils.js";
 import { getAudioInputIdsError } from "../utils/error_cause.js";
 
@@ -164,15 +164,24 @@ const getVoiceOverGroup = (context: MulmoStudioContext, index: number) => {
   return group;
 };
 
+const isSilentContinuation = (context: MulmoStudioContext, media: MediaDuration, beat: MulmoBeat) => {
+  // Only an empty-text beat whose visuals are a *generated* movie that will stay
+  // silent may continue the preceding narration. Imported movies and animated
+  // html_tailwind beats keep their own timeline (movieDuration > 0) and end the group.
+  return (
+    !beat.text?.trim() &&
+    media.audioDuration === 0 &&
+    media.movieDuration === 0 &&
+    Boolean(beat.moviePrompt) &&
+    !MulmoPresentationStyleMethods.generatedMovieHasAudio(context.presentationStyle, beat)
+  );
+};
+
 const getSpillOverGroup = (context: MulmoStudioContext, mediaDurations: MediaDuration[], index: number) => {
   const group = [index];
   for (let i = index + 1; i < context.studio.beats.length; i++) {
     const media = mediaDurations[i];
-    // An empty-text beat continues the preceding narration (spill-over) even when it
-    // carries its own silent visuals (a moviePrompt or a movie without audio);
-    // only a beat with its own audio — TTS text or a movie soundtrack — ends the group.
-    const isSilentContinuation = !context.studio.script.beats[i].text?.trim() && media.audioDuration === 0 && !(media.movieDuration > 0 && media.hasMovieAudio);
-    if (media.hasMedia && !isSilentContinuation) {
+    if (media.hasMedia && !isSilentContinuation(context, media, context.studio.script.beats[i])) {
       break;
     }
     group.push(i);

--- a/src/agents/movie_replicate_agent.ts
+++ b/src/agents/movie_replicate_agent.ts
@@ -105,8 +105,9 @@ async function generateMovie(
   const audio = provider2MovieAgent.replicate.modelParams[model].audio;
 
   if (audio.mode === AUDIO_MODE_OPTIONAL) {
-    // Always send the flag: several models (e.g. seedance-2.0) default it to true,
-    // which silently embeds generated audio. Silent unless explicitly requested.
+    // Always send the flag: several models (e.g. seedance-2.0's generate_audio,
+    // p-video's save_audio) default it to true, which silently embeds generated audio.
+    // Silent unless explicitly requested.
     (input as Record<string, unknown>)[audio.param] = generateAudio ?? false;
   }
   if (generateAudio !== undefined) {
@@ -117,10 +118,6 @@ async function generateMovie(
     } else if (audio.mode === AUDIO_MODE_ALWAYS && generateAudio === false) {
       GraphAILogger.warn(`movieReplicateAgent: model ${model} always generates audio — ignoring generateAudio=false`);
     }
-  }
-  if (audio.mode === AUDIO_MODE_NEVER && audio.param) {
-    // The model embeds generated audio unless this input is explicitly disabled.
-    (input as Record<string, unknown>)[audio.param] = false;
   }
 
   try {

--- a/src/methods/mulmo_presentation_style.ts
+++ b/src/methods/mulmo_presentation_style.ts
@@ -38,6 +38,9 @@ import {
   provider2SoundEffectAgent,
   provider2LipSyncAgent,
   defaultProviders,
+  getMovieModelAudio,
+  AUDIO_MODE_ALWAYS,
+  AUDIO_MODE_OPTIONAL,
 } from "../types/provider2agent.js";
 
 const defaultTextSlideStyles = [
@@ -168,6 +171,16 @@ export const MulmoPresentationStyleMethods = {
       movieParams,
       keyName: agentInfo.keyName,
     };
+  },
+  generatedMovieHasAudio(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat): boolean {
+    const { movieParams } = MulmoPresentationStyleMethods.getMovieAgentInfo(presentationStyle, beat);
+    const provider = text2MovieProviderSchema.parse(movieParams?.provider ?? defaultProviders.text2movie) as keyof typeof provider2MovieAgent;
+    const model = movieParams?.model ?? provider2MovieAgent[provider].defaultModel;
+    const audio = getMovieModelAudio(provider, model);
+    if (audio?.mode === AUDIO_MODE_ALWAYS) {
+      return true;
+    }
+    return audio?.mode === AUDIO_MODE_OPTIONAL && movieParams?.generateAudio === true;
   },
   getSoundEffectAgentInfo(presentationStyle: MulmoPresentationStyle, beat: MulmoBeat) {
     const soundEffectProvider = (beat.soundEffectParams?.provider ??

--- a/src/types/provider2agent.ts
+++ b/src/types/provider2agent.ts
@@ -124,10 +124,7 @@ export type ReplicateModel = `${string}/${string}`;
 export const AUDIO_MODE_NEVER = "never" as const;
 export const AUDIO_MODE_ALWAYS = "always" as const;
 export const AUDIO_MODE_OPTIONAL = "optional" as const;
-// For AUDIO_MODE_NEVER, an optional `param` names a model input that must be set to
-// false to keep the output silent (e.g. p-video's `save_audio`, which defaults to true).
-type MovieAudioSpec =
-  { mode: typeof AUDIO_MODE_NEVER; param?: string } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
+type MovieAudioSpec = { mode: typeof AUDIO_MODE_NEVER } | { mode: typeof AUDIO_MODE_ALWAYS } | { mode: typeof AUDIO_MODE_OPTIONAL; param: string };
 type ReplicateMovieModelParams = {
   durations: number[];
   start_image: string | undefined;
@@ -380,14 +377,15 @@ export const provider2MovieAgent = {
         durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
         start_image: "image",
         last_image: "last_frame_image",
-        audio: { mode: AUDIO_MODE_NEVER, param: "save_audio" },
+        audio: { mode: AUDIO_MODE_OPTIONAL, param: "save_audio" },
         price_per_sec: 0.02, // 720p, draft mode off ($0.04 at 1080p)
       },
       "xai/grok-imagine-video-1.5": {
         durations: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
         start_image: "image",
         start_image_required: true,
-        audio: { mode: AUDIO_MODE_NEVER },
+        // The model always outputs synchronized audio; there is no input to disable it.
+        audio: { mode: AUDIO_MODE_ALWAYS },
         price_per_sec: 0.08,
       },
     } as Record<ReplicateModel, ReplicateMovieModelParams>,
@@ -590,6 +588,11 @@ export const getModelDuration = (provider: keyof typeof provider2MovieAgent, mod
     return largerDurations.length > 0 ? largerDurations[0] : durations[durations.length - 1];
   }
   return durations?.[0];
+};
+
+export const getMovieModelAudio = (provider: keyof typeof provider2MovieAgent, model: string): MovieAudioSpec | undefined => {
+  const modelParams = provider2MovieAgent[provider]?.modelParams as Record<string, { audio?: MovieAudioSpec }>;
+  return modelParams?.[model]?.audio;
 };
 
 // ---- Pricing metadata (for pre-run usage estimation and cost reporting) ----

--- a/test/agents/test_combine_audio_files.ts
+++ b/test/agents/test_combine_audio_files.ts
@@ -1014,3 +1014,137 @@ test("updateDurations multiple voice-over groups with different movies", async (
   assert.strictEqual(res[2], 100); // Until second voice-over
   assert.strictEqual(res[3], 100); // Remaining movie2: 200 - 100 = 100
 });
+
+// Spill-over grouping across movie beats: a silent generated movie continues the
+// narration group; anything with its own audio or an intrinsic timeline ends it.
+
+const spillOverNarration = { movieDuration: 0, audioDuration: 10, hasMedia: true, silenceDuration: 0, hasMovieAudio: false };
+const moviePromptMedia = { movieDuration: 0, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false };
+
+test("updateDurations spill-over continues over a silent moviePrompt beat", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({ text: "", moviePrompt: "draw the diagram" });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 5); // narration splits evenly across the group
+  assert.strictEqual(res[1], 5);
+});
+
+test("updateDurations spill-over ends at a moviePrompt beat with generateAudio", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    moviePrompt: "draw the diagram",
+    movieParams: { model: "bytedance/seedance-2.0", generateAudio: true },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 10); // narration stays on the first beat
+  assert.strictEqual(res[1], 1); // movie beat falls back to the default duration
+});
+
+test("updateDurations spill-over ends at a moviePrompt beat with an always-audio model", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    moviePrompt: "draw the diagram",
+    movieParams: { model: "xai/grok-imagine-video-1.5" },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 10);
+  assert.strictEqual(res[1], 1);
+});
+
+test("updateDurations spill-over ends at an imported silent movie beat", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 10, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    image: { type: "movie", source: { kind: "path", path: "test-movie.mp4" } },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6); // narration is not spilled over the movie
+  assert.strictEqual(res[1], 10); // the movie keeps its intrinsic duration
+});
+
+test("updateDurations spill-over ends at an animated html_tailwind beat with explicit duration", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 8, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    duration: 8,
+    image: { type: "html_tailwind", html: "<div>animated</div>", animation: true },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6);
+  assert.strictEqual(res[1], 8); // the animation keeps its own timeline
+});
+
+test("updateDurations silent movie beat still heads a voice-over group after narration", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 10, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 0, audioDuration: 3, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    image: { type: "movie", source: { kind: "path", path: "test-movie.mp4" } },
+  });
+  const beat3 = createMockBeat({
+    image: { type: "voice_over", startAt: 2 },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2, beat3);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6);
+  assert.strictEqual(res[1], 2); // until the voice-over starts (startAt)
+  assert.strictEqual(res[2], 8); // remaining movie duration
+});

--- a/test/methods/test_presentation_style.ts
+++ b/test/methods/test_presentation_style.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert";
 
 import { MulmoPresentationStyleMethods } from "../../src/methods/mulmo_presentation_style.js";
+import { createMockContext, createMockBeat } from "../actions/utils.js";
 
 test("defaultSpeaker isDefault", async () => {
   const presentationStyle = {
@@ -161,4 +162,49 @@ test("getResolvedSlideTheme: non-slide beat falls through to fallback (no throw)
   // Falls through to the presentation-level theme since beat.image.theme
   // doesn't apply (different image kind), instead of throwing.
   assert.equal(result.colors.bg, "PRES");
+});
+
+// generatedMovieHasAudio: resolves provider/model (including defaults) and the
+// model's audio mode to predict whether a generated movie will carry a soundtrack.
+
+test("generatedMovieHasAudio: replicate default model (audio never) is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave" });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: optional-audio model without generateAudio is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "bytedance/seedance-2.0" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: optional-audio model with generateAudio true has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "bytedance/seedance-2.0", generateAudio: true } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: always-audio replicate model has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "xai/grok-imagine-video-1.5" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: google always-audio model has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "google", model: "veo-3.1-generate-preview" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: google default model (audio never) is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "google" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: mock provider is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "mock" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
 });


### PR DESCRIPTION
## Summary

Follow-up to the review on #1493 (https://github.com/receptron/mulmocast-cli/pull/1493#issuecomment-4973516324). Targets the `replicate-models-and-spillover-movies` branch so it can be merged into #1493 directly.

- **`prunaai/p-video` → `AUDIO_MODE_OPTIONAL` with `save_audio`**: `generateAudio: true` now maps to `save_audio: true` instead of throwing a factually wrong "does not support audio generation". This removes the `NEVER + param` special case from `MovieAudioSpec` and the extra branch in `movie_replicate_agent.ts`; the OPTIONAL path (always send the flag, default `false`) covers it.
- **`xai/grok-imagine-video-1.5` → `AUDIO_MODE_ALWAYS`**: the model always outputs synchronized audio and has no disable input (verified against the live Replicate schema), so `generateAudio: true` no longer throws and `false` takes the existing warn path.
- **`getSpillOverGroup`**: a follower beat continues the narration group only when it is an empty-text `moviePrompt` beat with no intrinsic timeline (`movieDuration === 0`) whose generated movie will stay silent — decided by the new `MulmoPresentationStyleMethods.generatedMovieHasAudio` (resolves provider/model incl. defaults, checks the model's audio mode and `generateAudio`). Imported movies, animated `html_tailwind` beats, and audio-carrying generations end the group exactly as on `main`. The intended feature (one narration flowing across self-drawing slides) is preserved.
- **Tests**: 6 spill-over regression tests (incl. the animated `html_tailwind` case and the voice_over-after-silent-movie case) and 7 `generatedMovieHasAudio` unit tests (replicate/google/mock providers, default-model resolution).

## Items to Confirm / Review

- The silent-continuation rule is now *intent-based* (`moviePrompt` + model audio mode) instead of probe-based. Please confirm this matches the whiteboard-deck use case: an empty-text beat whose `moviePrompt` movie is generated with a start image (`beat.image` of type `image`/`textSlide` etc. is fine — only `movieDuration > 0`, i.e. imported movies / animated html_tailwind, ends the group).
- `generatedMovieHasAudio` mirrors the agent behavior on this branch (OPTIONAL flag always sent, default `false`). If the OPTIONAL default is later changed back to provider defaults, this predicate must change with it.
- `getMovieModelAudio` uses the same `as Record<...>` lookup pattern as the existing `getModelDuration`.
- Pricing (`kling-v3-omni` tier comment, `kling-v3-video` $0.30) and the `docs/movie_reference_images.md` matrix from the review are NOT addressed here — they are data/docs fixes independent of this code path.

## User Prompt

(Relayed from the review session, translated) "For spill-over — where audio is shared across multiple beats — allow the following beats to use a moviePrompt. Post the review findings and the concrete fix diff as PR comments, have Codex cross-check both the PR and the comments, and package the fix plus spill-over regression tests (including the html_tailwind case) as a PR against the PR branch."

## Implementation notes

- Review evidence: the three spill-over regressions were reproduced by running `updateDurations` on both `main` and the PR branch; model specs were verified against the live Replicate API. A Codex cross-review (read-only) independently AGREEd with the three spill-over findings, marked the model-spec items PARTIAL (unverifiable from its sandbox), and additionally flagged the animated `html_tailwind` case — covered here by the `movieDuration === 0` gate and a dedicated test.
- Checks: `yarn lint` 0 errors (`generateMovie` back to main-level warnings), `yarn build` clean, `yarn ci_test` 971 tests / 0 fail (13 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
