### PR TITLE
fix(mermaid): escape the title and diagram source in both paths

### DIFF
--- a/plans/fix-escape-mermaid.md
+++ b/plans/fix-escape-mermaid.md
@@ -11,7 +11,15 @@
 | render (`processMermaid`) | `${title}`        | `assets/html/mermaid.html` の `<h1>` |
 | render (`processMermaid`) | `${diagram_code}` | 同 `.mermaid` div                    |
 
-`${id}` は `generateUniqueId` の内部生成、`${style}` は #1538 で対応済み。
+`${id}` も**エスケープする**。dump 経路の呼び出し元 (`mermaid.ts`) は `generateUniqueId` を渡すが、
+markdown 経路 (`beat_html/markdown.ts`) は caller 指定の `idPrefix` から組み立てており、
+`beat_html/index.ts` は「caller だけが一意な id を決められる」と書いている。
+`mulmoBeatSchema.id`（"Unique identifier for the beat"）はスクリプト由来かつ無制約なので、
+host が beat.id を prefix に渡すと属性を抜け出せる。mermaid の id は属性1文脈なのでエスケープで足りる。
+
+chart 側は id が属性と JS 文字列リテラルの2文脈に出るためエスケープでは解けない → #1540。
+
+`${style}` は #1538 で対応済み。
 
 ## エスケープしても mermaid は壊れない（実測）
 

--- a/plans/fix-escape-mermaid.md
+++ b/plans/fix-escape-mermaid.md
@@ -1,0 +1,26 @@
+# fix: mermaid の title と図のソースをエスケープする
+
+#1535 の第3弾（#1536 chart、#1538 style に続く）。
+
+## サイト
+
+| 経路                      | 差し込み口        | 文脈                                 |
+| ------------------------- | ----------------- | ------------------------------------ |
+| dump (`mermaidHtml`)      | `${title}`        | `<h3>` の text                       |
+| dump (`mermaidHtml`)      | `${code.trim()}`  | `.mermaid` div の text               |
+| render (`processMermaid`) | `${title}`        | `assets/html/mermaid.html` の `<h1>` |
+| render (`processMermaid`) | `${diagram_code}` | 同 `.mermaid` div                    |
+
+`${id}` は `generateUniqueId` の内部生成、`${style}` は #1538 で対応済み。
+
+## エスケープしても mermaid は壊れない（実測）
+
+mermaid は要素の textContent を読む。HTML パーサは実体参照を復号して textContent を作るので、
+mermaid が受け取る文字列は変わらない。5種類の図（単純 / `&` と引用符入り / 山括弧入り / 日本語 /
+sequence）で、エスケープ有無の**レンダリング済み SVG がバイト単位で同一**であることを確認した。
+
+## browser-safety ゲートの allow-list
+
+`mermaid_html.ts` は `beat_html` の依存グラフ内なので、`@mulmocast/deck` の追加でゲートが発火した。
+deck が持ち込むのは `lib/utils.js` 1ファイルのみ（beat_html 全体で 7 入力 / 58.3 KB、大半は marked）。
+barrel 経由だと 551 KB になるため deep import。理由を allow-list のコメントに記録。

--- a/plans/fix-escape-mermaid.md
+++ b/plans/fix-escape-mermaid.md
@@ -15,9 +15,13 @@
 
 ## エスケープしても mermaid は壊れない（実測）
 
