### PR TITLE
refactor(chart): extract the pure chart renderer into chart_html.ts

### DIFF
--- a/plans/refactor-chart-pure.md
+++ b/plans/refactor-chart-pure.md
@@ -1,0 +1,27 @@
+# refactor(chart): pure なチャート描画部を切り出す
+
+親 issue: #1526 の PR 3。
+
+## 目的
+
+`src/utils/image_plugins/chart.ts` の HTML 生成部は Node 依存
+(`generateUniqueId` → `node:crypto`) を持つため、ブラウザ側の beat fragment から
+import できない。`markdown_layout.ts` / `mermaid_html.ts` と同じ形で pure 化し、
+ブラウザ実装が「同じ関数を import する」状態を先に用意する。
+
+二重実装は必ずずれる（#1530 で、コピーした markdown 実装が同じバグを共有していたため
+parity テストが通ってしまった）。ブラウザ側を書く前に、共有される側を pure にしておく。
+
+## 変更
+
+- `src/utils/image_plugins/chart_html.ts` (新規, pure)
+  - `chartHtml(chartData, title, chartId)` — canvas id を引数で受ける
+  - `resolveChartPlugins(chartType)` と CDN テーブルを移設
+- `src/utils/image_plugins/chart.ts` — 上記を import する wrapper に。
+  `processChart` は一字も変えない。
+
+## 挙動不変の証明
+
+`origin/main` の旧コードを sed で機械抽出したハーネスと新コードを、生成入力で突き合わせる。
+mutation で「ハーネスが差分を検出できること」自体を先に確認する。
+恒久テストとして characterization test を `test/image_plugins/test_chart_html.ts` に残す。

--- a/plans/refactor-chart-pure.md
+++ b/plans/refactor-chart-pure.md
@@ -15,7 +15,9 @@ parity テストが通ってしまった）。ブラウザ側を書く前に、�
 ## 変更
 
 - `src/utils/image_plugins/chart_html.ts` (新規, pure)
-  - `chartHtml(chartData, title, chartId)` — canvas id を引数で受ける
+  - `chartHtml(chartDataJson, title, chartId)` — canvas id を引数で受ける
+  - `stringifyChartData(chartData)` — wrapper 側で先に呼ぶ。main の評価順
+    (stringify → title 読み取り → id 生成) を保つため
   - `resolveChartPlugins(chartType)` と CDN テーブルを移設
 - `src/utils/image_plugins/chart.ts` — 上記を import する wrapper に。
   `processChart` は一字も変えない。

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -3,7 +3,7 @@ import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
-import { chartHtml, resolveChartPlugins } from "./chart_html.js";
+import { chartHtml, resolveChartPlugins, stringifyChartData } from "./chart_html.js";
 
 export const imageType = "chart";
 
@@ -31,7 +31,10 @@ const dumpHtml = async (params: ImageProcessorParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
-  return chartHtml(beat.image.chartData, beat.image.title, generateUniqueId("chart"));
+  // main と同じ評価順（stringify → title 読み取り → id 生成）を保つ。引数式は本体より先に
+  // 評価されるので、stringify を wrapper 側でやらないと throw / getter の順序が入れ替わる。
+  const chartDataJson = stringifyChartData(beat.image.chartData);
+  return chartHtml(chartDataJson, beat.image.title, generateUniqueId("chart"));
 };
 
 export const process = processChart;

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -3,21 +3,9 @@ import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
+import { chartHtml, resolveChartPlugins } from "./chart_html.js";
 
 export const imageType = "chart";
