### PR TITLE
fix: stop media buffers from growing memory with the beat count

### DIFF
--- a/src/utils/filters.ts
+++ b/src/utils/filters.ts
@@ -35,6 +35,16 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     GraphAILogger.debug(`cache: ${path.basename(file)}`);
     return true;
   }
+
+  // The media payload is on disk by the time we return, and no downstream node reads it, so it
+  // must not become part of the node result: GraphAI keeps every node result (and a debug key for
+  // each of its leaves) alive for the whole run. Buffers are array-like, so that key walk expands
+  // one media buffer into a key per byte (~280x its size), which is what made memory grow with
+  // the beat count. Keep `usage` — createUsageCallback reads it off the transaction log.
+  const withoutPayload = <T extends { buffer?: Buffer; text?: string }>(output: T) => {
+    const { buffer: __buffer, ...rest } = output;
+    return rest;
+  };
   const backup = withBackup && withBackup.some((element: boolean | undefined) => element);
 
   try {
@@ -42,7 +52,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
     const output = ((await next(context)) as { buffer?: Buffer; text?: string; saved?: boolean }) || undefined;
     const { buffer, text, saved } = output ?? {};
     if (saved) {
-      return output;
+      return withoutPayload(output ?? {});
     }
     if (buffer) {
       writingMessage(file);
@@ -50,7 +60,7 @@ export const fileCacheAgentFilter: AgentFilterFunction = async (context, next) =
       if (backup) {
         await fsPromise.writeFile(getBackupFilePath(file), buffer);
       }
-      return output;
+      return withoutPayload(output ?? {});
     } else if (text) {
       writingMessage(file);
       await fsPromise.writeFile(file, text, "utf-8");


### PR DESCRIPTION
## Problem

Rendering a video consumed memory proportional to the beat count and eventually blew the Node heap. Reported at roughly **115MB per beat**.

## Cause

`fileCacheAgentFilter` returned the agent's `{ buffer }` as the node result, even though the payload is already written to disk at that point and no downstream node reads it (no graph node references `:someNode.buffer`).

GraphAI keeps every node result alive for the whole run, and records a debug key for each leaf of it — `TransactionLog.onComplete` → `debugResultKey`. `debugResultKeyInner` does:

```js
if (Array.isArray(result)) { ... }
return Object.keys(result).reduce(...)   // <- a Buffer lands here
```

A Buffer is array-like but `Array.isArray` is false, so it falls into the `Object.keys()` branch, which returns **every byte index**. The result is one key string per byte (`":tts.buffer.0"` … `":tts.buffer.262143"`), retained on the transaction log until the graph finishes.

Measured expansion: **~280x the buffer size**. mulmocast's per-beat TTS mp3 / PNG payloads are a few hundred KB, so `256KB × 280 ≈ 70MB/beat` and `400KB × 280 ≈ 115MB/beat` — matching the report.

## Fix

Drop `buffer` from the filter's return value. This covers every buffer-returning agent in the repo: `imageGenerator`, `movieGenerator`, `tts`, `soundEffectGenerator`, `lipSyncGenerator`, `htmlImageAgent`, `AudioTrimmer` are all behind this filter. `usage` is kept, since `createUsageCallback` reads it off the transaction log.

## Measurements

Mock image agent, 256KB buffer per beat, peak `heapUsed + external`:

| beats | before | after |
|---|---|---|
| 1 | 348MB | 144MB |
| 10 | 1109MB | 153MB |
| 30 | 2279MB | 160MB |
| 68 (4MB/beat) | **OOM at 4GB** | 180MB |

Growth is now ~0.5MB/beat instead of proportional to the payload size.

`yarn lint` clean (28 pre-existing warnings, 0 errors); `yarn ci_test` 1031 pass / 0 fail.

## Follow-ups (not in this PR)

- **Upstream graphai fix**, filed separately: `debugResultKeyInner` should skip binary views (`if (ArrayBuffer.isView(result) || result instanceof ArrayBuffer) return {};`). Verified locally: one 4MB buffer goes from 1252MB to 4MB. This PR keeps mulmocast off that path, but a future agent returning a buffer outside the cache filter would regress without the upstream fix.
- **ffmpeg-side memory** is a separate issue: `createVideo` builds one filter_complex over all beats, measuring ~23MB/beat at 1280x720 with no transitions (1.9GB at 68 beats), and ~240MB/beat with a fade on every beat (14.5GB at 60 beats) because `addTransitionEffects` stacks N overlay filters over the full-length concatenated stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage during workflow execution by removing large media buffers from cached node results.
  * Preserved usage information while preventing unnecessary media data from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->