-mermaid は要素の textContent を読む。HTML パーサは実体参照を復号して textContent を作るので、
-mermaid が受け取る文字列は変わらない。5種類の図（単純 / `&` と引用符入り / 山括弧入り / 日本語 /
-sequence）で、エスケープ有無の**レンダリング済み SVG がバイト単位で同一**であることを確認した。
+mermaid は要素の **innerHTML** を読み、パース前に entity decode する
+(mermaid 11.17.0: `o = u.innerHTML; o = ck(or.entityDecode(o))`)。したがって受け取る文字列は変わらない。
+
+当初「textContent を読む」と書いていたがこれは誤りで、Codex のレビューで指摘され runtime を読んで確認した。
+仕組みが違うと危険になる形が変わるため、測定対象を10形に広げた: 単純 / `&` と引用符 / 山括弧 / 日本語 /
+sequence / ラベル内の `<br/>` / mermaid 自身の `#quot;` / ラベル内の `&amp;` / ラベル内の生タグ `<b>` /
+`%%{init}%%` ディレクティブ。**全形でレンダリング済み SVG がバイト単位で同一**。
 
 ## browser-safety ゲートの allow-list
 

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -3,7 +3,7 @@ import { MulmoMediaSourceMethods } from "../../methods/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
-import { mermaidHtml } from "./mermaid_html.js";
+import { escapedMermaidTemplateValues, mermaidHtml } from "./mermaid_html.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
 import { resolveImageRefs, resolveMovieRefs, resolveRelativeImagePaths } from "./html_tailwind.js";
 
