### PR TITLE
fix: resync yarn.lock with the tar 7.5.22 resolution

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4219,10 +4219,10 @@ tar-stream@^3.0.0:
     fast-fifo "^1.2.0"
     streamx "^2.15.0"
 
-tar@7.5.20:
-  version "7.5.20"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.20.tgz#37a65aa911cbd69864002e14bf8a926a5551e240"
-  integrity sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==
+tar@7.5.22:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary

`yarn upgrade-interactive`（= `yarn latest`）が以下で失敗する問題の修正です。

```
error Outdated lockfile. Please run `yarn install` and try again.
```

**原因**: コミット `ce66cab2 "update"` が `package.json` の `resolutions.tar` を 7.5.20 → 7.5.22 に上げた際、`yarn.lock` を更新していませんでした。yarn.lock は `tar@7.5.20:` のままで、`upgrade-interactive` のロックファイル整合性チェックが package.json のパターンと一致しないため拒否されます。

**注意**: 素の `yarn install` では直りません（`Already up-to-date.` と言って何もしない）。`yarn install --force` で再解決させる必要がありました。前回 2.8.1 でも同じ現象が起きています。

## 変更

`yarn.lock` の tar エントリのみ（4行）:

```diff
-tar@7.5.20:
-  version "7.5.20"
+tar@7.5.22:
+  version "7.5.22"
```

## Items to Confirm / Review

- `tar` は直接依存ではなく `resolutions` 経由（推移的依存の固定）です。7.5.20 → 7.5.22 は patch 更新で、archiver / zip 系の動作に影響しないか一応ご確認ください。
- 再発防止として、`package.json` を編集する際は `yarn.lock` も同時にコミットする運用が必要です（今回で2回目）。CI に `yarn install --frozen-lockfile` チェックを追加する案もありますが、このPRの範囲外としています。

## 確認

- `yarn upgrade-interactive --latest` — "Outdated lockfile" が解消（非TTY環境のため最後のプロンプトでのみ停止）
- `yarn install --frozen-lockfile` — OK
- `yarn lint` — エラー0（警告28件はすべて既存）
- `yarn build` — OK
- `yarn ci_test` — 1035件 / fail 0

## User Prompt

- yarn ug 失敗する直して。

🤖 Generated with [Claude Code](https://claude.com/claude-code)