### PR TITLE
test/docs: spill-over regression tests + Replicate model matrix refresh (follow-up to #1493)

### DIFF
--- a/docs/movie_reference_images.md
+++ b/docs/movie_reference_images.md
@@ -121,7 +121,9 @@ For videos **longer than 8 seconds**, Veo 3.1 uses video extension (generating a
 | **seedance-1-lite/pro** | ✅ | ✅ | `last_frame_image` | ❌ | — |
 | **seedance-2.0/2.0-fast** | ✅ | ✅ | `last_frame_image` | optional | `generate_audio` |
 | **pixverse-v4.5** | ✅ | ✅ | `last_frame_image` | optional | `sound_effect_switch` |
+| **pixverse-v5** | ✅ | ✅ | `last_frame_image` | ❌ | — |
 | **hailuo-02** | ✅ | ✅ | `end_image` | ❌ | — |
+| **hailuo-02-fast / hailuo-2.3 / 2.3-fast** | ✅ | ❌ | — | ❌ | — |
 | **kling-v1.6/2.1/2.1-master** | ✅ | ❌ | — | ❌ | — |
 | **kling-v3-video/v3-omni-video** | ✅ | ✅ | `end_image` | optional | `generate_audio` |
 | **veo-2 (Replicate)** | ✅ | ❌ | — | ❌ | — |
@@ -129,10 +131,20 @@ For videos **longer than 8 seconds**, Veo 3.1 uses video extension (generating a
 | **veo-3.1/3.1-fast** | ✅ | ✅ | `last_frame_image` | optional | `generate_audio` |
 | **veo-3.1-lite** | ✅ | ✅ | `last_frame` | ❌ | — |
 | **minimax/video-01** | ✅ | ❌ | — | ❌ | — |
+| **runwayml/gen-4.5** | ✅ | ❌ | — | ❌ | — |
+| **alibaba/happyhorse-1.0** | ✅ | ❌ | — | ❌ | — |
+| **prunaai/p-video** | ✅ | ✅ | `last_frame_image` | optional | `save_audio` |
+| **xai/grok-imagine-video** | ✅ | ❌ | — | ❌ | — |
+| **xai/grok-imagine-video-1.5** | ✅ | ❌ | — | always | — |
 | **xai/grok-imagine-r2v** | ❌ | ❌ | — | ❌ | — |
-| **wan-video/wan-2.2** | ✅ | ❌ | — | ❌ | — |
+| **wan-2.2-i2v-fast** | ✅ | ✅ | `last_image` | ❌ | — |
+| **wan-2.2-t2v-fast** | ❌ | ❌ | — | ❌ | — |
 
 > **Note**: `referenceImages` is supported by Veo 3.1 (Google GenAI), Kling v3, and Grok R2V (Replicate).
+
+> **First frame required**: `wan-2.2-i2v-fast`, `hailuo-2.3-fast`, and `grok-imagine-video-1.5` cannot generate from text alone — they need an `imagePrompt` / `firstFrameImageName` (or a beat image).
+
+> **Audio behavior**: models marked `optional` are **silent by default** — set `movieParams: { "generateAudio": true }` to embed the generated soundtrack. Models marked `always` (grok-imagine-video-1.5) embed audio in every output and cannot be silenced; `generateAudio: false` logs a warning and is ignored.
 
 ## Test Script
 

--- a/test/agents/test_combine_audio_files.ts
+++ b/test/agents/test_combine_audio_files.ts
@@ -1014,3 +1014,137 @@ test("updateDurations multiple voice-over groups with different movies", async (
   assert.strictEqual(res[2], 100); // Until second voice-over
   assert.strictEqual(res[3], 100); // Remaining movie2: 200 - 100 = 100
 });
+
+// Spill-over grouping across movie beats: a silent generated movie continues the
+// narration group; anything with its own audio or an intrinsic timeline ends it.
+
+const spillOverNarration = { movieDuration: 0, audioDuration: 10, hasMedia: true, silenceDuration: 0, hasMovieAudio: false };
+const moviePromptMedia = { movieDuration: 0, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false };
+
+test("updateDurations spill-over continues over a silent moviePrompt beat", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({ text: "", moviePrompt: "draw the diagram" });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 5); // narration splits evenly across the group
+  assert.strictEqual(res[1], 5);
+});
+
+test("updateDurations spill-over ends at a moviePrompt beat with generateAudio", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    moviePrompt: "draw the diagram",
+    movieParams: { model: "bytedance/seedance-2.0", generateAudio: true },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 10); // narration stays on the first beat
+  assert.strictEqual(res[1], 1); // movie beat falls back to the default duration
+});
+
+test("updateDurations spill-over ends at a moviePrompt beat with an always-audio model", async () => {
+  const mediaDurations = [{ ...spillOverNarration }, { ...moviePromptMedia }];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    moviePrompt: "draw the diagram",
+    movieParams: { model: "xai/grok-imagine-video-1.5" },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 10);
+  assert.strictEqual(res[1], 1);
+});
+
+test("updateDurations spill-over ends at an imported silent movie beat", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 10, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    image: { type: "movie", source: { kind: "path", path: "test-movie.mp4" } },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6); // narration is not spilled over the movie
+  assert.strictEqual(res[1], 10); // the movie keeps its intrinsic duration
+});
+
+test("updateDurations spill-over ends at an animated html_tailwind beat with explicit duration", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 8, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    duration: 8,
+    image: { type: "html_tailwind", html: "<div>animated</div>", animation: true },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6);
+  assert.strictEqual(res[1], 8); // the animation keeps its own timeline
+});
+
+test("updateDurations silent movie beat still heads a voice-over group after narration", async () => {
+  const mediaDurations = [
+    { movieDuration: 0, audioDuration: 6, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 10, audioDuration: 0, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+    { movieDuration: 0, audioDuration: 3, hasMedia: true, silenceDuration: 0, hasMovieAudio: false },
+  ];
+  const beat1 = createMockBeat({});
+  const beat2 = createMockBeat({
+    text: "",
+    image: { type: "movie", source: { kind: "path", path: "test-movie.mp4" } },
+  });
+  const beat3 = createMockBeat({
+    image: { type: "voice_over", startAt: 2 },
+  });
+
+  const mock = createMockContext();
+  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.studio.script.beats.push(beat1, beat2, beat3);
+  mock.studio = createStudioData(mock.studio.script, "test");
+
+  const res = updateDurations(mock, mediaDurations);
+
+  assert.strictEqual(res[0], 6);
+  assert.strictEqual(res[1], 2); // until the voice-over starts (startAt)
+  assert.strictEqual(res[2], 8); // remaining movie duration
+});

--- a/test/methods/test_presentation_style.ts
+++ b/test/methods/test_presentation_style.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert";
 
 import { MulmoPresentationStyleMethods } from "../../src/methods/mulmo_presentation_style.js";
+import { createMockContext, createMockBeat } from "../actions/utils.js";
 
 test("defaultSpeaker isDefault", async () => {
   const presentationStyle = {
@@ -161,4 +162,49 @@ test("getResolvedSlideTheme: non-slide beat falls through to fallback (no throw)
   // Falls through to the presentation-level theme since beat.image.theme
   // doesn't apply (different image kind), instead of throwing.
   assert.equal(result.colors.bg, "PRES");
+});
+
+// generatedMovieHasAudio: resolves provider/model (including defaults) and the
+// model's audio mode to predict whether a generated movie will carry a soundtrack.
+
+test("generatedMovieHasAudio: replicate default model (audio never) is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave" });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: optional-audio model without generateAudio is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "bytedance/seedance-2.0" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: optional-audio model with generateAudio true has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "bytedance/seedance-2.0", generateAudio: true } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: always-audio replicate model has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { model: "xai/grok-imagine-video-1.5" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: google always-audio model has audio", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "google", model: "veo-3.1-generate-preview" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), true);
+});
+
+test("generatedMovieHasAudio: google default model (audio never) is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "google" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
+});
+
+test("generatedMovieHasAudio: mock provider is silent", () => {
+  const { presentationStyle } = createMockContext();
+  const beat = createMockBeat({ moviePrompt: "wave", movieParams: { provider: "mock" } });
+  assert.equal(MulmoPresentationStyleMethods.generatedMovieHasAudio(presentationStyle, beat), false);
 });

