### PR TITLE
fix: stop script-supplied css from terminating the style block

### DIFF
--- a/plans/fix-escape-style-terminator.md
+++ b/plans/fix-escape-style-terminator.md
@@ -1,0 +1,37 @@
+# fix: script 由来の CSS が `<style>` ブロックを抜け出せる問題
+
+issue: #1537（#1535 の第2弾）。
+
+## 調べたこと — 当初 issue に書いた入力経路は間違っていた
+
+issue には `beat.image.style` と書いたが、これは誤り。`resolveStyle` はこれを **CSS ではなく
+スタイル名**として `getMarkdownStyle` で引いており、未知の名前は fallback に置き換わる
+(`utils.ts:10`)。最初の再現はテンプレートに直接文字列を差し込んだもので、ユーザー入力が
+そこに届くことを示していなかった。
+
+実際に届くのは `textSlideParams.cssStyles`:
+
+```
+beat.textSlideParams.cssStyles / presentationStyle.textSlideParams.cssStyles
+  → getTextSlideStyle()        (mulmo_presentation_style.ts:85-90)
+  → params.textSlideStyle      (image_agents.ts:25)
+  → resolveCombinedStyle()     (bg_image_util.ts:64)
+  → ${style} in assets/html/{chart,mermaid}.html
+```
+
+スキーマは `cssStyles: stringOrStringArray`（`schema.ts:493`）で内容に制約なし。
+
+## 変更
+
+- `neutralizeStyleTerminator(css)` を `html_escape.ts` に追加（pure）
+- `resolveCombinedStyle` の返り値に適用。**生産者は1つ、消費者は4プラグイン**
+  （chart / mermaid / markdown / text_slide）なので、ここ1箇所で全部塞がる
+
+CSS 全体をエスケープすると「script が CSS を書ける」仕様が壊れる。`<style>` は raw text 要素で
+終端は `</style` だけなので、そこだけ CSS エスケープ `\3c ` にする。マッチした文字列は
+そのまま繋ぐので `</STYLE>` の大文字も保たれる。
+
+## 検証
+
+実ブラウザで、`getTextSlideStyle` から組み立てた実経路で before/after を比較する。
+`\3c ` が値を保つこと（`content: "</style>"` が同じ値として読まれること）も確認する。