@@ -21,9 +21,8 @@ const processMermaid = async (params: ImageProcessorParams) => {
   if (diagram_code) {
     const combinedStyle = await resolveCombinedStyle(params, beat.image.backgroundImage, beat.image.style);
     const rawHtml = interpolate(template, {
-      title: beat.image.title,
+      ...escapedMermaidTemplateValues(beat.image.title, `${diagram_code}\n${beat.image.appendix?.join("\n") ?? ""}`),
       style: combinedStyle,
-      diagram_code: `${diagram_code}\n${beat.image.appendix?.join("\n") ?? ""}`,
     });
     const resolvedImageRefs = resolveImageRefs(rawHtml, params.imageRefs ?? {});
     const resolvedAllRefs = resolveMovieRefs(resolvedImageRefs, params.movieRefs ?? {});

--- a/src/utils/image_plugins/mermaid_html.ts
+++ b/src/utils/image_plugins/mermaid_html.ts
@@ -1,3 +1,5 @@
+import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
+
 /**
  * Mermaid markup. Pure — no Node, no filesystem — because both the Node render path and
  * the browser fragment path draw the same diagram and must draw it the same way.
@@ -6,16 +8,26 @@
  * a PNG so a random id is fine, while the browser path re-renders and needs the same beat
  * to produce the same markup, or a host diffing fragments sees every diagram change
  * identity on every render.
+ *
+ * Both values are escaped. Mermaid reads the element's textContent, which the HTML parser
+ * produces by decoding entities, so it receives the original characters either way —
+ * measured across five diagram kinds, the rendered SVG is byte-identical.
  */
 export const mermaidHtml = (code: string, id: string, title?: string): string => {
-  const titleHtml = title ? `<h3 class="text-xl font-semibold mb-4">${title}</h3>` : "";
+  const titleHtml = title ? `<h3 class="text-xl font-semibold mb-4">${escapeHtml(title)}</h3>` : "";
   return `
 <div class="mermaid-container mb-6">
   ${titleHtml}
   <div class="flex justify-center">
     <div id="${id}" class="mermaid">
-      ${code.trim()}
+      ${escapeHtml(code.trim())}
     </div>
   </div>
 </div>`;
 };
+
+/** The two values assets/html/mermaid.html interpolates from user data, escaped for its `<h1>` and `.mermaid` text contexts. */
+export const escapedMermaidTemplateValues = (title: string, diagramCode: string): { title: string; diagram_code: string } => ({
+  title: escapeHtml(title),
+  diagram_code: escapeHtml(diagramCode),
+});

--- a/src/utils/image_plugins/mermaid_html.ts
+++ b/src/utils/image_plugins/mermaid_html.ts
@@ -7,7 +7,8 @@ import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
  * The element id is a parameter rather than generated here: the Node path renders once to
  * a PNG so a random id is fine, while the browser path re-renders and needs the same beat
  * to produce the same markup, or a host diffing fragments sees every diagram change
- * identity on every render.
+ * identity on every render. It is escaped because that parameter is caller-supplied — the
+ * markdown path builds it from an idPrefix, and a beat's `id` comes from the script.
  *
  * Both values are escaped. Mermaid reads the element's innerHTML and entity-decodes it
  * before parsing (mermaid 11.17.0: `o = u.innerHTML; o = entityDecode(o)`), so it receives
@@ -20,7 +21,7 @@ export const mermaidHtml = (code: string, id: string, title?: string): string =>
 <div class="mermaid-container mb-6">
   ${titleHtml}
   <div class="flex justify-center">
-    <div id="${id}" class="mermaid">
+    <div id="${escapeHtml(id)}" class="mermaid">
       ${escapeHtml(code.trim())}
     </div>
   </div>

--- a/src/utils/image_plugins/mermaid_html.ts
+++ b/src/utils/image_plugins/mermaid_html.ts
@@ -9,9 +9,10 @@ import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
  * to produce the same markup, or a host diffing fragments sees every diagram change
  * identity on every render.
  *
- * Both values are escaped. Mermaid reads the element's textContent, which the HTML parser
- * produces by decoding entities, so it receives the original characters either way —
- * measured across five diagram kinds, the rendered SVG is byte-identical.
+ * Both values are escaped. Mermaid reads the element's innerHTML and entity-decodes it
+ * before parsing (mermaid 11.17.0: `o = u.innerHTML; o = entityDecode(o)`), so it receives
+ * the original characters either way — measured across ten diagram shapes including `<br/>`
+ * in labels, `#quot;`, raw tags and an init directive, the rendered SVG is byte-identical.
  */
 export const mermaidHtml = (code: string, id: string, title?: string): string => {
   const titleHtml = title ? `<h3 class="text-xl font-semibold mb-4">${escapeHtml(title)}</h3>` : "";

--- a/test/actions/test_image_preprocess_agent_plugin.ts
+++ b/test/actions/test_image_preprocess_agent_plugin.ts
@@ -264,6 +264,8 @@ const mermaidPluginExpected = {
     "    G --> H[Customer Support]\n" +
     "    H --> A\n" +
     "```",
+  // The diagram source is escaped for its HTML text context. Mermaid reads textContent,
+  // which the parser produces by decoding entities, so the rendered SVG is unchanged.
   html:
     "\n" +
     '<div class="mermaid-container mb-6">\n' +
@@ -271,14 +273,14 @@ const mermaidPluginExpected = {
     '  <div class="flex justify-center">\n' +
     '    <div id="id" class="mermaid">\n' +
     "      graph LR\n" +
-    "    A[Market Research] --> B[Product Planning]\n" +
-    "    B --> C[Development]\n" +
-    "    C --> D[Testing]\n" +
-    "    D --> E[Manufacturing]\n" +
-    "    E --> F[Marketing]\n" +
-    "    F --> G[Sales]\n" +
-    "    G --> H[Customer Support]\n" +
-    "    H --> A\n" +
+    "    A[Market Research] --&gt; B[Product Planning]\n" +
+    "    B --&gt; C[Development]\n" +
+    "    C --&gt; D[Testing]\n" +
+    "    D --&gt; E[Manufacturing]\n" +
+    "    E --&gt; F[Marketing]\n" +
+    "    F --&gt; G[Sales]\n" +
+    "    G --&gt; H[Customer Support]\n" +
+    "    H --&gt; A\n" +
     "    </div>\n" +
     "  </div>\n" +
     "</div>",

--- a/test/actions/test_image_preprocess_agent_plugin.ts
+++ b/test/actions/test_image_preprocess_agent_plugin.ts
@@ -264,8 +264,8 @@ const mermaidPluginExpected = {
     "    G --> H[Customer Support]\n" +
     "    H --> A\n" +
     "```",
-  // The diagram source is escaped for its HTML text context. Mermaid reads textContent,
-  // which the parser produces by decoding entities, so the rendered SVG is unchanged.
+  // The diagram source is escaped for its HTML text context. Mermaid entity-decodes the
+  // element's innerHTML before parsing, so the rendered SVG is unchanged.
   html:
     "\n" +
     '<div class="mermaid-container mb-6">\n' +

--- a/test/beat_html/test_browser_safety.ts
+++ b/test/beat_html/test_browser_safety.ts
@@ -70,7 +70,11 @@ const BROWSER_ONLY: ts.CompilerOptions = {
  * this decides whether it BELONGS here. Adding one is a deliberate act, not a side effect
  * of an import — the smaller this graph stays, the less there is to go wrong in a bundle.
  */
-const ALLOWED_PACKAGES = new Set(["marked"]);
+// @mulmocast/deck is here for escapeHtml, imported deeply rather than through the package
+// barrel: the barrel pulls every layout and all of zod (551kb measured), the deep path pulls
+// one file. It contributes exactly `lib/utils.js` to this bundle, and the browser fragment
+// path depends on deck anyway.
+const ALLOWED_PACKAGES = new Set(["marked", "@mulmocast/deck"]);
 
 const bundle = (options: esbuild.BuildOptions) =>
   esbuild.build({

--- a/test/beat_html/test_markdown.ts
+++ b/test/beat_html/test_markdown.ts
@@ -28,13 +28,13 @@ test("a mermaid fence turns into mermaid markup and requires the runtime", () =>
   const { html, requires } = markdownToHtml(media("# T\n\n```mermaid\ngraph TD; A-->B\n```"), "p");
   assert.deepStrictEqual(requires, ["mermaid"], "the host has to be told to load mermaid");
   assert.match(html, /class="mermaid"/);
-  // Unescaped, because mermaid reads the element's textContent and `-->` in a text node
+  // Mermaid entity-decodes the element's innerHTML, so `--&gt;` reaches it as `-->`; the
   // is ordinary HTML. `image_plugins/mermaid.ts` interpolates the code the same way, so
   // the two paths render a diagram identically — which is the point of sharing
   // mermaid_html.ts, shared by both paths. It also means a diagram containing `</div>` would break out of the
   // element, which is the unsanitized contract on BeatHtmlFragment.html, not a new hole.
-  // Escaped for its HTML text context. Mermaid reads textContent, which the parser produces by
-  // decoding entities, so the diagram it draws is unchanged — measured byte-identical SVG.
+  // Escaped for its HTML text context. Mermaid entity-decodes the element's innerHTML before
+  // parsing, so the diagram it draws is unchanged — measured byte-identical SVG.
   assert.match(html, /graph TD; A--&gt;B/, "the diagram source survives into the element");
   assert.ok(!html.includes("<code"), "the fence must not render as a code block");
 });

--- a/test/beat_html/test_markdown.ts
+++ b/test/beat_html/test_markdown.ts
@@ -28,13 +28,10 @@ test("a mermaid fence turns into mermaid markup and requires the runtime", () =>
   const { html, requires } = markdownToHtml(media("# T\n\n```mermaid\ngraph TD; A-->B\n```"), "p");
   assert.deepStrictEqual(requires, ["mermaid"], "the host has to be told to load mermaid");
   assert.match(html, /class="mermaid"/);
-  // Mermaid entity-decodes the element's innerHTML, so `--&gt;` reaches it as `-->`; the
-  // is ordinary HTML. `image_plugins/mermaid.ts` interpolates the code the same way, so
-  // the two paths render a diagram identically — which is the point of sharing
-  // mermaid_html.ts, shared by both paths. It also means a diagram containing `</div>` would break out of the
-  // element, which is the unsanitized contract on BeatHtmlFragment.html, not a new hole.
-  // Escaped for its HTML text context. Mermaid entity-decodes the element's innerHTML before
-  // parsing, so the diagram it draws is unchanged — measured byte-identical SVG.
+  // The source is escaped for its HTML text context by mermaid_html.ts, which both this path
+  // and image_plugins/mermaid.ts share. Mermaid entity-decodes the element's innerHTML before
+  // parsing, so `--&gt;` reaches it as `-->` and the diagram it draws is unchanged — measured
+  // byte-identical SVG across ten diagram shapes.
   assert.match(html, /graph TD; A--&gt;B/, "the diagram source survives into the element");
   assert.ok(!html.includes("<code"), "the fence must not render as a code block");
 });

--- a/test/beat_html/test_markdown.ts
+++ b/test/beat_html/test_markdown.ts
@@ -33,7 +33,9 @@ test("a mermaid fence turns into mermaid markup and requires the runtime", () =>
   // the two paths render a diagram identically — which is the point of sharing
   // mermaid_html.ts, shared by both paths. It also means a diagram containing `</div>` would break out of the
   // element, which is the unsanitized contract on BeatHtmlFragment.html, not a new hole.
-  assert.match(html, /graph TD; A-->B/, "the diagram source survives into the element");
+  // Escaped for its HTML text context. Mermaid reads textContent, which the parser produces by
+  // decoding entities, so the diagram it draws is unchanged — measured byte-identical SVG.
+  assert.match(html, /graph TD; A--&gt;B/, "the diagram source survives into the element");
   assert.ok(!html.includes("<code"), "the fence must not render as a code block");
 });
 

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -286,3 +286,13 @@ test("the render template's user values are escaped for their own contexts", () 
   assert.ok(!values.diagram_code.includes("<"), "the diagram value must not carry a tag");
   assert.strictEqual(values.title, "&lt;/H1 &gt;&lt;img src=x onerror=&quot;pwn()&quot;&gt;");
 });
+
+// The id is caller-supplied on the markdown path (built from an idPrefix), and a beat's `id`
+// comes from the script, so it cannot be trusted to be attribute-safe.
+test("a hostile element id cannot escape its attribute", () => {
+  const html = mermaidHtml("graph TD; A-->B;", '" onload="pwn()" x=');
+  // The word survives; what must not is a quote that ends the attribute early, which is what
+  // would turn the rest into markup the browser acts on.
+  assert.strictEqual(html.split('<div id="')[1].split('"')[0], "&quot; onload=&quot;pwn()&quot; x=", "the id value must stay one attribute");
+  assert.ok(!/<div id="[^"]*"[^>]*onload=/.test(html), "no event handler may be introduced");
+});

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -255,9 +255,10 @@ test("mermaid plugin with empty code", () => {
 });
 
 // Both mermaid paths drop the title into an HTML text context and the diagram source into a
-// `.mermaid` element. Mermaid reads that element's textContent, which the parser produces by
-// decoding entities, so escaping is transparent to it — measured in a browser across five
-// diagram kinds, the rendered SVG is byte-identical with and without the escape.
+// `.mermaid` element. Mermaid entity-decodes that element's innerHTML before parsing, so
+// escaping is transparent to it — measured in a browser across ten diagram shapes, including
+// the ones that mechanism makes non-obvious (`<br/>` in a label, mermaid's own `#quot;`, a
+// raw `<b>` tag, an init directive), the rendered SVG is byte-identical either way.
 const countTags = (html: string, tag: string): number => html.toLowerCase().split(tag).length - 1;
 
 test("a hostile title and hostile diagram source cannot escape their contexts", () => {

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert";
 import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
+import { escapedMermaidTemplateValues, mermaidHtml } from "../../src/utils/image_plugins/mermaid_html.js";
 
 test("mermaid plugin basic functionality", () => {
   const plugin = findImagePlugin("mermaid");
@@ -251,4 +252,36 @@ test("mermaid plugin with empty code", () => {
 
   const markdown = plugin.markdown(mockParams);
   assert.strictEqual(markdown, "```mermaid\n\n```");
+});
+
+// Both mermaid paths drop the title into an HTML text context and the diagram source into a
+// `.mermaid` element. Mermaid reads that element's textContent, which the parser produces by
+// decoding entities, so escaping is transparent to it — measured in a browser across five
+// diagram kinds, the rendered SVG is byte-identical with and without the escape.
+const countTags = (html: string, tag: string): number => html.toLowerCase().split(tag).length - 1;
+
+test("a hostile title and hostile diagram source cannot escape their contexts", () => {
+  const html = mermaidHtml('graph TD; A-->B;</DIV ><img src=x onerror="pwn()">', "d1", '</H3 ><img src=x onerror="pwn()">');
+  assert.strictEqual(countTags(html, "<img"), 0, "no injected element may survive");
+  assert.strictEqual(countTags(html, "<h3"), 1, "the heading must not be closed early");
+  assert.strictEqual(countTags(html, "<div"), 3, "only the three containers may appear");
+  assert.strictEqual(countTags(html, "</div"), 3, "the containers must not be closed early");
+});
+
+test("the diagram source keeps its characters, escaped for the text context", () => {
+  const html = mermaidHtml('graph TD; A-->B["R&D"];', "d1");
+  assert.match(html, /graph TD; A--&gt;B\[&quot;R&amp;D&quot;\];/, "arrows, quotes and ampersands are entities, not raw");
+  assert.ok(!html.includes("A-->B"), "the raw form must not also be present");
+});
+
+test("a title is optional and an empty one emits no heading", () => {
+  assert.ok(!mermaidHtml("graph TD; A-->B;", "d1").includes("<h3"), "no title, no heading");
+  assert.ok(!mermaidHtml("graph TD; A-->B;", "d1", "").includes("<h3"), "an empty title emits no heading either");
+});
+
+test("the render template's user values are escaped for their own contexts", () => {
+  const values = escapedMermaidTemplateValues('</H1 ><img src=x onerror="pwn()">', 'graph TD; A-->B;</DIV ><img src=x onerror="pwn()">');
+  assert.ok(!values.title.includes("<"), "the heading value must not carry a tag");
+  assert.ok(!values.diagram_code.includes("<"), "the diagram value must not carry a tag");
+  assert.strictEqual(values.title, "&lt;/H1 &gt;&lt;img src=x onerror=&quot;pwn()&quot;&gt;");
 });


### PR DESCRIPTION
## Summary

mermaid beat の `title` と図のソースが、**HTML dump 経路と PNG/PDF/動画経路の両方**で無エスケープでした。どちらの文脈も mulmoscript から閉じられます。

`#1535` の第3弾です（#1536 chart、#1538 style に続く）。

| 経路 | 差し込み口 | 文脈 |
| --- | --- | --- |
| dump (`mermaidHtml`) | `${title}` / `${code}` | `<h3>` の text / `.mermaid` div の text |
| render (`processMermaid`) | `${title}` / `${diagram_code}` | `<h1>` / `.mermaid` div |

`${id}` も**エスケープします**（round 3 で Codex が指摘）。dump 経路の呼び出し元は `generateUniqueId` を渡しますが、markdown 経路は caller 指定の `idPrefix` から組み立てており、`beat_html/index.ts` は「caller だけが一意な id を決められる」と書いています。`mulmoBeatSchema.id`（"Unique identifier for the beat"）はスクリプト由来で無制約なので到達します。mermaid の id は属性1文脈なのでエスケープで足ります。

**chart 側は id が属性と JS 文字列リテラルの2文脈に出るためエスケープでは解けず、#1540 に分離しました**（`<script>` 内では実体参照が復号されないので `getElementById` が一致しなくなる）。

`${style}` は #1538 で対応済みなので触っていません。

## Items to Confirm / Review

### 1. エスケープしても mermaid の描画は変わりません（推論ではなく実測）

これが本PRの要点です。mermaid は要素の **innerHTML** を読み、パース前に entity decode します
(mermaid 11.17.0: `o = u.innerHTML; o = ck(or.entityDecode(o))`)。したがって受け取る文字列は変わりません。

> **訂正**: 当初「textContent を読む」と書いていましたが誤りで、Codex round 1 の指摘を受けて実際の runtime を読んで確認しました。結論は変わりませんが、**仕組みが違うと危険になる形が変わる**ので測定を5形→10形に広げています。

エスケープ有無の**レンダリング済み SVG をバイト単位で比較**（10形すべて 🟢 同一）:

| 図 | SVG |
|---|---|
| 単純 (`graph TD; A-->B;`) | 🟢 同一 (10837 bytes) |
| ラベルに `&` と引用符 | 🟢 同一 (10844 bytes) |
| ラベルに山括弧 | 🟢 同一 (10841 bytes) |
| 日本語 | 🟢 同一 (10725 bytes) |
| sequenceDiagram | 🟢 同一 (22336 bytes) |
| **ラベル内の `<br/>`** | 🟢 同一 |
| **mermaid 自身の `#quot;`** | 🟢 同一 |
| **ラベル内の `&amp;`** | 🟢 同一 |
| **ラベル内の生タグ `<b>`** | 🟢 同一 |
| **`%%{init}%%` ディレクティブ** | 🟢 同一 |

下5つが「innerHTML + entityDecode という仕組み」が非自明にする形で、round 1 で追加したものです。

実装そのものを通した before/after も確認済み（両経路とも攻撃 🔴→🟢、正常な図は SVG が描かれる）。

### 2. browser-safety の allow-list に `@mulmocast/deck` を追加しました

`mermaid_html.ts` は `beat_html` の依存グラフ内なので、`escapeHtml` の import で**私が以前作ったブラウザ安全性ゲートが発火しました**（設計どおりの動作です）。

追加は意図的な判断として行い、コストを測っています: deck が持ち込むのは **`lib/utils.js` の1ファイルだけ**（beat_html 全体で 7 入力 / 58.3 KB、大半は marked）。barrel 経由だと 551 KB になるため deep import です。理由は allow-list のコメントに残しました。

**ここは判断が分かれるところなので見てください。** 代案は `escapeHtml` を自前で持つこと（3つ目の実装になる。#1536 で一度削除した）です。

### 3. golden fixture を更新しています

`test_image_preprocess_agent_plugin.ts` の `mermaidPluginExpected` の **`html` フィールドのみ** 8箇所を `--&gt;` に更新しました。`markdown` フィールド（8箇所）は markdown dump 経路で無関係なので据え置きです。件数を assert して確認しています。

### 4. 影響

図のソースに `& < > " '` を含む場合、生成 HTML のバイトは変わります（`A-->B` → `A--&gt;B`）。上記のとおり**描画は同一**です。

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit`: clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1106 tests, 0 fail**
- 新テストは `NODE_ENV=test` あり／なし両方で緑
- **変異4種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | dump: title のエスケープ除去 | fail=1 |
  | dump: code のエスケープ除去 | fail=4 |
  | render: title のエスケープ除去 | fail=1 |
  | render: code のエスケープ除去 | fail=1 |

## User Prompt

> とりこんですすむ

（#1526 のブラウザ経路に進む前に #1535 のエスケープを片付ける。#1536 / #1538 に続く3本目）

Refs #1535



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Mermaid diagram rendering by safely escaping titles, element IDs, and diagram content.
  * Prevented special characters and potentially unsafe markup from being interpreted during rendering.
  * Preserved Mermaid diagram structure and output while supporting escaped content.

* **Tests**
  * Added coverage for special characters in titles, diagram sources, template values, and IDs.
  * Updated rendering expectations to reflect safe HTML escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->