--- a/test/utils/test_estimate_usage.ts
+++ b/test/utils/test_estimate_usage.ts
@@ -131,6 +131,16 @@ describe("estimateUsage: movie / soundEffect / lipSync", () => {
     assert.ok(Math.abs((movie.costUSD ?? 0) - 8 * 0.036) < 1e-12);
   });
 
+  it("snaps up to the next supported duration across a gap in the durations list", () => {
+    const records = estimateUsage(
+      makeScript([{ speaker: "Presenter", text: "", moviePrompt: "wave", duration: 7, movieParams: { model: "bytedance/seedance-1-pro" } }]),
+    );
+    const movie = byProcess(records, "movie")[0];
+    assert.equal(movie.model, "bytedance/seedance-1-pro");
+    assert.deepEqual(movie.predictSec, { value: 10, precision: "exact" }); // supported durations are [5, 10]: ceiling, not nearest
+    assert.ok(Math.abs((movie.costUSD ?? 0) - 10 * 0.15) < 1e-12);
+  });
+
   it("estimates the duration from the narration text when no duration is set", () => {
     const records = estimateUsage(makeScript([{ speaker: "Presenter", text: "こんにちは。これはテストです。", moviePrompt: "city" }]));
     assert.deepEqual(byProcess(records, "movie")[0].predictSec, { value: 4, precision: "estimated" });


### PR DESCRIPTION
## Summary

Follow-up to #1493 (merged): the regression tests and doc updates that the review left open.

- **Tests (14 new, from the #1493 review / commit 8d179c25 of closed #1494)**
  - 6 `updateDurations` spill-over cases locking in the new grouping semantics: silent `moviePrompt` continuation (even split); group break on `generateAudio: true`, on an always-audio model (grok-imagine-video-1.5), on an imported silent movie, and on an animated `html_tailwind` beat with explicit duration; `voice_over` `startAt` honored after a silent movie beat.
  - 7 `generatedMovieHasAudio` cases: replicate / google / mock providers, including default-model resolution.
  - 1 estimate-usage case restoring gap-snapping coverage for `getModelDuration` (7s → 10 on seedance-1-pro's `[5, 10]`) — the only test proving ceiling-vs-nearest semantics, lost when seedance-1-lite's list became gapless.
- **Docs (`docs/movie_reference_images.md`)**
  - wan-2.2 row split: `wan-2.2-i2v-fast` supports lastFrame via `last_image` (wired in #1493); `wan-2.2-t2v-fast` is text-to-video only.
  - Added missing rows: `prunaai/p-video`, `xai/grok-imagine-video` / `-1.5`, `pixverse-v5`, hailuo variants, `runwayml/gen-4.5`, `alibaba/happyhorse-1.0` — all cross-checked against `provider2MovieAgent.replicate.modelParams`.
  - New notes: optional-audio models are silent by default (`generateAudio: true` to opt in), always-audio models can't be silenced, and which models require a first frame.

## Items to Confirm / Review

- Matrix rows were derived from `modelParams` in `src/types/provider2agent.ts` on current main — please sanity-check the rows for models you use often.
- The "First frame required" note reflects `start_image_required` in modelParams (wan-2.2-i2v-fast, hailuo-2.3-fast, grok-imagine-video-1.5).
- Not included (left as separate work): kling-v3 pricing corrections in `provider2agent.ts`, and the CHANGELOG note about the silent-by-default flip (belongs in the next release entry).

## User Prompt

(Translated) "The original PR was merged. Update main, then create a PR with the test commit 8d179c25, the docs/movie_reference_images.md update, and any other tests or document updates that are needed."

## Verification

- `yarn lint`: 0 errors
- `yarn build`: clean
- `yarn ci_test`: 972 tests, 0 fail (14 new)
- All 13 spill-over/audio-mode tests were previously validated against the #1493 head before merge (45/45 in the touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