--- a/plans/fix-escape-style-terminator.md
+++ b/plans/fix-escape-style-terminator.md
@@ -11,7 +11,7 @@ issue には `beat.image.style` と書いたが、これは誤り。`resolveStyl
 
 実際に届くのは `textSlideParams.cssStyles`:
 
-```
+```text
 beat.textSlideParams.cssStyles / presentationStyle.textSlideParams.cssStyles
   → getTextSlideStyle()        (mulmo_presentation_style.ts:85-90)
   → params.textSlideStyle      (image_agents.ts:25)
@@ -28,10 +28,10 @@ beat.textSlideParams.cssStyles / presentationStyle.textSlideParams.cssStyles
   （chart / mermaid / markdown / text_slide）なので、ここ1箇所で全部塞がる
 
 CSS 全体をエスケープすると「script が CSS を書ける」仕様が壊れる。`<style>` は raw text 要素で
-終端は `</style` だけなので、そこだけ CSS エスケープ `\3c ` にする。マッチした文字列は
-そのまま繋ぐので `</STYLE>` の大文字も保たれる。
+終端は `</style` だけなので、そこだけ CSS の16進エスケープ（`\3c` に**続く空白1個**まで含めてエスケープを終端する）
+に置き換える。マッチした文字列はそのまま繋ぐので `</STYLE>` の大文字も保たれる。
 
 ## 検証
 
 実ブラウザで、`getTextSlideStyle` から組み立てた実経路で before/after を比較する。
-`\3c ` が値を保つこと（`content: "</style>"` が同じ値として読まれること）も確認する。
+このエスケープが値を保つこと（`content: "</style>"` が同じ値として読まれること）も確認する。

--- a/src/utils/html_escape.ts
+++ b/src/utils/html_escape.ts
@@ -24,3 +24,10 @@ const SCRIPT_JSON_ESCAPES = new Map([
 
 /** Neutralize the output of JSON.stringify for embedding inside an inline `<script>`. */
 export const escapeJsonForScript = (json: string): string => json.replace(/[<>&\u2028\u2029]/g, (character) => SCRIPT_JSON_ESCAPES.get(character) ?? character);
+
+// A <style> element holds raw text: nothing inside it is parsed as markup except the closing
+// tag, so `</style` is the only sequence that can end it. Neutralizing just that keeps
+// author-supplied CSS working, which escaping the whole string would not. `\3c ` is the CSS
+// escape for `<`, and the matched text is carried through unchanged so a `</STYLE>` written
+// inside a CSS string keeps its casing as well as its value.
+export const neutralizeStyleTerminator = (css: string): string => css.replace(/<\/style/gi, (terminator) => `\\3c ${terminator.slice(1)}`);

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -2,6 +2,7 @@ import { BackgroundImage, MulmoStudioContext, ImageProcessorParams } from "../..
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 import { resolveStyle } from "./utils.js";
 import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../fetch.js";
+import { neutralizeStyleTerminator } from "../html_escape.js";
 
 /**
  * Resolve background image from beat level and global level settings.
@@ -62,7 +63,7 @@ export const resolveCombinedStyle = async (
   const resolvedBackgroundImage = resolveBackgroundImage(beatBackgroundImage, globalBackgroundImage);
   const backgroundCSS = await backgroundImageToCSS(resolvedBackgroundImage, context);
   const style = resolveStyle(beatStyle, textSlideStyle);
-  return backgroundCSS + style;
+  return neutralizeStyleTerminator(backgroundCSS + style);
 };
 
 export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | undefined, context: MulmoStudioContext): Promise<string> => {

--- a/test/image_plugins/test_bg_image_util.ts
+++ b/test/image_plugins/test_bg_image_util.ts
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert";
+import { resolveCombinedStyle } from "../../src/utils/image_plugins/bg_image_util.js";
+
+/**
+ * resolveCombinedStyle is the only producer of the CSS that chart, mermaid, markdown and
+ * text_slide interpolate into a <style> block, so the terminator is neutralized here rather
+ * than at each of the four call sites.
+ *
+ * The script-controlled CSS arrives as textSlideStyle, built from textSlideParams.cssStyles.
+ * A beat's own `style` is a style NAME looked up in the built-in table, not raw CSS, so it
+ * cannot carry a terminator — pinned below so that stays true.
+ */
+
+const paramsWith = (textSlideStyle: string) => ({
+  context: { studio: { script: {} } },
+  textSlideStyle,
+});
+
+const ATTACK = 'h1{color:red}</style><img src=x onerror="pwn()">';
+
+test("script-supplied css cannot terminate the style block it is placed in", async () => {
+  const css = await resolveCombinedStyle(paramsWith(ATTACK), undefined, undefined);
+  assert.ok(!/<\/style/i.test(css), "no terminator may survive");
+  assert.ok(css.includes("h1{color:red}"), "the author's CSS is kept, not dropped");
+});
+
+test("a beat style is a name, so an unknown one falls back rather than being emitted", async () => {
+  const css = await resolveCombinedStyle(paramsWith("h1 { color: rgb(1, 1, 1); }"), undefined, ATTACK);
+  assert.strictEqual(css, "h1 { color: rgb(1, 1, 1); }", "the unknown name is replaced by the fallback style");
+});
+
+test("ordinary CSS passes through resolveCombinedStyle unchanged", async () => {
+  const style = "h1 { color: rgb(9, 9, 9); }";
+  assert.strictEqual(await resolveCombinedStyle(paramsWith(style), undefined, undefined), style);
+});

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -90,6 +90,16 @@ test("neutralizeStyleTerminator uses a CSS escape, so the value is preserved", (
   assert.strictEqual(neutralizeStyleTerminator('h1::after{content:"</style>"}'), 'h1::after{content:"\\3c /style>"}');
 });
 
+// Deliberately broader than the exploitable set. Measured in a browser, injection needs
+// `</style` followed by `>` or HTML whitespace (space, tab, LF, CR, FF); `</stylex` and a
+// trailing `</style` at end of input do not inject. Escaping those anyway costs nothing —
+// the CSS escape preserves the value — and it removes any dependence on getting the
+// terminator set exactly right in every browser.
+test("neutralizeStyleTerminator over-matches on purpose, and the value survives it", () => {
+  assert.strictEqual(neutralizeStyleTerminator('a{content:"</stylesheet>"}'), 'a{content:"\\3c /stylesheet>"}');
+  assert.strictEqual(neutralizeStyleTerminator("h1{}</style"), "h1{}\\3c /style");
+});
+
 test("neutralizeStyleTerminator leaves ordinary CSS byte-identical", () => {
   [
     "",

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { escapeJsonForScript } from "../../src/utils/html_escape.js";
+import { escapeJsonForScript, neutralizeStyleTerminator } from "../../src/utils/html_escape.js";
 
 const LINE_SEPARATOR = " ";
 const PARAGRAPH_SEPARATOR = " ";
@@ -66,4 +66,39 @@ test("escapeJsonForScript covers the separators that were line terminators befor
   const escaped = escapeJsonForScript(json);
   assert.ok(!escaped.includes(LINE_SEPARATOR), "U+2028 must not survive raw");
   assert.ok(!escaped.includes(PARAGRAPH_SEPARATOR), "U+2029 must not survive raw");
+});
+
+// A <style> element holds raw text, so `</style` is the ONLY sequence that can end it — no
+// entities, no comments, no other spelling. That is why enumerating the bad form is complete
+// here, unlike the script case where the value itself has to be neutralized.
+test("neutralizeStyleTerminator catches the terminator in every casing and shape", () => {
+  ["</style>", "</STYLE>", "</StYlE>", "</style >", "</style\n>", "</style/"].forEach((terminator) => {
+    const out = neutralizeStyleTerminator(`h1{color:red}${terminator}<img src=x onerror="pwn()">`);
+    assert.ok(!/<\/style/i.test(out), `${JSON.stringify(terminator)} must not survive`);
+    assert.ok(out.startsWith("h1{color:red}"), "the author's CSS before it is untouched");
+  });
+});
+
+test("neutralizeStyleTerminator catches every occurrence, not just the first", () => {
+  const out = neutralizeStyleTerminator("a</style>b</STYLE>c");
+  assert.strictEqual(out, "a\\3c /style>b\\3c /STYLE>c");
+});
+
+// Verified in a browser: the escaped form computes to the value "</style>", so CSS that
+// deliberately contains the text keeps working.
+test("neutralizeStyleTerminator uses a CSS escape, so the value is preserved", () => {
+  assert.strictEqual(neutralizeStyleTerminator('h1::after{content:"</style>"}'), 'h1::after{content:"\\3c /style>"}');
+});
+
+test("neutralizeStyleTerminator leaves ordinary CSS byte-identical", () => {
+  [
+    "",
+    "h1 { color: rgb(9, 9, 9); }",
+    "body { background-image: url('data:image/png;base64,AAA'); }",
+    "/* <style> in a comment is not a terminator */ p { margin: 0 }",
+    "@media (max-width: 100px) { .a > .b { content: '<'; } }",
+    ".x::before { content: 'style'; }",
+  ].forEach((css) => {
+    assert.strictEqual(neutralizeStyleTerminator(css), css, `${JSON.stringify(css)} must pass through`);
+  });
 });

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -91,10 +91,11 @@ test("neutralizeStyleTerminator uses a CSS escape, so the value is preserved", (
 });
 
 // Deliberately broader than the exploitable set. Measured in a browser, injection needs
-// `</style` followed by `>` or HTML whitespace (space, tab, LF, CR, FF); `</stylex` and a
-// trailing `</style` at end of input do not inject. Escaping those anyway costs nothing —
-// the CSS escape preserves the value — and it removes any dependence on getting the
-// terminator set exactly right in every browser.
+// `</style` followed by `>`, `/`, or HTML whitespace (space, tab, LF, CR, FF), with a `>`
+// closing the end tag before the payload; `</stylex`, VT, NBSP and a trailing `</style` at
+// end of input do not inject. Escaping those anyway costs nothing — the CSS escape preserves
+// the value — and it removes any dependence on carrying that boundary set exactly right for
+// every browser that opens a dump.
 test("neutralizeStyleTerminator over-matches on purpose, and the value survives it", () => {
   assert.strictEqual(neutralizeStyleTerminator('a{content:"</stylesheet>"}'), 'a{content:"\\3c /stylesheet>"}');
   assert.strictEqual(neutralizeStyleTerminator("h1{}</style"), "h1{}\\3c /style");


### PR DESCRIPTION
## Summary

mulmoscript の `textSlideParams.cssStyles` が `<style>${style}</style>` に生で入るため、`</style>` を書くとブロックを抜けて任意のマークアップが実行できます。

- `neutralizeStyleTerminator(css)` を `html_escape.ts` に追加（pure）
- `resolveCombinedStyle` の返り値に適用 — **生産者は1つ、消費者は4プラグイン**なのでここ1箇所で全部塞がる

`#1535` の第2弾です（#1536 の chart に続く）。