-
-/** Chart.js plugin CDN URLs keyed by chart type */
-const CHART_PLUGIN_CDNS: Record<string, string> = {
-  sankey: "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey",
-  treemap: "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3",
-};
-
-/** Resolve CDN script tags for Chart.js plugins based on chart type */
-const resolveChartPlugins = (chartType: string): string => {
-  const cdn = CHART_PLUGIN_CDNS[chartType];
-  if (!cdn) return "";
-  return `<script src="${cdn}"></script>`;
-};
 
 const processChart = async (params: ImageProcessorParams) => {
   const { beat, imagePath, canvasSize } = params;
@@ -43,23 +31,7 @@ const dumpHtml = async (params: ImageProcessorParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
-  const chartData = JSON.stringify(beat.image.chartData, null, 2);
-  const title = beat.image.title || "Chart";
-  const chartId = generateUniqueId("chart");
-
-  return `
-<div class="chart-container mb-6">
-  <h3 class="text-xl font-semibold mb-4">${title}</h3>
-  <div class="w-full" style="position: relative; height: 400px;">
-    <canvas id="${chartId}"></canvas>
-  </div>
-  <script>
-    (function() {
-      const ctx = document.getElementById('${chartId}').getContext('2d');
-      new Chart(ctx, ${chartData});
-    })();
-  </script>
-</div>`;
+  return chartHtml(beat.image.chartData, beat.image.title, generateUniqueId("chart"));
 };
 
 export const process = processChart;

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -24,8 +24,9 @@ export const resolveChartPlugins = (chartType: string): string => {
   return `<script src="${cdn}"></script>`;
 };
 
-export const chartHtml = (chartData: MulmoChartMedia["chartData"], title: string, chartId: string): string => {
-  const data = JSON.stringify(chartData, null, 2);
+export const stringifyChartData = (chartData: MulmoChartMedia["chartData"]): string => JSON.stringify(chartData, null, 2);
+
+export const chartHtml = (chartDataJson: string, title: string, chartId: string): string => {
   const heading = title || "Chart";
 
   return `
@@ -37,7 +38,7 @@ export const chartHtml = (chartData: MulmoChartMedia["chartData"], title: string
   <script>
     (function() {
       const ctx = document.getElementById('${chartId}').getContext('2d');
-      new Chart(ctx, ${data});
+      new Chart(ctx, ${chartDataJson});
     })();
   </script>
 </div>`;

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -1,0 +1,44 @@
+import type { MulmoChartMedia } from "../../types/index.js";
+
+/**
+ * Chart.js markup and plugin resolution. Pure — no Node, no filesystem — because both the
+ * Node render path and the browser fragment path draw the same chart and must draw it the
+ * same way.
+ *
+ * The canvas id is a parameter rather than generated here: the Node path renders once to a
+ * PNG so a random id is fine, while the browser path re-renders and needs the same beat to
+ * produce the same markup, or a host diffing fragments sees every chart change identity on
+ * every render.
+ */
+
+/** Chart.js plugin CDN URLs keyed by chart type */
+const CHART_PLUGIN_CDNS: Record<string, string> = {
+  sankey: "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey",
+  treemap: "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3",
+};
+
+/** Resolve CDN script tags for Chart.js plugins based on chart type */
+export const resolveChartPlugins = (chartType: string): string => {
+  const cdn = CHART_PLUGIN_CDNS[chartType];
+  if (!cdn) return "";
+  return `<script src="${cdn}"></script>`;
+};
+
+export const chartHtml = (chartData: MulmoChartMedia["chartData"], title: string, chartId: string): string => {
+  const data = JSON.stringify(chartData, null, 2);
+  const heading = title || "Chart";
+
+  return `
+<div class="chart-container mb-6">
+  <h3 class="text-xl font-semibold mb-4">${heading}</h3>
+  <div class="w-full" style="position: relative; height: 400px;">
+    <canvas id="${chartId}"></canvas>
+  </div>
+  <script>
+    (function() {
+      const ctx = document.getElementById('${chartId}').getContext('2d');
+      new Chart(ctx, ${data});
+    })();
+  </script>
+</div>`;
+};

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -120,9 +120,22 @@ test("the plugin declines beats that are not charts", async () => {
   assert.strictEqual(await html({ beat: { image: { type: "markdown", markdown: "x" } } }), undefined);
 });
 
-test("each call gets its own id", { skip: process.env.NODE_ENV === "test" ? 'generateUniqueId is pinned to "id" in test mode' : false }, async () => {
+// generateUniqueId returns the literal "id" under NODE_ENV=test, which is what CI sets, so
+// the id's real shape is only observable with that flag off.
+test("each call gets its own chart-prefixed id", async () => {
   const html = chartPluginHtml();
-  const beat = { image: { type: "chart", title: "t", chartData: {} } };
-  const ids = await Promise.all([0, 1, 2].map(async () => (await html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
-  assert.strictEqual(new Set(ids).size, 3, `ids must be unique, got ${JSON.stringify(ids)}`);
+  const saved = process.env.NODE_ENV;
+  delete process.env.NODE_ENV;
+  try {
+    const beat = { image: { type: "chart", title: "t", chartData: {} } };
+    const ids = await Promise.all([0, 1, 2].map(async () => (await html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
+    ids.forEach((id) => assert.match(id ?? "", /^chart-[0-9a-f]{8}$/));
+    assert.strictEqual(new Set(ids).size, 3, `ids must be unique, got ${JSON.stringify(ids)}`);
+  } finally {
+    if (saved === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = saved;
+    }
+  }
 });

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -1,0 +1,100 @@
+import test from "node:test";
+import assert from "node:assert";
+import { chartHtml, resolveChartPlugins } from "../../src/utils/image_plugins/chart_html.js";
+import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+
+/**
+ * Characterization tests for the chart renderer, which is shared by the Node render path
+ * (PNG / PDF / movie) and the `mulmo html` dump.
+ *
+ * The exact bytes are pinned, not just the elements: the markup is embedded in a document
+ * whose Chart.js is loaded elsewhere, so a change here is inert until a chart silently
+ * stops drawing.
+ */
+
+const CHART_DATA = { type: "bar", data: { labels: ["a", "b"], datasets: [{ data: [1, 2] }] } };
+
+test("chart markup is exact", () => {
+  assert.strictEqual(
+    chartHtml({ type: "bar" }, "Revenue", "c1"),
+    [
+      "",
+      '<div class="chart-container mb-6">',
+      '  <h3 class="text-xl font-semibold mb-4">Revenue</h3>',
+      '  <div class="w-full" style="position: relative; height: 400px;">',
+      '    <canvas id="c1"></canvas>',
+      "  </div>",
+      "  <script>",
+      "    (function() {",
+      `      const ctx = document.getElementById('c1').getContext('2d');`,
+      '      new Chart(ctx, {\n  "type": "bar"\n});',
+      "    })();",
+      "  </script>",
+      "</div>",
+    ].join("\n"),
+  );
+});
+
+test("an empty title falls back to Chart, a present one is used verbatim", () => {
+  assert.match(chartHtml({}, "", "c1"), /<h3 class="text-xl font-semibold mb-4">Chart<\/h3>/);
+  assert.match(chartHtml({}, "  ", "c1"), /<h3 class="text-xl font-semibold mb-4"> {2}<\/h3>/);
+  assert.match(chartHtml({}, "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 & <b><\/h3>/);
+});
+
+test("the caller-supplied id is the only id, and reaches both the canvas and the lookup", () => {
+  const html = chartHtml({}, "t", "beat-3-chart");
+  assert.strictEqual(html.match(/beat-3-chart/g)?.length, 2);
+  assert.match(html, /<canvas id="beat-3-chart"><\/canvas>/);
+  assert.match(html, /getElementById\('beat-3-chart'\)/);
+});
+
+test("chart data is embedded 2-space-indented and round-trips", () => {
+  const html = chartHtml(CHART_DATA, "t", "c1");
+  const embedded = html.match(/new Chart\(ctx, ([\s\S]*?)\);\n {4}\}\)\(\);/)?.[1];
+  assert.ok(embedded, "the embedded chart data must be locatable");
+  assert.deepStrictEqual(JSON.parse(embedded), CHART_DATA);
+  assert.ok(embedded.includes('\n  "type": "bar"'), "must stay pretty-printed with 2 spaces");
+});
+
+test("plugin CDNs are resolved per chart type, and unknown types get nothing", () => {
+  assert.strictEqual(resolveChartPlugins("sankey"), '<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"></script>');
+  assert.strictEqual(resolveChartPlugins("treemap"), '<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3"></script>');
+  ["bar", "pie", "", "SANKEY", "Sankey", " sankey", "doughnut"].forEach((type) => {
+    assert.strictEqual(resolveChartPlugins(type), "", `${JSON.stringify(type)} must resolve to no plugin`);
+  });
+});
+
+// Pre-existing on main: the lookup is a plain object literal, so a chart type naming an
+// Object.prototype member resolves through the prototype chain. Pinned to make a fix visible,
+// not because it is wanted.
+test("prototype member names leak through the plugin lookup", () => {
+  assert.strictEqual(resolveChartPlugins("constructor"), '<script src="function Object() { [native code] }"></script>');
+  assert.strictEqual(resolveChartPlugins("__proto__"), '<script src="[object Object]"></script>');
+});
+
+test("the plugin passes the beat straight through to the renderer", async () => {
+  const plugin = findImagePlugin("chart");
+  const beat = { image: { type: "chart", title: "Revenue", chartData: CHART_DATA } };
+
+  const html = await plugin.html({ beat });
+  assert.ok(html, "a chart beat must produce html");
+
+  const id = html.match(/<canvas id="([^"]*)">/)?.[1];
+  assert.ok(id, "the canvas must carry an id");
+  assert.match(id, /^(id|chart-[0-9a-f]{8})$/, "the id must come from generateUniqueId with the chart prefix");
+  assert.strictEqual(html, chartHtml(CHART_DATA, "Revenue", id));
+});
+
+test("the plugin declines beats that are not charts", async () => {
+  const plugin = findImagePlugin("chart");
+  assert.strictEqual(await plugin.html({ beat: {} }), undefined);
+  assert.strictEqual(await plugin.html({ beat: { image: undefined } }), undefined);
+  assert.strictEqual(await plugin.html({ beat: { image: { type: "markdown", markdown: "x" } } }), undefined);
+});
+
+test("each call gets its own id", { skip: process.env.NODE_ENV === "test" ? 'generateUniqueId is pinned to "id" in test mode' : false }, async () => {
+  const plugin = findImagePlugin("chart");
+  const beat = { image: { type: "chart", title: "t", chartData: {} } };
+  const ids = await Promise.all([0, 1, 2].map(async () => (await plugin.html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
+  assert.strictEqual(new Set(ids).size, 3, `ids must be unique, got ${JSON.stringify(ids)}`);
+});

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { chartHtml, resolveChartPlugins } from "../../src/utils/image_plugins/chart_html.js";
+import { chartHtml, resolveChartPlugins, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
 import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
 
 /**
@@ -22,7 +22,7 @@ const chartPluginHtml = () => {
 
 test("chart markup is exact", () => {
   assert.strictEqual(
-    chartHtml({ type: "bar" }, "Revenue", "c1"),
+    chartHtml(stringifyChartData({ type: "bar" }), "Revenue", "c1"),
     [
       "",
       '<div class="chart-container mb-6">',
@@ -42,20 +42,20 @@ test("chart markup is exact", () => {
 });
 
 test("an empty title falls back to Chart, a present one is used verbatim", () => {
-  assert.match(chartHtml({}, "", "c1"), /<h3 class="text-xl font-semibold mb-4">Chart<\/h3>/);
-  assert.match(chartHtml({}, "  ", "c1"), /<h3 class="text-xl font-semibold mb-4"> {2}<\/h3>/);
-  assert.match(chartHtml({}, "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 & <b><\/h3>/);
+  assert.match(chartHtml("{}", "", "c1"), /<h3 class="text-xl font-semibold mb-4">Chart<\/h3>/);
+  assert.match(chartHtml("{}", "  ", "c1"), /<h3 class="text-xl font-semibold mb-4"> {2}<\/h3>/);
+  assert.match(chartHtml("{}", "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 & <b><\/h3>/);
 });
 
 test("the caller-supplied id is the only id, and reaches both the canvas and the lookup", () => {
-  const html = chartHtml({}, "t", "beat-3-chart");
+  const html = chartHtml("{}", "t", "beat-3-chart");
   assert.strictEqual(html.match(/beat-3-chart/g)?.length, 2);
   assert.match(html, /<canvas id="beat-3-chart"><\/canvas>/);
   assert.match(html, /getElementById\('beat-3-chart'\)/);
 });
 
 test("chart data is embedded 2-space-indented and round-trips", () => {
-  const html = chartHtml(CHART_DATA, "t", "c1");
+  const html = chartHtml(stringifyChartData(CHART_DATA), "t", "c1");
   const embedded = html.match(/new Chart\(ctx, ([\s\S]*?)\);\n {4}\}\)\(\);/)?.[1];
   assert.ok(embedded, "the embedded chart data must be locatable");
   assert.deepStrictEqual(JSON.parse(embedded), CHART_DATA);
@@ -85,7 +85,32 @@ test("the plugin passes the beat straight through to the renderer", async () => 
   const id = html.match(/<canvas id="([^"]*)">/)?.[1];
   assert.ok(id, "the canvas must carry an id");
   assert.match(id, /^(id|chart-[0-9a-f]{8})$/, "the id must come from generateUniqueId with the chart prefix");
-  assert.strictEqual(html, chartHtml(CHART_DATA, "Revenue", id));
+  assert.strictEqual(html, chartHtml(stringifyChartData(CHART_DATA), "Revenue", id));
+});
+
+// The wrapper stringifies before it reads `title`, matching the order the code had before
+// it was split in two. A `title` getter observing a chartData that cannot be serialized is
+// the only way to see the difference, and it is what a reordered wrapper would break.
+test("chart data is serialized before the title is read", async () => {
+  const html = chartPluginHtml();
+  const cyclic: Record<string, unknown> = { type: "bar" };
+  cyclic.self = cyclic;
+  const read: string[] = [];
+  const image = {
+    type: "chart",
+    chartData: cyclic,
+    get title(): string {
+      read.push("title");
+      return "T";
+    },
+  };
+
+  await assert.rejects(() => Promise.resolve(html({ beat: { image } })), /circular structure/);
+  assert.deepStrictEqual(read, [], "the title must not be read once serialization has thrown");
+});
+
+test("stringifyChartData pretty-prints with two spaces", () => {
+  assert.strictEqual(stringifyChartData({ type: "bar", n: 1 }), '{\n  "type": "bar",\n  "n": 1\n}');
 });
 
 test("the plugin declines beats that are not charts", async () => {

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -14,6 +14,12 @@ import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
 
 const CHART_DATA = { type: "bar", data: { labels: ["a", "b"], datasets: [{ data: [1, 2] }] } };
 
+const chartPluginHtml = () => {
+  const plugin = findImagePlugin("chart");
+  assert.ok(plugin?.html, "the chart plugin must expose an html method");
+  return plugin.html;
+};
+
 test("chart markup is exact", () => {
   assert.strictEqual(
     chartHtml({ type: "bar" }, "Revenue", "c1"),
@@ -73,10 +79,7 @@ test("prototype member names leak through the plugin lookup", () => {
 });
 
 test("the plugin passes the beat straight through to the renderer", async () => {
-  const plugin = findImagePlugin("chart");
-  const beat = { image: { type: "chart", title: "Revenue", chartData: CHART_DATA } };
-
-  const html = await plugin.html({ beat });
+  const html = await chartPluginHtml()({ beat: { image: { type: "chart", title: "Revenue", chartData: CHART_DATA } } });
   assert.ok(html, "a chart beat must produce html");
 
   const id = html.match(/<canvas id="([^"]*)">/)?.[1];
@@ -86,15 +89,15 @@ test("the plugin passes the beat straight through to the renderer", async () => 
 });
 
 test("the plugin declines beats that are not charts", async () => {
-  const plugin = findImagePlugin("chart");
-  assert.strictEqual(await plugin.html({ beat: {} }), undefined);
-  assert.strictEqual(await plugin.html({ beat: { image: undefined } }), undefined);
-  assert.strictEqual(await plugin.html({ beat: { image: { type: "markdown", markdown: "x" } } }), undefined);
+  const html = chartPluginHtml();
+  assert.strictEqual(await html({ beat: {} }), undefined);
+  assert.strictEqual(await html({ beat: { image: undefined } }), undefined);
+  assert.strictEqual(await html({ beat: { image: { type: "markdown", markdown: "x" } } }), undefined);
 });
 
 test("each call gets its own id", { skip: process.env.NODE_ENV === "test" ? 'generateUniqueId is pinned to "id" in test mode' : false }, async () => {
-  const plugin = findImagePlugin("chart");
+  const html = chartPluginHtml();
   const beat = { image: { type: "chart", title: "t", chartData: {} } };
-  const ids = await Promise.all([0, 1, 2].map(async () => (await plugin.html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
+  const ids = await Promise.all([0, 1, 2].map(async () => (await html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
   assert.strictEqual(new Set(ids).size, 3, `ids must be unique, got ${JSON.stringify(ids)}`);
 });


### PR DESCRIPTION
## Summary

`src/utils/image_plugins/chart.ts` の HTML 生成部を pure な `chart_html.ts` に切り出し、`chart.ts` はそれを import する wrapper にしました。`markdown_layout.ts` / `mermaid_html.ts` と同じ形です。

- `chart_html.ts`（新規, pure）: `chartHtml(chartData, title, chartId)` と `resolveChartPlugins` + CDN テーブル
- canvas id は引数。Node 側は PNG に一度描くだけなのでランダムで良いが、ブラウザ側は再描画するため同じ beat が同じ markup を返す必要がある
- `processChart`（PNG 経路）は **main と byte 一致**（`diff` で確認済み）
- `test/image_plugins/test_chart_html.ts`（新規）: chart 描画には今までテストが1本も無かったので characterization test を追加

挙動は変えていません。これは #1526 の PR 3 で、ブラウザ側 fragment(PR 4) が「同じ関数を import する」状態を先に作るための下準備です。

## Items to Confirm / Review

1. **挙動不変の実測**（推論ではなく実行で確認しています）
   - 旧コードは `git show origin/main:...chart.ts` から **sed で機械抽出**（手で写していません）。抽出物と harness 本体を `diff` して改変ゼロを確認。
   - 生成入力 **527 件で差分 0**。id がランダムなモードと `NODE_ENV=test`（id 固定）の両方で 0。
   - **評価順ハーネスを追加（Codex round 1 の指摘）: 8 件で差分 0。** 当初この生成器には cyclic / BigInt /
     throw する getter が無く、2/8 が差分していました（下記 round 1 参照）。修正後 0。
   - 入力の形: title = 空 / undefined / null / 0 / false / HTML / 引用符 / バッククォート / `</script>` / 日本語 / 500字、chartData = `{}` / 配列 / 文字列 / 数値 / null / `NaN` / `Infinity` / 1e21 / 関数 / Date / `undefined` 値 / 深いネスト / `Object.create` によるプロトタイプ持ち / `JSON.parse('{"__proto__":…}')` / 同値2箇所、beat = image 無し / image undefined / 別 type / chartData 無し。
   - **ハーネスが差分を見られることを mutation で先に確認**（0 という数字を信じる前に）:

     | 変異 | 差分件数 |
     |---|---|
     | M1 JSON indent 2 → なし | 378 |
     | M2 `title \|\| "Chart"` → `??` | 108 |
     | M3 markup `mb-6` → `mb-4` | 505 |
     | M4 treemap CDN の版数変更 | 1 |
     | M5 canvas id を空に | 505 |
     | M6 wrapper が title を渡さない | 288 |
     | M7 wrapper の id prefix `chart` → `x` | 505 |

     件数も生成器と一致します（M2=108 は falsy-but-not-nullish な title 3種×36、M6=288 は `"Chart"` 自身を除く truthy title 8種×36）。

   **Codex round 1 で M7 に加えもう1つの盲点が見つかりました**: 生成器に `JSON.stringify` が throw する形
   （cyclic / BigInt / throw する `toJSON`）と `title` の getter が無く、**split が持ち込んだ評価順の入れ替わり**
   を見られませんでした。main は stringify → title 読み取り → id 生成の順ですが、引数式は本体より先に評価されるため
   wrapper では title が先に読まれていました。実測 **8 ケース中 2 件が差分**（cyclic + throw する title getter →
   エラーが `circular structure` ではなく `title boom` になる／cyclic + 副作用のある getter → getter が余計に走る）。

   `stringifyChartData` を wrapper 側で先に呼ぶ形に直し、**両ハーネスとも 0 差分**に戻しました。
   恒久テスト「chart data is serialized before the title is read」で性質を固定し、
   title を stringify より先に読む変異で赤くなること（順序ハーネスは 3 差分）も確認済みです。

2. **恒久テスト側も同じ変異で赤くなるか確認**。M8（非 chart beat も描いてしまう）と M9（id を固定値にする）を追加して全て検出。

   当初 **M7（id prefix `chart`→`x`）だけは `NODE_ENV=test` では検出できず**、CI がそのモードで走るため
   id の退行は CI をすり抜けていました（`generateUniqueId` が test モードで prefix を無視して `"id"` を返すため）。
   **CodeRabbit の指摘を受けて塞ぎました**: `generateUniqueId` は env を呼び出し時に読むので、テスト内で一時的に
   `NODE_ENV` を外し `finally` で戻す形にしました。skip は無くなり、**M7 は CI と同じモードでも赤くなります**
   （NODE_ENV=test:fail=1）。`image_plugins` 全体 158 tests / 0 fail / **0 skip** で env の復元も確認済みです。

3. **pre-existing の quirk を1つ発見しました（このPRでは直していません）**
   `CHART_PLUGIN_CDNS` は素のオブジェクトリテラルなので、`chartData.type` が `constructor` / `toString` / `__proto__` などだとプロトタイプ経由で値が引かれます:

   ```
   resolveChartPlugins("constructor") → <script src="function Object() { [native code] }"></script>
   resolveChartPlugins("__proto__")   → <script src="[object Object]"></script>
   ```

   `chartData` は `z.record(z.string(), z.any())` なのでユーザーの mulmoscript から到達可能です。実害は「壊れた script タグが1つ入り読み込みに失敗する」程度（値に `"` を含まないので属性からは抜けません）。**挙動不変が主張の PR なのでここでは直さず**、テストで固定して可視化だけしています。別 issue にするか、ご判断ください。

4. `chartHtml` の引数順（`chartData, title, chartId`）— PR 4 でブラウザ側が同じ関数を使います。

## 検証

- `npx prettier --check` / `npx eslint`（対象3ファイル）: clean
- `npx tsc --noEmit`: clean
- `NODE_ENV=test npx tsx --test test/image_plugins/test_*.ts`: **158 tests, 0 fail, 0 skip**
- 新テストは `NODE_ENV=test` あり／なしの **両方**で緑（#1530 のレビューで、test モード前提のテストを書いて指摘された件の再発防止）

マシンの load average が 185（他セッションの作業）だったため、フルビルドは回さず対象を絞って検証しています。全体は CI を ground truth とします。

## User Prompt

> ちょっと、このあとの変更は、まず先にimage plugins以下をrefactoringする変更を１つ１つしてからbeat htmlをつくるようにする？

> つづけて

（検証水準は「差分ハーネス＋恒久テスト」を選択いただいたものに従っています）

Closes #1532
Refs #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Chart rendering now uses a consistent shared HTML generation process across supported rendering paths.
  * Chart titles, data, and canvas identifiers are rendered consistently for reliable updates and comparisons.
  * Sankey and treemap charts automatically load the required visualization plugins.

* **Bug Fixes**
  * Preserved existing chart output and behavior while improving rendering consistency.
  * Improved chart rendering reliability across repeated updates and different rendering paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

