### PR TITLE
fix(chart): escape the title and chart data embedded in the dump HTML

### DIFF
--- a/plans/fix-escape-chart-html.md
+++ b/plans/fix-escape-chart-html.md
@@ -25,6 +25,9 @@ canvas id は内部生成 (`generateUniqueId`)、CDN URL は内部テーブル�
   - `escapeJsonForScript(json)` — `JSON.stringify` の出力を inline `<script>` 用に無害化
   - lookup は Map。オブジェクトリテラルだと #1534 と同じプロトタイプ経由の穴が空く
 - `chart_html.ts` — title に `escapeHtml`、chartData に `escapeJsonForScript`
+- `escapedChartTemplateValues` — PNG/PDF/動画経路 (`processChart`) 用。Codex レビューで
+  こちらを見落としていたことが判明した。`--allow-file-access-from-files` 付きで起動するため
+  dump 経路より影響が大きい。Puppeteer 無しでテストできるよう pure 関数に切り出す。
 
 ## 検証
 
@@ -34,3 +37,4 @@ canvas id は内部生成 (`generateUniqueId`)、CDN URL は内部テーブル�
 
 mermaid / bg_image_util / html_tailwind・markdown の契約。
 `src/actions/html.ts:51` の `<title>${title}</title>` も無エスケープ。
+`beat.image.style` の `</style>` breakout は #1537（生産者は `resolveCombinedStyle` 1つ、消費者4プラグイン）。

--- a/plans/fix-escape-chart-html.md
+++ b/plans/fix-escape-chart-html.md
@@ -6,11 +6,11 @@
 
 `#1535` は当初「6ファイルを一括で直す」と書いていたが、実際に各サイトを見ると3種類に割れる。
 
-| 種別 | 該当 | 対応 |
-|---|---|---|
-| データ（HTML text / 属性 / script 内 JSON） | chart の title・chartData、mermaid の title・code | エスケープする |
-| CSS 文字列内の URL | `bg_image_util` の `url('${imageUrl}')` | CSS エスケープ（別種） |
-| 意図的なマークアップ | `html_tailwind` のユーザー HTML/JS、markdown→marked 経路 | エスケープ不可。契約として明記する |
+| 種別                                        | 該当                                                     | 対応                               |
+| ------------------------------------------- | -------------------------------------------------------- | ---------------------------------- |
+| データ（HTML text / 属性 / script 内 JSON） | chart の title・chartData、mermaid の title・code        | エスケープする                     |
+| CSS 文字列内の URL                          | `bg_image_util` の `url('${imageUrl}')`                  | CSS エスケープ（別種）             |
+| 意図的なマークアップ                        | `html_tailwind` のユーザー HTML/JS、markdown→marked 経路 | エスケープ不可。契約として明記する |
 
 3番目をエスケープすると機能が壊れる。`size` は enum、`opacity` は範囲付き数値なのでユーザー制御ではない。
 

--- a/plans/fix-escape-chart-html.md
+++ b/plans/fix-escape-chart-html.md
@@ -1,0 +1,36 @@
+# fix: chart の HTML / inline JS 埋め込みをエスケープする
+
+親 issue: #1535 の第1弾（chart のみ）。
+
+## 調べたこと
+
+`#1535` は当初「6ファイルを一括で直す」と書いていたが、実際に各サイトを見ると3種類に割れる。
+
+| 種別 | 該当 | 対応 |
+|---|---|---|
+| データ（HTML text / 属性 / script 内 JSON） | chart の title・chartData、mermaid の title・code | エスケープする |
+| CSS 文字列内の URL | `bg_image_util` の `url('${imageUrl}')` | CSS エスケープ（別種） |
+| 意図的なマークアップ | `html_tailwind` のユーザー HTML/JS、markdown→marked 経路 | エスケープ不可。契約として明記する |
+
+3番目をエスケープすると機能が壊れる。`size` は enum、`opacity` は範囲付き数値なのでユーザー制御ではない。
+
+chart の中でも、実際にユーザーが握るのは **title と chartData の2つだけ**。
+canvas id は内部生成 (`generateUniqueId`)、CDN URL は内部テーブル（プロトタイプ経由の件は #1534）なので、
+到達しない値まで包まない。
+
+## 変更
+
+- `src/utils/html_escape.ts`（新規, pure）
+  - `escapeHtml(value)` — HTML text と引用符付き属性の両方に使える
+  - `escapeJsonForScript(json)` — `JSON.stringify` の出力を inline `<script>` 用に無害化
+  - lookup は Map。オブジェクトリテラルだと #1534 と同じプロトタイプ経由の穴が空く
+- `chart_html.ts` — title に `escapeHtml`、chartData に `escapeJsonForScript`
+
+## 検証
+
+実ブラウザ（puppeteer）で main と突き合わせる。build が通ることは動くことの証明にならない。
+
+## 残り（別PR）
+
+mermaid / bg_image_util / html_tailwind・markdown の契約。
+`src/actions/html.ts:51` の `<title>${title}</title>` も無エスケープ。