## Items to Confirm / Review

### 1. issue #1537 に書いた入力経路は間違っていました（訂正済み）

最初 `beat.image.style` と書きましたが誤りです。`resolveStyle` はこれを **CSS ではなくスタイル名**として `getMarkdownStyle` で引いており、未知の名前は fallback に置き換わります（`utils.ts:10`）。**最初の再現はテンプレートに直接文字列を差し込んだもので、ユーザー入力がそこに届くことを示していませんでした。** これは自分で書いたテストが暴きました。

実際に届く経路:

```
beat.textSlideParams.cssStyles / presentationStyle.textSlideParams.cssStyles
  → getTextSlideStyle()        (mulmo_presentation_style.ts:85-90)
  → params.textSlideStyle      (image_agents.ts:25)
  → resolveCombinedStyle()     (bg_image_util.ts:64)
  → ${style} in assets/html/{chart,mermaid}.html
```

スキーマは `cssStyles: stringOrStringArray`（`schema.ts:493`）で内容に制約はありません。
`beat.image.style` が安全であること（未知の名前は fallback になる）もテストで固定しました。

### 2. なぜ CSS 全体をエスケープしないのか

script が CSS を書けるのは仕様です。`<style>` は raw text 要素で、終端は **`</style` だけ**（実体参照もコメントも解釈されない）なので、そこだけ潰せば機能を保ったまま塞げます。ここは「悪い形の列挙」ですが、仕様上その形は1つしかないので完全です。

