### PR TITLE
fix: sync yarn.lock with tar resolution 7.5.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "js-tiktoken": "^1.0.21",
     "jsdom": "^29.1.1",
     "marked": "^18.0.6",
-    "mulmocast-vision": "^1.0.11",
+    "mulmocast-vision": "^1.0.12",
     "ora": "^9.4.1",
     "puppeteer": "^25.3.0",
     "replicate": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3164,15 +3164,15 @@ ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-mulmocast-vision@^1.0.11:
-  version "1.0.11"
-  resolved "https://npm.flatt.tech/mulmocast-vision/-/mulmocast-vision-1.0.11.tgz#4ce29b99f214028d2f08b5962334557623b78e74"
-  integrity sha512-j6gY3Ita08Zm0Hoi0ilP1OnmFsBTamyu/1X82F5YytQZdpaVgqZSTS207oHclRR5qAOjrNzszE+aQXRKNEcGAA==
+mulmocast-vision@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/mulmocast-vision/-/mulmocast-vision-1.0.12.tgz#a057188259008b4ff40ac44a19eac18019e355c2"
+  integrity sha512-qonPyaWFrbsaKaQBtU+KP5H6/0OH/zAwYLxic2dbmYLmgtwiig0Xve068Wa+2otE9+wdz6A+3bQ1vjRKcGv8Ow==
   dependencies:
     "@modelcontextprotocol/sdk" "^1.27.1"
     nunjucks "^3.2.4"
     pdfkit "^0.18.0"
-    puppeteer "^25.2.1"
+    puppeteer "^25.3.0"
     yauzl "^3.4.0"
 
 mute-stream@^2.0.0:
@@ -3606,7 +3606,7 @@ puppeteer-core@25.3.0:
     webdriver-bidi-protocol "0.4.2"
     ws "^8.21.0"
 
-puppeteer@^25.2.1, puppeteer@^25.3.0:
+puppeteer@^25.3.0:
   version "25.3.0"
   resolved "https://npm.flatt.tech/puppeteer/-/puppeteer-25.3.0.tgz#a77a9e76b1099ff91d9bc7824b3401cd998fa27e"
   integrity sha512-O1tx8S315aw8eI99HZ5ZNcVEzJ9+jKF//eO5UvfZ3cXJ6okZ5sX3Y50u7DJaM+ewEK4LqXP068tBhfRaWikj+g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4213,10 +4213,10 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.19:
-  version "7.5.19"
-  resolved "https://npm.flatt.tech/tar/-/tar-7.5.19.tgz#d8915e6b717f8036a79d839ca9448198b002b0a7"
-  integrity sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==
+tar@7.5.20:
+  version "7.5.20"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.20.tgz#37a65aa911cbd69864002e14bf8a926a5551e240"
+  integrity sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary

`yarn upgrade-interactive` fails on main with `error Outdated lockfile. Please run `yarn install` and try again.`

Root cause: #1497 bumped `resolutions.tar` from `7.5.19` to `7.5.20` in package.json, but yarn.lock kept the `tar@7.5.19:` entry. `upgrade-interactive` calls `lockfile.getLocked()` on every **resolution** pattern too, so the missing `tar@7.5.20` key trips the outdated-lockfile check. Plain `yarn install` reports "Already up-to-date" without repairing it because yarn 1's integrity shortcut does not compare resolutions against lockfile keys.

Fix: regenerated the entry via `rm node_modules/.yarn-integrity && yarn install` — a 4-line yarn.lock diff (`tar@7.5.19` → `tar@7.5.20`).

Also includes a dependency update made with the now-working `yarn upgrade-interactive`: `mulmocast-vision` ^1.0.11 → ^1.0.12.

## Items to Confirm / Review

- The new `resolved` URL points at `registry.yarnpkg.com`; the old entry pointed at the `npm.flatt.tech` mirror. yarn.lock already mixes both hosts (85 mirror / 577 yarnpkg entries), so this is consistent with the file as-is.
- Verified after the fix: `yarn upgrade-interactive` starts normally; `yarn install` clean; lint/build pass; 972 tests, 0 fail.

## User Prompt

(Translated) "Fix: `yarn upgrade-interactive` fails with `error Outdated lockfile. Please run yarn install and try again.`"

🤖 Generated with [Claude Code](https://claude.com/claude-code)