--- a/src/utils/html_escape.ts
+++ b/src/utils/html_escape.ts
@@ -1,0 +1,34 @@
+/**
+ * Escaping for values interpolated into generated HTML. Pure — no Node, no filesystem —
+ * because the Node render path and the browser fragment path embed the same values and must
+ * neutralize them the same way.
+ *
+ * Lookups go through a Map rather than an object literal so a value naming an
+ * Object.prototype member cannot resolve through the prototype chain.
+ */
+
+const HTML_ESCAPES = new Map([
+  ["&", "&amp;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+  ['"', "&quot;"],
+  ["'", "&#39;"],
+]);
+
+/** Neutralize a value placed in HTML text or inside a quoted attribute. */
+export const escapeHtml = (value: string): string => value.replace(/[&<>"']/g, (character) => HTML_ESCAPES.get(character) ?? character);
+
+// JSON.stringify emits these only from inside string literals, so replacing them with their
+// \u escapes leaves the parsed value identical while stopping `</script>` from terminating the
+// block the JSON is embedded in. U+2028 / U+2029 are valid JSON output but were line
+// terminators in JavaScript source before ES2019.
+const SCRIPT_JSON_ESCAPES = new Map([
+  ["<", "\\u003c"],
+  [">", "\\u003e"],
+  ["&", "\\u0026"],
+  ["\u2028", "\\u2028"],
+  ["\u2029", "\\u2029"],
+]);
+
+/** Neutralize the output of JSON.stringify for embedding inside an inline `<script>`. */
+export const escapeJsonForScript = (json: string): string => json.replace(/[<>&\u2028\u2029]/g, (character) => SCRIPT_JSON_ESCAPES.get(character) ?? character);

--- a/src/utils/html_escape.ts
+++ b/src/utils/html_escape.ts
@@ -1,22 +1,14 @@
 /**
- * Escaping for values interpolated into generated HTML. Pure — no Node, no filesystem —
- * because the Node render path and the browser fragment path embed the same values and must
- * neutralize them the same way.
+ * Escaping for JSON embedded in an inline script. Pure — no Node, no filesystem — because the
+ * Node render path and the browser fragment path embed the same values and must neutralize
+ * them the same way.
  *
- * Lookups go through a Map rather than an object literal so a value naming an
+ * HTML text and attributes are handled by escapeHtml from @mulmocast/deck; this module exists
+ * only for the inline-script context, which that helper does not cover.
+ *
+ * The lookup goes through a Map rather than an object literal so a value naming an
  * Object.prototype member cannot resolve through the prototype chain.
  */
-
-const HTML_ESCAPES = new Map([
-  ["&", "&amp;"],
-  ["<", "&lt;"],
-  [">", "&gt;"],
-  ['"', "&quot;"],
-  ["'", "&#39;"],
-]);
-
-/** Neutralize a value placed in HTML text or inside a quoted attribute. */
-export const escapeHtml = (value: string): string => value.replace(/[&<>"']/g, (character) => HTML_ESCAPES.get(character) ?? character);
 
 // JSON.stringify emits these only from inside string literals, so replacing them with their
 // \u escapes leaves the parsed value identical while stopping `</script>` from terminating the

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -3,7 +3,7 @@ import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
-import { chartHtml, resolveChartPlugins, stringifyChartData } from "./chart_html.js";
+import { chartHtml, escapedChartTemplateValues, resolveChartPlugins, stringifyChartData } from "./chart_html.js";
 
 export const imageType = "chart";
 
@@ -17,10 +17,9 @@ const processChart = async (params: ImageProcessorParams) => {
   const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
   const template = getHTMLFile("chart");
   const htmlData = interpolate(template, {
-    title: beat.image.title,
+    ...escapedChartTemplateValues(beat.image.title, beat.image.chartData),
     style: combinedStyle,
     chart_width: chart_width.toString(),
-    chart_data: JSON.stringify(beat.image.chartData),
     chart_plugins: resolveChartPlugins(chartType),
   });
   await renderHTMLToImage(htmlData, imagePath, canvasSize.width, canvasSize.height);

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -47,3 +47,12 @@ export const chartHtml = (chartDataJson: string, title: string, chartId: string)
   </script>
 </div>`;
 };
+
+/**
+ * The two values the PNG/PDF/movie template interpolates from user data, escaped for the
+ * contexts it drops them into: `<h1>${title}</h1>` and `const chartData = ${chart_data};`.
+ */
+export const escapedChartTemplateValues = (title: string, chartData: MulmoChartMedia["chartData"]): { title: string; chart_data: string } => ({
+  title: escapeHtml(title),
+  chart_data: escapeJsonForScript(JSON.stringify(chartData)),
+});

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -1,4 +1,5 @@
 import type { MulmoChartMedia } from "../../types/index.js";
+import { escapeHtml, escapeJsonForScript } from "../html_escape.js";
 
 /**
  * Chart.js markup and plugin resolution. Pure — no Node, no filesystem — because both the
@@ -27,7 +28,7 @@ export const resolveChartPlugins = (chartType: string): string => {
 export const stringifyChartData = (chartData: MulmoChartMedia["chartData"]): string => JSON.stringify(chartData, null, 2);
 
 export const chartHtml = (chartDataJson: string, title: string, chartId: string): string => {
-  const heading = title || "Chart";
+  const heading = escapeHtml(title || "Chart");
 
   return `
 <div class="chart-container mb-6">
@@ -38,7 +39,7 @@ export const chartHtml = (chartDataJson: string, title: string, chartId: string)
   <script>
     (function() {
       const ctx = document.getElementById('${chartId}').getContext('2d');
-      new Chart(ctx, ${chartDataJson});
+      new Chart(ctx, ${escapeJsonForScript(chartDataJson)});
     })();
   </script>
 </div>`;

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -1,5 +1,8 @@
 import type { MulmoChartMedia } from "../../types/index.js";
-import { escapeHtml, escapeJsonForScript } from "../html_escape.js";
+// Deep import: the package barrel pulls in every layout and all of zod, which measured
+// 551kb against 1.5kb for this file, and the browser fragment path bundles this module.
+import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
+import { escapeJsonForScript } from "../html_escape.js";
 
 /**
  * Chart.js markup and plugin resolution. Pure — no Node, no filesystem — because both the

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { chartHtml, resolveChartPlugins, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
+import { chartHtml, escapedChartTemplateValues, resolveChartPlugins, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
 import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
 
 /**
@@ -157,4 +157,16 @@ test("each call gets its own chart-prefixed id", async () => {
       process.env.NODE_ENV = saved;
     }
   }
+});
+
+// The PNG / PDF / movie path renders assets/html/chart.html through Puppeteer with
+// --allow-file-access-from-files, so an injection there reads local files. Verified in a
+// browser: before this, both payloads ran and the chart did not draw at all.
+test("the render template's user values are escaped for their own contexts", () => {
+  const values = escapedChartTemplateValues('</h1><img src=x onerror="pwn()">', { label: "</script><script>pwn()</script>" });
+  assert.ok(!values.title.includes("<"), "the heading value must not carry a tag");
+  assert.strictEqual(values.title, "&lt;/h1&gt;&lt;img src=x onerror=&quot;pwn()&quot;&gt;");
+  assert.ok(!values.chart_data.includes("</script>"), "the script value must not terminate the block");
+  assert.ok(!values.chart_data.includes("<"), "the script value must not carry a raw angle bracket");
+  assert.deepStrictEqual(JSON.parse(values.chart_data), { label: "</script><script>pwn()</script>" }, "the value itself is unchanged");
 });

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -47,6 +47,14 @@ test("an empty title falls back to Chart, a present one is escaped into the head
   assert.match(chartHtml("{}", "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 &amp; &lt;b&gt;<\/h3>/);
 });
 
+// The title is text, not markup, so an entity reference stops decoding as well: a browser
+// showed "Revenue &amp; Profit" rendering as "Revenue & Profit" before and literally after.
+// Pinned because it is the second user-visible consequence of the fix, and the easier to miss.
+test("entity references in a title become literal text", () => {
+  assert.match(chartHtml("{}", "Revenue &amp; Profit", "c1"), /<h3[^>]*>Revenue &amp;amp; Profit<\/h3>/);
+  assert.match(chartHtml("{}", "&#x58;", "c1"), /<h3[^>]*>&amp;#x58;<\/h3>/);
+});
+
 // Verified in a real browser before and after: with these values main executed the injected
 // handler AND lost the chart entirely, because the `</script>` ended the block that draws it.
 test("a hostile title and hostile chart data cannot escape their contexts", () => {

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -41,10 +41,21 @@ test("chart markup is exact", () => {
   );
 });
 
-test("an empty title falls back to Chart, a present one is used verbatim", () => {
+test("an empty title falls back to Chart, a present one is escaped into the heading", () => {
   assert.match(chartHtml("{}", "", "c1"), /<h3 class="text-xl font-semibold mb-4">Chart<\/h3>/);
   assert.match(chartHtml("{}", "  ", "c1"), /<h3 class="text-xl font-semibold mb-4"> {2}<\/h3>/);
-  assert.match(chartHtml("{}", "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 & <b><\/h3>/);
+  assert.match(chartHtml("{}", "日本語 & <b>", "c1"), /<h3 class="text-xl font-semibold mb-4">日本語 &amp; &lt;b&gt;<\/h3>/);
+});
+
+// Verified in a real browser before and after: with these values main executed the injected
+// handler AND lost the chart entirely, because the `</script>` ended the block that draws it.
+test("a hostile title and hostile chart data cannot escape their contexts", () => {
+  const html = chartHtml(stringifyChartData({ label: "</script><script>pwn()</script>" }), '</h3><img src=x onerror="pwn()">', "c1");
+  assert.strictEqual(html.match(/<h3/g)?.length, 1, "the heading must not be closed early");
+  assert.strictEqual(html.match(/<script>/g)?.length, 1, "only the chart's own script tag may appear");
+  assert.strictEqual(html.match(/<\/script>/g)?.length, 1, "the chart's script must not be terminated early");
+  assert.ok(!html.includes("<img"), "no injected element may survive");
+  assert.ok(html.includes("&lt;/h3&gt;"), "the title is neutralized, not dropped");
 });
 
 test("the caller-supplied id is the only id, and reaches both the canvas and the lookup", () => {

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -57,13 +57,18 @@ test("entity references in a title become literal text", () => {
 
 // Verified in a real browser before and after: with these values main executed the injected
 // handler AND lost the chart entirely, because the `</script>` ended the block that draws it.
+// Counting is done on the lower-cased string rather than with a tag-shaped regex: the escape
+// neutralizes `<` itself, so a guard that only recognized lower-case tags would be weaker than
+// the code it checks.
+const countTags = (html: string, tag: string): number => html.toLowerCase().split(tag).length - 1;
+
 test("a hostile title and hostile chart data cannot escape their contexts", () => {
-  const html = chartHtml(stringifyChartData({ label: "</script><script>pwn()</script>" }), '</h3><img src=x onerror="pwn()">', "c1");
-  assert.strictEqual(html.match(/<h3/g)?.length, 1, "the heading must not be closed early");
-  assert.strictEqual(html.match(/<script>/g)?.length, 1, "only the chart's own script tag may appear");
-  assert.strictEqual(html.match(/<\/script>/g)?.length, 1, "the chart's script must not be terminated early");
-  assert.ok(!html.includes("<img"), "no injected element may survive");
-  assert.ok(html.includes("&lt;/h3&gt;"), "the title is neutralized, not dropped");
+  const html = chartHtml(stringifyChartData({ label: "</SCRIPT ><script>pwn()</script>" }), '</H3 ><img src=x onerror="pwn()">', "c1");
+  assert.strictEqual(countTags(html, "<h3"), 1, "the heading must not be closed early");
+  assert.strictEqual(countTags(html, "<script"), 1, "only the chart's own script tag may appear");
+  assert.strictEqual(countTags(html, "</script"), 1, "the chart's script must not be terminated early");
+  assert.strictEqual(countTags(html, "<img"), 0, "no injected element may survive");
+  assert.ok(html.includes("&lt;/H3 &gt;"), "the title is neutralized, not dropped");
 });
 
 test("the caller-supplied id is the only id, and reaches both the canvas and the lookup", () => {

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -1,29 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import { escapeHtml, escapeJsonForScript } from "../../src/utils/html_escape.js";
+import { escapeJsonForScript } from "../../src/utils/html_escape.js";
 
 const LINE_SEPARATOR = " ";
 const PARAGRAPH_SEPARATOR = " ";
-
-test("escapeHtml neutralizes every character that can leave a text or attribute context", () => {
-  assert.strictEqual(escapeHtml("&"), "&amp;");
-  assert.strictEqual(escapeHtml("<"), "&lt;");
-  assert.strictEqual(escapeHtml(">"), "&gt;");
-  assert.strictEqual(escapeHtml('"'), "&quot;");
-  assert.strictEqual(escapeHtml("'"), "&#39;");
-  assert.strictEqual(escapeHtml("</h3><img src=x onerror=alert(1)>"), "&lt;/h3&gt;&lt;img src=x onerror=alert(1)&gt;");
-});
-
-// The near-miss half: a guard that escapes everything is as wrong as one that escapes nothing.
-test("escapeHtml leaves everything else byte-identical", () => {
-  ["", "Revenue", "売上 2026", "a-b_c 100%", "80% → 90%", "line\nbreak", "tab\there", "emoji 📊", "\\backslash", "`tick`"].forEach((value) => {
-    assert.strictEqual(escapeHtml(value), value, `${JSON.stringify(value)} must pass through unchanged`);
-  });
-});
-
-test("escapeHtml escapes what it is given, so calling it twice double-escapes", () => {
-  assert.strictEqual(escapeHtml(escapeHtml("&")), "&amp;amp;");
-});
 
 test("escapeJsonForScript stops JSON from terminating the script that carries it", () => {
   const json = JSON.stringify({ s: "</script><script>alert(1)</script>" });
@@ -50,6 +30,12 @@ test("escapeJsonForScript preserves the value a JSON reader sees", () => {
     const escaped = escapeJsonForScript(json);
     assert.deepStrictEqual(JSON.parse(escaped), value, "JSON.parse must see the same value");
   });
+});
+
+// `&` cannot terminate a script, so it is defence in depth rather than the breakout fix —
+// pinned so removing it is a decision someone makes rather than one that goes unnoticed.
+test("escapeJsonForScript also escapes the ampersand", () => {
+  assert.strictEqual(escapeJsonForScript(JSON.stringify({ s: "a&b" })), '{"s":"a\\u0026b"}');
 });
 
 test("escapeJsonForScript leaves JSON without those characters byte-identical", () => {

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert";
+import { escapeHtml, escapeJsonForScript } from "../../src/utils/html_escape.js";
+
+const LINE_SEPARATOR = " ";
+const PARAGRAPH_SEPARATOR = " ";
+
+test("escapeHtml neutralizes every character that can leave a text or attribute context", () => {
+  assert.strictEqual(escapeHtml("&"), "&amp;");
+  assert.strictEqual(escapeHtml("<"), "&lt;");
+  assert.strictEqual(escapeHtml(">"), "&gt;");
+  assert.strictEqual(escapeHtml('"'), "&quot;");
+  assert.strictEqual(escapeHtml("'"), "&#39;");
+  assert.strictEqual(escapeHtml("</h3><img src=x onerror=alert(1)>"), "&lt;/h3&gt;&lt;img src=x onerror=alert(1)&gt;");
+});
+
+// The near-miss half: a guard that escapes everything is as wrong as one that escapes nothing.
+test("escapeHtml leaves everything else byte-identical", () => {
+  ["", "Revenue", "売上 2026", "a-b_c 100%", "80% → 90%", "line\nbreak", "tab\there", "emoji 📊", "\\backslash", "`tick`"].forEach((value) => {
+    assert.strictEqual(escapeHtml(value), value, `${JSON.stringify(value)} must pass through unchanged`);
+  });
+});
+
+test("escapeHtml escapes what it is given, so calling it twice double-escapes", () => {
+  assert.strictEqual(escapeHtml(escapeHtml("&")), "&amp;amp;");
+});
+
+test("escapeJsonForScript stops JSON from terminating the script that carries it", () => {
+  const json = JSON.stringify({ s: "</script><script>alert(1)</script>" });
+  const escaped = escapeJsonForScript(json);
+  assert.ok(!escaped.includes("</script>"), "no closing script tag may survive");
+  assert.ok(!escaped.includes("<"), "no raw angle bracket may survive");
+});
+
+// The browser reads this as a JavaScript object literal inside <script>, not as JSON. The
+// \uXXXX escape means the same thing in both grammars, and evaluating it here would trip the
+// repo's sonarjs/code-eval rule, so the JS reading is verified against a real browser instead.
+test("escapeJsonForScript preserves the value a JSON reader sees", () => {
+  const values: unknown[] = [
+    { s: "</script>" },
+    { s: `a & b < c > d` },
+    { s: LINE_SEPARATOR + PARAGRAPH_SEPARATOR },
+    { nested: { deep: ["<", "&", ">"] } },
+    { 予算: "1<2" },
+    {},
+    [],
+  ];
+  values.forEach((value) => {
+    const json = JSON.stringify(value, null, 2);
+    const escaped = escapeJsonForScript(json);
+    assert.deepStrictEqual(JSON.parse(escaped), value, "JSON.parse must see the same value");
+  });
+});
+
+test("escapeJsonForScript leaves JSON without those characters byte-identical", () => {
+  [{ type: "bar", data: { labels: ["東京", "大阪"], datasets: [{ data: [1, 2] }] } }, {}, { n: 0 }].forEach((value) => {
+    const json = JSON.stringify(value, null, 2);
+    assert.strictEqual(escapeJsonForScript(json), json);
+  });
+});
+
+test("escapeJsonForScript covers the separators that were line terminators before ES2019", () => {
+  const json = JSON.stringify({ s: LINE_SEPARATOR + PARAGRAPH_SEPARATOR });
+  const escaped = escapeJsonForScript(json);
+  assert.ok(!escaped.includes(LINE_SEPARATOR), "U+2028 must not survive raw");
+  assert.ok(!escaped.includes(PARAGRAPH_SEPARATOR), "U+2029 must not survive raw");
+});

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -32,10 +32,26 @@ test("escapeJsonForScript preserves the value a JSON reader sees", () => {
   });
 });
 
-// `&` cannot terminate a script, so it is defence in depth rather than the breakout fix —
-// pinned so removing it is a decision someone makes rather than one that goes unnoticed.
-test("escapeJsonForScript also escapes the ampersand", () => {
-  assert.strictEqual(escapeJsonForScript(JSON.stringify({ s: "a&b" })), '{"s":"a\\u0026b"}');
+// The whole mapping, not one character at a time: this table was added after a review found
+// `&` untested, and a second review then found `>` untested. Only `<` is load-bearing for the
+// breakout — the rest are defence in depth — but an incomplete table is how the next one hides.
+test("escapeJsonForScript escapes every character it claims, and only those", () => {
+  const escapes: [string, string][] = [
+    ["<", "\\u003c"],
+    [">", "\\u003e"],
+    ["&", "\\u0026"],
+    ["\u2028", "\\u2028"],
+    ["\u2029", "\\u2029"],
+  ];
+  escapes.forEach(([raw, escaped]) => {
+    assert.strictEqual(escapeJsonForScript(JSON.stringify({ s: raw })), `{"s":"${escaped}"}`, `${JSON.stringify(raw)} must become ${escaped}`);
+  });
+
+  // The near-miss half: everything JSON.stringify can emit that is NOT in the table survives.
+  ["'", '\\"', "/", "\\\\", "a", "日", "\u00a0", "\u200b"].forEach((raw) => {
+    const json = JSON.stringify({ s: raw });
+    assert.strictEqual(escapeJsonForScript(json), json, `${JSON.stringify(raw)} must pass through`);
+  });
 });
 
 test("escapeJsonForScript leaves JSON without those characters byte-identical", () => {


### PR DESCRIPTION
## Summary

chart beat の `title` は `<h3>` に、`chartData` は inline `<script>` に、どちらも**無エスケープ**で入っていました。mulmoscript からどちらのコンテキストも閉じられます。

- `src/utils/html_escape.ts`（新規, pure）— `escapeJsonForScript`（HTML text/属性は `@mulmocast/deck` の `escapeHtml` を再利用）
- `chart_html.ts` — `title` と `chartData` にのみ適用

`#1535` の第1弾です（chart のみ。mermaid / bg_image_util / html_tailwind は別PR）。

## Items to Confirm / Review

### 1. 「6箇所を一括で」ではありませんでした — 分類が変わっています

`#1535` は当初そう書いていましたが、各サイトを実際に見ると3種類に割れ、**3番目をエスケープすると機能が壊れます**。

| 種別 | 該当 | 対応 |
|---|---|---|
| **データ** | chart の title・chartData、mermaid の title・code | エスケープする |
| **CSS 文字列内の URL** | `bg_image_util` の `url('${imageUrl}')` | CSS エスケープ（別種） |
| **意図的なマークアップ** | `html_tailwind` のユーザー HTML/JS、markdown→marked | エスケープ不可。契約として明記するしかない |

`size` は `z.enum`、`opacity` は `z.number().min(0).max(1)` なのでユーザー制御ではありません。issue にも追記済みです。

### 2. chart の中でも、包むのは2つだけにしました

ユーザーが握るのは `title` と `chartData` だけです。canvas id は `generateUniqueId` の内部生成、CDN URL は内部テーブル（プロトタイプ経由の件は #1534）なので、**到達しない値まで包んでいません**。ここは判断が分かれるところなのでレビューしてください。

### 3. 実ブラウザで確認しました（build が通ることは動くことの証明にならないので）

puppeteer で main と本ブランチを同じ文書に載せて比較:

| | XSS(title) | XSS(data) | h3 の文字列 | Chart が見たラベル | グラフ描画 |
|---|---|---|---|---|---|
| **main・敵対的入力** | 🔴 実行 | 🔴 実行 | `""`（`</h3>` で閉じられた） | (chart 無し) | 🔴 **描かれない** |
| **本ブランチ・敵対的入力** | 🟢 なし | 🟢 なし | 文字通り表示 | 元の値のまま | 🟢 描かれる |
| **正常入力・main** | — | — | `売上 & 利益` | `Q&A` | 🟢 |
| **正常入力・本ブランチ** | — | — | `売上 & 利益` | `Q&A` | 🟢 |

main の敵対的ケースは `pageerror: Invalid or unexpected token` を出します。つまり**これはセキュリティだけの問題ではなく、`</script>` を含むデータを持つチャートは今も壊れています。**

### 4. 既存コンテンツへの影響 — バイトは変わるが描画は変わりません

現実的な title × chartData の 77 通りで実測: **42 件 (55%) でバイトが変わります**（`Q&A` → `Q&amp;A` など）。ただし上の表の下2行のとおり、**DOM のテキストと Chart.js が読むデータはブラウザ上で同一**です。

**利用者に見える変化は2つあります**（当初1つと書いていましたが、Codex の指摘で2つ目が見つかりました）。どちらも「title は markup ではなくテキスト」という同じ帰結で、実ブラウザで測っています。

| 入力 | main | 本ブランチ |
|---|---|---|
| `<b>bold</b>` | 太字で描画 | 文字通り表示 |
| `Revenue &amp; Profit` | `Revenue & Profit` | `Revenue &amp; Profit` ⚠️ |
| `&#x58;` | `X` | `&#x58;` ⚠️ |
| `Q&A` / `R&D 予算` | そのまま | **同じ**（よくあるケースは影響なし） |

スキーマ上 `title` は `z.string()` で、HTML や実体参照を書けるとはどこにも書かれていません。両方ともテストで固定してあります。判断が要るなら教えてください。

### 5. テストで eval を使えませんでした

`escapeJsonForScript` の出力は `<script>` 内で **JSON ではなく JS のオブジェクトリテラル**として読まれます。それを in-process で確かめようとすると `new Function` も `node:vm` も repo の `sonarjs/code-eval` に掛かります。**抑制はしない**方針なので、JS としての読み取りは上記の実ブラウザ検証で担保し、ユニットテストは `JSON.parse` 同値性に留めました。テストにその旨をコメントで残しています。

## 検証

- `npx prettier --check` / `npx eslint`（対象5ファイル）: clean
- `npx tsc --noEmit`: clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1094 tests, 0 fail**
- 新テストは `NODE_ENV=test` あり／なしの両方で緑
- **エスケープを外す変異すべてで赤くなることを確認**（レビュー中に対象が増えています）:

  | 変異 | 結果 |
  |---|---|
  | dump 経路: title のエスケープを外す | fail=3 |
  | dump 経路: chartData のエスケープを外す | fail=1 |
  | **render 経路: title のエスケープを外す** | fail=1 |
  | **render 経路: chart_data のエスケープを外す** | fail=1 |
  | `escapeJsonForScript` の表から `<` を外す | fail=2 |
  | 同 `>` を外す | fail=1 |
  | 同 `&` を外す | fail=1 |
  | 同 U+2028 / U+2029 を外す | fail=2 / 2 |

- lookup は Map。オブジェクトリテラルだと #1534 と同じプロトタイプ経由の穴が空くため

### 6. 既存実装の再利用（round 1 で変更）

Codex に「repo には既に `escapeHtml` が2つある」と指摘され、3つ目を作っていたことが分かりました。`@mulmocast/deck` の実装と実測で**全12入力バイト一致**だったので自前実装は削除し、そちらを import しています。

ただし **barrel 経由だと 102 モジュール / 551.6 KB**（全 layout と zod 全ロケール）が入るため、**deep import (`@mulmocast/deck/lib/utils.js`) にしました → 3 モジュール / 1.5 KB**。この module はブラウザ fragment 経路でバンドルされるのが存在理由なので、そこは譲れないところです。理由はコメントに残しています。deck に subpath export を足すのが本筋なので、必要なら別途対応します。

`src/utils/swipe_to_html.ts:56` にも3つ目のローカル実装があり、そちらは `'` をエスケープしていません（使われているのは二重引用符属性とテキストなので脆弱性ではない）。別PRで統合します。

## User Prompt

> とりこんですすむ

（#1526 のブラウザ経路に進む前に #1535 のエスケープを先に片付ける、という順序で進めています）

Refs #1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart security by safely escaping chart titles and embedded chart data.
  * Prevented specially crafted titles or data from injecting HTML elements or prematurely ending scripts.
  * Ensured entity references in chart titles display as literal text.

* **Tests**
  * Added coverage for HTML-sensitive characters, script termination, JSON preservation, and Unicode line separators.

* **Documentation**
  * Added a Japanese implementation plan outlining chart escaping improvements and remaining related work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