CSS の16進エスケープ（`\3c` に**続く空白1個**までがエスケープ、空白はそこで消費される）を使い、マッチした文字列はそのまま繋ぐので `</STYLE>` の大文字も保たれます。**ブラウザで値が保たれることを確認済み**: `content: "</style>"` → エスケープ後も computed value は `"</style>"`。

### 3. 実ブラウザでの before / after（実経路で組み立て）

| テンプレート | 入力 | main | 本PR |
|---|---|---|---|
| chart.html | 攻撃 | 🔴 実行 | 🟢 なし |
| chart.html | 正常CSS | `rgb(9,9,9)` | **同じ** |
| mermaid.html | 攻撃 | 🔴 実行 | 🟢 なし |
| mermaid.html | 正常CSS | `rgb(9,9,9)` | **同じ** |

攻撃ケースでも、攻撃文字列より前にある正常な CSS（`h1{color:rgb(1,2,3)}`）は**両方で適用されます** — 落としていません。

`renderHTMLToImage` は `--allow-file-access-from-files` 付きで puppeteer を起動する（`html_render.ts:148,214,265`）ため、注入された JS はローカルファイルを読めます。

### 4. 消費者4つのうち2つしか実機確認していません

`${style}` を持つテンプレートは `chart.html` と `mermaid.html` の2つで、両方ブラウザで確認しました。`markdown.ts` と `text_slide.ts` も同じ `resolveCombinedStyle` を通りますが、そちらは実機確認していません（生産者が同一なので同じ結果になるはずですが、実行してはいません）。

## 検証

- `npx prettier --check` / `npx eslint`（対象5ファイル）: clean
- `npx tsc --noEmit`: clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1101 tests, 0 fail**
- 新テストは `NODE_ENV=test` あり／なし両方で緑
- **変異3種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | 呼び出し側で `neutralizeStyleTerminator` を外す（plumbing） | fail=1 |
  | 大文字小文字の無視を外す (`gi`→`g`) | fail=2 |
  | 置換を無効化（そのまま返す） | fail=4 |

## User Prompt

> とりこんですすむ

（#1526 のブラウザ経路に進む前に #1535 のエスケープを片付ける、という順序。#1536 に続く2本目です）

Closes #1537
Refs #1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for custom CSS embedded in generated pages by neutralizing closing style-tag sequences.
  * Preserved ordinary CSS, casing, escaped values, and script-related content.
  * Applied the fix across supported chart, Mermaid, markdown, and text slide visualizations.

* **Tests**
  * Added coverage for varied casing, multiple occurrences, fallback styles, and unchanged CSS content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
