### PR TITLE
fix: validate element ids against a permitted set instead of escaping them

### DIFF
--- a/plans/fix-element-id-contract.md
+++ b/plans/fix-element-id-contract.md
@@ -17,8 +17,14 @@ JS 側と食い違い `getElementById` が一致しなくなる。文脈ごと�
 
 ## 採った形: 許されるものを列挙する
 
-`[A-Za-z0-9_-]+` に限れば、HTML 属性・JS 文字列リテラル・CSS セレクタ・URL 断片の
+`[A-Za-z_][A-Za-z0-9_-]*` に限れば、HTML 属性・JS 文字列リテラル・CSS セレクタ・URL 断片の
 **どの文脈でも安全**になる。新しい文脈が増えても壊れない。fail closed。
+
+先頭文字を縛るのは CSS の id セレクタが一番厳しいため。**実測**: `querySelector("#0")` / `"#-"` /
+`"#0a"` / `"#-0"` はいずれも throw する一方、`getElementById` はすべて通す。つまり今日動く id が
+セレクタで触った瞬間に使えなくなり得る。当初 `[A-Za-z0-9_-]+` にしていたのは Codex のレビューで
+過大主張と指摘され、ブラウザで測って狭めた。CSS が許す `-a` も弾いており（一文で言える形との交換）、
+文字集合から生成した 152 通りで **受理側にセレクタ失敗ゼロ**、棄却側に実は安全な 8 件、を確認済み。
 
 - `src/utils/element_id.ts`（新規, pure）: `isSafeElementId` / `assertSafeElementId`
 - 強制点は3つ: `chartHtml` / `mermaidHtml` / `beatToHtml`（境界）

--- a/plans/fix-element-id-contract.md
+++ b/plans/fix-element-id-contract.md
@@ -1,0 +1,41 @@
+# fix: element id は「許可集合の検証」で守る
+
+issue: #1540。#1535 のエスケープ作業から派生。
+
+## なぜエスケープでは解けないか
+
+`chart_html.ts` の id は2つの文脈に出る:
+
+```html
+<canvas id="${chartId}"></canvas>                  ← HTML 属性
+  const ctx = document.getElementById('${chartId}')  ← <script> 内の JS 文字列リテラル
+```
+
+`<script>` の中では HTML 実体参照は復号されない。属性側だけ `escapeHtml` を掛けると
+JS 側と食い違い `getElementById` が一致しなくなる。文脈ごとに別のエスケープを当てる手もあるが、
+その場合は文脈が増えるたびに規則が増え、同期が崩れた箇所が穴になる。
+
+## 採った形: 許されるものを列挙する
+
+`[A-Za-z0-9_-]+` に限れば、HTML 属性・JS 文字列リテラル・CSS セレクタ・URL 断片の
+**どの文脈でも安全**になる。新しい文脈が増えても壊れない。fail closed。
+
+- `src/utils/element_id.ts`（新規, pure）: `isSafeElementId` / `assertSafeElementId`
+- 強制点は3つ: `chartHtml` / `mermaidHtml` / `beatToHtml`（境界）
+
+## 到達性
+
+`beat_html/index.ts` の契約は「beat の id か index を渡せ」と書いており、
+`mulmoBeatSchema.id`（"Unique identifier for the beat"）はスクリプト由来かつ無制約。
+host が beat.id をそのまま渡すと属性を抜け出せる。
+
+## 正規化ではなく throw にした理由
+
+不正文字を置換すると、異なる2つの beat id が同じ安全な id に潰れ得る。
+重複 element id はまさに `idPrefix` が防ごうとしているバグなので、黙って直すより落とす。
+契約に「index を渡すか、自分で sanitize しろ」と明記した。
+
+## #1539 との関係
+
+#1539 では mermaid の id を `escapeHtml` した。検証はそれより強い（JS 文字列文脈も覆う）ため、
+そちらのエスケープは外して規則を1つにした。

--- a/plans/fix-element-id-contract.md
+++ b/plans/fix-element-id-contract.md
@@ -27,7 +27,10 @@ JS 側と食い違い `getElementById` が一致しなくなる。文脈ごと�
 文字集合から生成した 152 通りで **受理側にセレクタ失敗ゼロ**、棄却側に実は安全な 8 件、を確認済み。
 
 - `src/utils/element_id.ts`（新規, pure）: `isSafeElementId` / `assertSafeElementId`
-- 強制点は3つ: `chartHtml` / `mermaidHtml` / `beatToHtml`（境界）
+- 強制点は4つ: `chartHtml` / `mermaidHtml` / `beatToHtml`（境界） / `swipe_to_html`
+  （4つ目はレビューで見つかった。属性はエスケープ済み・生成JS内の CSS セレクタは生、という
+  まさに「エスケープでは解けない」形だった）
+- 公開スキーマ `swipeElementSchema.id` にも同じ規則を入れ、描画時ではなく parse 時に落とす
 
 ## 到達性
 

--- a/plans/fix-element-id-contract.md
+++ b/plans/fix-element-id-contract.md
@@ -31,7 +31,7 @@ JS 側と食い違い `getElementById` が一致しなくなる。文脈ごと�
 
 ## 到達性
 
-`beat_html/index.ts` の契約は「beat の id か index を渡せ」と書いており、
+`beat_html/index.ts` の契約は当初「beat の id か index を渡せ」と書いており、
 `mulmoBeatSchema.id`（"Unique identifier for the beat"）はスクリプト由来かつ無制約。
 host が beat.id をそのまま渡すと属性を抜け出せる。
 
@@ -39,7 +39,7 @@ host が beat.id をそのまま渡すと属性を抜け出せる。
 
 不正文字を置換すると、異なる2つの beat id が同じ安全な id に潰れ得る。
 重複 element id はまさに `idPrefix` が防ごうとしているバグなので、黙って直すより落とす。
-契約に「index を渡すか、自分で sanitize しろ」と明記した。
+契約には「index から derive せよ（`beat-3`。`3` は数字始まりなので不可）、または自分で sanitize せよ」と明記した。
 
 ## #1539 との関係
 

--- a/src/types/const.ts
+++ b/src/types/const.ts
@@ -18,3 +18,11 @@ export const bundleTargetLang = ["ja", "en"];
 
 export const ASPECT_RATIOS = ["1:1", "9:16", "16:9"];
 export const PRO_ASPECT_RATIOS = ["1:1", "2:3", "3:2", "3:4", "4:3", "4:5", "5:4", "9:16", "16:9", "21:9"];
+
+/**
+ * Element ids that generated markup interpolates. Restricting the set — rather than escaping
+ * per context — is what makes one id safe in an HTML attribute, a JavaScript string literal
+ * inside a `<script>`, and a CSS selector at once. Lives here because `schema.ts` compiles
+ * standalone in the types package and can only reach files under `src/types/`.
+ */
+export const SAFE_ELEMENT_ID = /^[A-Za-z_][A-Za-z0-9_-]*$/;

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { htmlLLMProvider, provider2TTSAgent, provider2ImageAgent, provider2MovieAgent, defaultProviders, provider2SoundEffectAgent } from "./provider2agent.js";
 import { currentMulmoScriptVersion } from "./const.js";
+import { SAFE_ELEMENT_ID } from "../utils/element_id.js";
 import { mulmoVideoFilterSchema } from "./schema_video_filter.js";
 import { mulmoSlideMediaSchema, slideThemeSchema, slideBrandingSchema } from "@mulmocast/deck";
 
@@ -292,7 +293,11 @@ const swipeShadowSchema = z
 export const swipeElementSchema: z.ZodType = z.lazy(() =>
   z
     .object({
-      id: z.string().optional(),
+      id: z
+        .string()
+        .regex(SAFE_ELEMENT_ID, "must start with a letter or underscore, then letters, digits, hyphens or underscores")
+        .optional()
+        .describe("Element id. Used as an HTML id and as a CSS selector in the generated animation script, so it must match [A-Za-z_][A-Za-z0-9_-]*."),
       // Position & size
       x: swipePositionValue.optional(),
       y: swipePositionValue.optional(),

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { htmlLLMProvider, provider2TTSAgent, provider2ImageAgent, provider2MovieAgent, defaultProviders, provider2SoundEffectAgent } from "./provider2agent.js";
-import { currentMulmoScriptVersion } from "./const.js";
-import { SAFE_ELEMENT_ID } from "../utils/element_id.js";
+import { currentMulmoScriptVersion, SAFE_ELEMENT_ID } from "./const.js";
 import { mulmoVideoFilterSchema } from "./schema_video_filter.js";
 import { mulmoSlideMediaSchema, slideThemeSchema, slideBrandingSchema } from "@mulmocast/deck";
 

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -22,7 +22,7 @@ export const supportedBeatTypes = ["textSlide", "markdown"] as const;
  * **The markup is not sanitized** — see `BeatHtmlFragment.html`. Sanitize before inserting
  * it into a DOM.
  *
- * `options.idPrefix` is required and must match `[A-Za-z0-9_-]+`: fragments can generate
+ * `options.idPrefix` is required and must match `[A-Za-z_][A-Za-z0-9_-]*`: fragments generate
  * element ids, only the caller knows which beat this is, and a beat's own `id` comes from
  * the script and is unrestricted. Throws on anything else rather than guessing a repair,
  * because a guess can collapse two beats onto one id. See `BeatHtmlOptions`.

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -2,6 +2,7 @@ import type { MulmoBeat } from "../../types/index.js";
 import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
 import { textSlideToHtml } from "./text_slide.js";
 import { markdownToHtml } from "./markdown.js";
+import { assertSafeElementId } from "../element_id.js";
 
 export type { BeatHtmlFragment, BeatHtmlOptions, BeatRuntime } from "./type.js";
 export { textSlideToMarkdown, textSlideToHtml } from "./text_slide.js";
@@ -21,8 +22,10 @@ export const supportedBeatTypes = ["textSlide", "markdown"] as const;
  * **The markup is not sanitized** — see `BeatHtmlFragment.html`. Sanitize before inserting
  * it into a DOM.
  *
- * `options.idPrefix` is required: fragments can generate element ids, and only the caller
- * knows which beat this is. See `BeatHtmlOptions`.
+ * `options.idPrefix` is required and must match `[A-Za-z0-9_-]+`: fragments can generate
+ * element ids, only the caller knows which beat this is, and a beat's own `id` comes from
+ * the script and is unrestricted. Throws on anything else rather than guessing a repair,
+ * because a guess can collapse two beats onto one id. See `BeatHtmlOptions`.
  *
  * Returns `undefined` for a beat this module cannot render — a type not yet supported,
  * or one whose media it cannot reach from a browser (a local file path, say). Callers
@@ -36,6 +39,7 @@ export const supportedBeatTypes = ["textSlide", "markdown"] as const;
 export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlFragment | undefined => {
   const image = beat.image;
   if (!image) return undefined;
+  assertSafeElementId(options.idPrefix);
   switch (image.type) {
     case "textSlide":
       return textSlideToHtml(image);

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -37,7 +37,12 @@ export type BeatHtmlOptions = {
    * a library can pick that is unique per beat AND stable across re-renders — only the
    * caller knows which beat this is, so the caller says.
    *
-   * Pass the beat's id, or its index in the deck.
+   * Must match `[A-Za-z0-9_-]+`: the id ends up in an HTML attribute and, for some beat
+   * types, in a JavaScript string literal inside a `<script>` where HTML entities are not
+   * decoded. Restricting the set is what makes one id safe in both — see `element_id.ts`.
+   *
+   * A beat's `id` comes from the script and is not restricted, so pass its index in the
+   * deck, or sanitize the id yourself. `beatToHtml` throws rather than guessing.
    */
   idPrefix: string;
 };

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -37,12 +37,14 @@ export type BeatHtmlOptions = {
    * a library can pick that is unique per beat AND stable across re-renders — only the
    * caller knows which beat this is, so the caller says.
    *
-   * Must match `[A-Za-z0-9_-]+`: the id ends up in an HTML attribute and, for some beat
-   * types, in a JavaScript string literal inside a `<script>` where HTML entities are not
-   * decoded. Restricting the set is what makes one id safe in both — see `element_id.ts`.
+   * Must match `[A-Za-z_][A-Za-z0-9_-]*`: the id ends up in an HTML attribute and, for some
+   * beat types, in a JavaScript string literal inside a `<script>` where HTML entities are
+   * not decoded, and it has to stay usable from a CSS selector. Restricting the set is what
+   * makes one id safe in all of them — see `element_id.ts`.
    *
-   * A beat's `id` comes from the script and is not restricted, so pass its index in the
-   * deck, or sanitize the id yourself. `beatToHtml` throws rather than guessing.
+   * A beat's `id` comes from the script and is not restricted, so pass something derived
+   * from its index — `beat-3`, not `3`, since it must not start with a digit — or sanitize
+   * the id yourself. `beatToHtml` throws rather than guessing.
    */
   idPrefix: string;
 };

--- a/src/utils/element_id.ts
+++ b/src/utils/element_id.ts
@@ -1,0 +1,28 @@
+/**
+ * The rule for element ids that generated markup interpolates. Pure — no Node, no
+ * filesystem — because the Node render path and the browser fragment path build the same
+ * markup and must agree on it.
+ *
+ * This enumerates what is PERMITTED rather than escaping what is not. An id drawn from this
+ * set is safe in every context the markup uses it in — an HTML attribute, a JavaScript
+ * string literal inside a `<script>` where HTML entities are not decoded, a CSS selector, a
+ * URL fragment — so a new context cannot introduce a hole the way a per-context escaper can.
+ * Escaping would also have to keep the contexts in sync: entity-escaping `<canvas id>` while
+ * the `getElementById` beside it stays raw makes the two disagree and the lookup fail.
+ */
+const SAFE_ELEMENT_ID = /^[A-Za-z0-9_-]+$/;
+
+export const isSafeElementId = (id: string): boolean => SAFE_ELEMENT_ID.test(id);
+
+/**
+ * Throws unless the id is safe in every context. A caller reaching this with a bad id has a
+ * bug, not bad user input: values that come from a script have to be turned into an id
+ * before they get here.
+ */
+export const assertSafeElementId = (id: string): void => {
+  if (!isSafeElementId(id)) {
+    throw new Error(
+      `element id must match ${SAFE_ELEMENT_ID.source}, got ${JSON.stringify(id)}. Derive it from the beat's index, or sanitize the beat's id, before passing it.`,
+    );
+  }
+};

--- a/src/utils/element_id.ts
+++ b/src/utils/element_id.ts
@@ -1,3 +1,5 @@
+import { SAFE_ELEMENT_ID } from "../types/const.js";
+
 /**
  * The rule for element ids that generated markup interpolates. Pure — no Node, no
  * filesystem — because the Node render path and the browser fragment path build the same
@@ -17,7 +19,6 @@
  * narrower than CSS allows (it rejects `-a`, which is valid) in exchange for being stateable
  * in one line.
  */
-export const SAFE_ELEMENT_ID = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 
 export const isSafeElementId = (id: string): boolean => SAFE_ELEMENT_ID.test(id);
 

--- a/src/utils/element_id.ts
+++ b/src/utils/element_id.ts
@@ -9,8 +9,15 @@
  * URL fragment — so a new context cannot introduce a hole the way a per-context escaper can.
  * Escaping would also have to keep the contexts in sync: entity-escaping `<canvas id>` while
  * the `getElementById` beside it stays raw makes the two disagree and the lookup fail.
+ *
+ * The leading character is restricted because a CSS id selector is the strictest of those
+ * contexts. Measured in a browser: `querySelector("#0")`, `"#-"`, `"#0a"` and `"#-0"` all
+ * throw, while `getElementById` accepts every one of them — so an id that works today can
+ * still be unusable the moment anything reaches for it with a selector. This set is a little
+ * narrower than CSS allows (it rejects `-a`, which is valid) in exchange for being stateable
+ * in one line.
  */
-const SAFE_ELEMENT_ID = /^[A-Za-z0-9_-]+$/;
+const SAFE_ELEMENT_ID = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 
 export const isSafeElementId = (id: string): boolean => SAFE_ELEMENT_ID.test(id);
 
@@ -22,7 +29,7 @@ export const isSafeElementId = (id: string): boolean => SAFE_ELEMENT_ID.test(id)
 export const assertSafeElementId = (id: string): void => {
   if (!isSafeElementId(id)) {
     throw new Error(
-      `element id must match ${SAFE_ELEMENT_ID.source}, got ${JSON.stringify(id)}. Derive it from the beat's index, or sanitize the beat's id, before passing it.`,
+      `element id must match ${SAFE_ELEMENT_ID.source}, got ${JSON.stringify(id)}. Derive it from the beat's index (beat-3, not 3 — it must not start with a digit), or sanitize the beat's id, before passing it.`,
     );
   }
 };

--- a/src/utils/element_id.ts
+++ b/src/utils/element_id.ts
@@ -17,7 +17,7 @@
  * narrower than CSS allows (it rejects `-a`, which is valid) in exchange for being stateable
  * in one line.
  */
-const SAFE_ELEMENT_ID = /^[A-Za-z_][A-Za-z0-9_-]*$/;
+export const SAFE_ELEMENT_ID = /^[A-Za-z_][A-Za-z0-9_-]*$/;
 
 export const isSafeElementId = (id: string): boolean => SAFE_ELEMENT_ID.test(id);
 

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -3,6 +3,7 @@ import type { MulmoChartMedia } from "../../types/index.js";
 // 551kb against 1.5kb for this file, and the browser fragment path bundles this module.
 import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
 import { escapeJsonForScript } from "../html_escape.js";
+import { assertSafeElementId } from "../element_id.js";
 
 /**
  * Chart.js markup and plugin resolution. Pure — no Node, no filesystem — because both the
@@ -31,6 +32,7 @@ export const resolveChartPlugins = (chartType: string): string => {
 export const stringifyChartData = (chartData: MulmoChartMedia["chartData"]): string => JSON.stringify(chartData, null, 2);
 
 export const chartHtml = (chartDataJson: string, title: string, chartId: string): string => {
+  assertSafeElementId(chartId);
   const heading = escapeHtml(title || "Chart");
 
   return `

--- a/src/utils/image_plugins/mermaid_html.ts
+++ b/src/utils/image_plugins/mermaid_html.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
+import { assertSafeElementId } from "../element_id.js";
 
 /**
  * Mermaid markup. Pure — no Node, no filesystem — because both the Node render path and
@@ -7,8 +8,9 @@ import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
  * The element id is a parameter rather than generated here: the Node path renders once to
  * a PNG so a random id is fine, while the browser path re-renders and needs the same beat
  * to produce the same markup, or a host diffing fragments sees every diagram change
- * identity on every render. It is escaped because that parameter is caller-supplied — the
- * markdown path builds it from an idPrefix, and a beat's `id` comes from the script.
+ * identity on every render. That parameter is caller-supplied — the markdown path builds it
+ * from an idPrefix, and a beat's `id` comes from the script — so it is validated rather than
+ * escaped: see element_id.ts for why the permitted-set rule beats a per-context escaper.
  *
  * Both values are escaped. Mermaid reads the element's innerHTML and entity-decodes it
  * before parsing (mermaid 11.17.0: `o = u.innerHTML; o = entityDecode(o)`), so it receives
@@ -16,12 +18,13 @@ import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
  * in labels, `#quot;`, raw tags and an init directive, the rendered SVG is byte-identical.
  */
 export const mermaidHtml = (code: string, id: string, title?: string): string => {
+  assertSafeElementId(id);
   const titleHtml = title ? `<h3 class="text-xl font-semibold mb-4">${escapeHtml(title)}</h3>` : "";
   return `
 <div class="mermaid-container mb-6">
   ${titleHtml}
   <div class="flex justify-center">
-    <div id="${escapeHtml(id)}" class="mermaid">
+    <div id="${id}" class="mermaid">
       ${escapeHtml(code.trim())}
     </div>
   </div>

--- a/src/utils/swipe_to_html.ts
+++ b/src/utils/swipe_to_html.ts
@@ -1,3 +1,5 @@
+import { assertSafeElementId } from "./element_id.js";
+
 export interface SwipeTransition {
   opacity?: number;
   rotate?: number;
@@ -55,6 +57,22 @@ export interface SwipeElement {
 
 const escapeHtml = (str: string): string => {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+};
+
+/**
+ * The element id both the markup and the generated animation script use. It reaches an HTML
+ * attribute AND a raw CSS selector inside a JavaScript string literal
+ * (`animation.animate('#id')`), so it is validated rather than escaped — escaping one
+ * context leaves the other wrong, and a quote in an id silently produces broken JavaScript
+ * instead of a diagnosable error.
+ *
+ * Not a privilege boundary: `html_tailwind` accepts an author's own `script` by design, so
+ * an author already has that capability. This is here so the two contexts agree.
+ */
+const elementId = (el: SwipeElement, index: number): string => {
+  const id = el.id ?? `swipe_el_${index}`;
+  assertSafeElementId(id);
+  return id;
 };
 
 const toCssValue = (value: number | string): string => {
@@ -115,7 +133,7 @@ const buildTextStyle = (el: SwipeElement): string => {
 };
 
 const elementToHtml = (el: SwipeElement, index: number): string => {
-  const id = el.id ?? `swipe_el_${index}`;
+  const id = elementId(el, index);
   const style = buildElementStyle(el);
   const textStyle = buildTextStyle(el);
   const lines: string[] = [];
@@ -157,7 +175,7 @@ interface AnimationEntry {
 
 const collectAnimations = (elements: SwipeElement[], entries: AnimationEntry[], indexBase: number = 0): void => {
   elements.forEach((el, i) => {
-    const id = el.id ?? `swipe_el_${indexBase + i}`;
+    const id = elementId(el, indexBase + i);
     if (el.to || el.loop) {
       entries.push({ id, to: el.to, loop: el.loop });
     }

--- a/test/beat_html/test_index.ts
+++ b/test/beat_html/test_index.ts
@@ -2,19 +2,20 @@ import test from "node:test";
 import assert from "node:assert";
 import { beatToHtml } from "../../src/utils/beat_html/index.js";
 
-// The contract tells callers to pass the beat's index or a sanitized id. A beat's own `id`
+// The contract tells callers to pass something derived from the beat's index — `beat-3`,
+// not `3`, since an id must not start with a digit — or a sanitized id. A beat's own `id`
 // comes from the script and is unrestricted, so the boundary refuses rather than guessing a
 // repair — a guess can collapse two beats onto one element id, which is the bug idPrefix exists to prevent.
 test("beatToHtml refuses an idPrefix outside the permitted set", () => {
   const beat = { image: { type: "markdown", markdown: "# T" } };
-  ['" onload="pwn()" x=', "beat 1", "第1章", ""].forEach((idPrefix) => {
+  ['" onload="pwn()" x=', "beat 1", "第1章", "", "0", "3"].forEach((idPrefix) => {
     assert.throws(() => beatToHtml(beat, { idPrefix }), /element id must match/, `${JSON.stringify(idPrefix)} must be rejected`);
   });
 });
 
 test("beatToHtml accepts the shapes the contract recommends", () => {
   const beat = { image: { type: "markdown", markdown: "# T" } };
-  ["0", "3", "beat-3", "beat_3"].forEach((idPrefix) => {
+  ["beat-0", "beat-3", "beat_3", "b3"].forEach((idPrefix) => {
     assert.ok(beatToHtml(beat, { idPrefix }), `${idPrefix} must be accepted`);
   });
 });

--- a/test/beat_html/test_index.ts
+++ b/test/beat_html/test_index.ts
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert";
+import { beatToHtml } from "../../src/utils/beat_html/index.js";
+
+// The contract tells callers to pass the beat's index or a sanitized id. A beat's own `id`
+// comes from the script and is unrestricted, so the boundary refuses rather than guessing a
+// repair — a guess can collapse two beats onto one element id, which is the bug idPrefix exists to prevent.
+test("beatToHtml refuses an idPrefix outside the permitted set", () => {
+  const beat = { image: { type: "markdown", markdown: "# T" } };
+  ['" onload="pwn()" x=', "beat 1", "第1章", ""].forEach((idPrefix) => {
+    assert.throws(() => beatToHtml(beat, { idPrefix }), /element id must match/, `${JSON.stringify(idPrefix)} must be rejected`);
+  });
+});
+
+test("beatToHtml accepts the shapes the contract recommends", () => {
+  const beat = { image: { type: "markdown", markdown: "# T" } };
+  ["0", "3", "beat-3", "beat_3"].forEach((idPrefix) => {
+    assert.ok(beatToHtml(beat, { idPrefix }), `${idPrefix} must be accepted`);
+  });
+});

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -175,3 +175,18 @@ test("the render template's user values are escaped for their own contexts", () 
   assert.ok(!values.chart_data.includes("<"), "the script value must not carry a raw angle bracket");
   assert.deepStrictEqual(JSON.parse(values.chart_data), { label: "</script><script>pwn()</script>" }, "the value itself is unchanged");
 });
+
+// The id lands in an attribute AND in a JavaScript string literal inside the <script>, where
+// HTML entities are not decoded — so it is validated against a permitted set rather than
+// escaped for one context and left wrong in the other.
+test("an element id outside the permitted set is rejected", () => {
+  ['" onload="pwn()" x=', "a'b", "a b", "第1章", ""].forEach((id) => {
+    assert.throws(() => chartHtml("{}", "t", id), /element id must match/, `${JSON.stringify(id)} must be rejected`);
+  });
+});
+
+test("the ids the plugin actually generates are accepted", () => {
+  ["id", "chart-abc12345", "beat_3-chart-0"].forEach((id) => {
+    assert.match(chartHtml("{}", "t", id), new RegExp(`<canvas id="${id}">`), `${id} must pass`);
+  });
+});

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -289,10 +289,17 @@ test("the render template's user values are escaped for their own contexts", () 
 
 // The id is caller-supplied on the markdown path (built from an idPrefix), and a beat's `id`
 // comes from the script, so it cannot be trusted to be attribute-safe.
-test("a hostile element id cannot escape its attribute", () => {
-  const html = mermaidHtml("graph TD; A-->B;", '" onload="pwn()" x=');
-  // The word survives; what must not is a quote that ends the attribute early, which is what
-  // would turn the rest into markup the browser acts on.
-  assert.strictEqual(html.split('<div id="')[1].split('"')[0], "&quot; onload=&quot;pwn()&quot; x=", "the id value must stay one attribute");
-  assert.ok(!/<div id="[^"]*"[^>]*onload=/.test(html), "no event handler may be introduced");
+// The id is caller-supplied on the markdown path and a beat's `id` comes from the script, so
+// it is validated against the permitted set rather than escaped — that rule holds in every
+// context, which a per-context escaper does not.
+test("an element id outside the permitted set is rejected, not escaped", () => {
+  ['" onload="pwn()" x=', "a b", "第1章", "a.b", "a:b", "", "a/b"].forEach((id) => {
+    assert.throws(() => mermaidHtml("graph TD; A-->B;", id), /element id must match/, `${JSON.stringify(id)} must be rejected`);
+  });
+});
+
+test("ordinary element ids are accepted unchanged", () => {
+  ["id", "chart-abc12345", "beat_3-mermaid-0", "A1"].forEach((id) => {
+    assert.match(mermaidHtml("graph TD; A-->B;", id), new RegExp(`<div id="${id}" class="mermaid">`), `${id} must pass`);
+  });
 });

--- a/test/utils/test_element_id.ts
+++ b/test/utils/test_element_id.ts
@@ -2,9 +2,20 @@ import test from "node:test";
 import assert from "node:assert";
 import { assertSafeElementId, isSafeElementId } from "../../src/utils/element_id.js";
 
-test("the permitted set is letters, digits, hyphen and underscore", () => {
-  ["id", "a", "A1", "chart-abc12345", "beat_3-mermaid-0", "_", "-", "0"].forEach((id) => {
+test("the permitted set starts with a letter or underscore", () => {
+  ["id", "a", "A1", "chart-abc12345", "beat_3-mermaid-0", "_", "_0", "a-", "beat-0"].forEach((id) => {
     assert.strictEqual(isSafeElementId(id), true, `${JSON.stringify(id)} must be permitted`);
+  });
+});
+
+// Measured in a browser, not read off a spec: querySelector("#0"), "#-", "#0a" and "#-0" all
+// throw, while getElementById accepts every one of them. An id can therefore work today and
+// become unusable the moment anything reaches for it with a selector, so the leading
+// character is restricted. `-a` is valid CSS and rejected anyway — the set is deliberately a
+// little narrower than CSS in exchange for being stateable in one line.
+test("a leading digit or hyphen is rejected, because a CSS id selector cannot take it", () => {
+  ["0", "-", "0a", "-0", "-a", "--a", "9beat"].forEach((id) => {
+    assert.strictEqual(isSafeElementId(id), false, `${JSON.stringify(id)} must be rejected`);
   });
 });
 
@@ -31,5 +42,5 @@ test("everything else is rejected, including characters that only break one cont
 });
 
 test("the error says what to do instead", () => {
-  assert.throws(() => assertSafeElementId("a b"), /Derive it from the beat's index, or sanitize the beat's id/);
+  assert.throws(() => assertSafeElementId("a b"), /Derive it from the beat's index/);
 });

--- a/test/utils/test_element_id.ts
+++ b/test/utils/test_element_id.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert";
+import { assertSafeElementId, isSafeElementId } from "../../src/utils/element_id.js";
+
+test("the permitted set is letters, digits, hyphen and underscore", () => {
+  ["id", "a", "A1", "chart-abc12345", "beat_3-mermaid-0", "_", "-", "0"].forEach((id) => {
+    assert.strictEqual(isSafeElementId(id), true, `${JSON.stringify(id)} must be permitted`);
+  });
+});
+
+// The near-miss half. Every one of these is safe in SOME context and not in others, which is
+// the reason the rule is a permitted set rather than a list of characters to escape.
+test("everything else is rejected, including characters that only break one context", () => {
+  [
+    "", // an empty id silently matches nothing
+    '" onload="pwn()" x=', // breaks the HTML attribute
+    "a'b", // breaks a JavaScript string literal, not the attribute
+    "a b",
+    "a.b", // a CSS class selector, not an id, if used in one
+    "a:b",
+    "a/b",
+    "a\\b",
+    "第1章",
+    "a\nb",
+    "<b>",
+    "a&b",
+  ].forEach((id) => {
+    assert.strictEqual(isSafeElementId(id), false, `${JSON.stringify(id)} must be rejected`);
+    assert.throws(() => assertSafeElementId(id), /element id must match/, `${JSON.stringify(id)} must throw`);
+  });
+});
+
+test("the error says what to do instead", () => {
+  assert.throws(() => assertSafeElementId("a b"), /Derive it from the beat's index, or sanitize the beat's id/);
+});

--- a/test/utils/test_swipe_to_html.ts
+++ b/test/utils/test_swipe_to_html.ts
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert";
+import { swipeElementsToHtml, swipeElementsToScript, type SwipeElement } from "../../src/utils/swipe_to_html.js";
+
+/**
+ * A swipe element's id reaches an HTML attribute AND a raw CSS selector inside a JavaScript
+ * string literal in the generated script, so it goes through the same permitted-set rule as
+ * every other element id. Escaping the attribute alone would leave the selector wrong.
+ *
+ * This is not a privilege boundary — `html_tailwind` accepts an author's own `script` by
+ * design — but a quote in an id otherwise produces broken JavaScript with no diagnostic.
+ */
+
+const withId = (id: string): SwipeElement[] => [{ id, text: "x", to: { opacity: 1 } }];
+
+test("an element id outside the permitted set is rejected by both generators", () => {
+  ["a'b", '"x"', "a b", "0", "-", "第1章"].forEach((id) => {
+    assert.throws(() => swipeElementsToHtml(withId(id)), /element id must match/, `html: ${JSON.stringify(id)}`);
+    assert.throws(() => swipeElementsToScript(withId(id)), /element id must match/, `script: ${JSON.stringify(id)}`);
+  });
+});
+
+test("the default id and ordinary ids are accepted, and reach both outputs", () => {
+  const html = swipeElementsToHtml(withId("panel_2"));
+  assert.match(html, /<div id="panel_2"/);
+  assert.match(swipeElementsToScript(withId("panel_2")), /animation\.animate\('#panel_2'/);
+});
+
+test("elements without an id get a generated one that satisfies the rule", () => {
+  const elements: SwipeElement[] = [{ text: "x", to: { opacity: 1 } }];
+  assert.match(swipeElementsToHtml(elements), /<div id="swipe_el_0"/);
+  assert.match(swipeElementsToScript(elements), /animation\.animate\('#swipe_el_0'/);
+});

--- a/test/zod/test_swipe_element_id.ts
+++ b/test/zod/test_swipe_element_id.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert";
+import { mulmoBeatSchema } from "../../src/types/schema.js";
+
+/**
+ * The id reaches an HTML attribute and a CSS selector inside the generated animation
+ * script, so the renderer refuses one it cannot use. The schema carries the same rule so an
+ * author is told at parse time instead of mid-render — and because the ids it now rejects
+ * were already broken: `a'b` produces a JavaScript syntax error in the generated script and
+ * `swipe el` produces a selector that silently matches nothing.
+ */
+
+const beatWith = (id: string) => ({ image: { type: "html_tailwind", elements: [{ id, text: "x" }] } });
+
+test("a swipe element id outside the permitted set is rejected at parse time", () => {
+  ["a'b", "swipe el", '"x"', "0", "-", "第1章", "a.b"].forEach((id) => {
+    const result = mulmoBeatSchema.safeParse(beatWith(id));
+    assert.strictEqual(result.success, false, `${JSON.stringify(id)} must be rejected`);
+  });
+});
+
+test("ordinary swipe element ids parse", () => {
+  ["panel_2", "a", "_x", "swipe_el_0", "A-1"].forEach((id) => {
+    const result = mulmoBeatSchema.safeParse(beatWith(id));
+    assert.strictEqual(result.success, true, `${JSON.stringify(id)} must parse: ${JSON.stringify(result.error?.issues?.[0])}`);
+  });
+});
+
+test("the id stays optional", () => {
+  assert.strictEqual(mulmoBeatSchema.safeParse({ image: { type: "html_tailwind", elements: [{ text: "x" }] } }).success, true);
+});


### PR DESCRIPTION
## Summary

生成マークアップに埋める element id を `[A-Za-z_][A-Za-z0-9_-]*`（先頭は英字か `_`）に制限し、外れたら throw します。

- `src/utils/element_id.ts`（新規, pure）— `isSafeElementId` / `assertSafeElementId`
- 強制点は**4つ**: `chartHtml` / `mermaidHtml` / `beatToHtml`（境界） / `swipe_to_html`（round 4 でレビューが見つけた4つ目）
- **スキーマにも同じ規則を入れました**（`swipeElementSchema.id`）— 描画時ではなく parse 時に落ちるように
- `BeatHtmlOptions.idPrefix` の契約に規則を明記

`#1540` を閉じます。`#1526` のブラウザ経路に進む前に決めておくべき設計判断でした。

## Items to Confirm / Review

### 1. なぜエスケープではなく検証か

`chart_html.ts` の id は**2文脈**に出ます:

```html
<canvas id="${chartId}"></canvas>                   ← HTML 属性
  const ctx = document.getElementById('${chartId}')   ← <script> 内の JS 文字列リテラル
```

`<script>` の中では HTML 実体参照が復号されないので、属性側だけ `escapeHtml` を掛けると **JS 側と食い違い `getElementById` が一致しなくなります**。文脈ごとに別のエスケープを当てる手もありますが、文脈が増えるたびに規則が増え、同期が崩れた箇所が穴になります。

`[A-Za-z_][A-Za-z0-9_-]*` に限れば HTML 属性・JS 文字列・CSS セレクタ・URL 断片の**どれでも安全**で、新しい文脈が増えても壊れません（fail closed）。

> **round 1 で狭めました**: 当初 `[A-Za-z0-9_-]+` としていましたが、Codex に「`#0` や `#-` は CSS セレクタとして不正だから契約が過大主張」と指摘され、ブラウザで測って先頭文字を縛りました。
>
> | id | `getElementById` | `querySelector('#id')` |
> |---|---|---|
> | `0` / `-` / `0a` / `-0` | 🟢 通る | 🔴 **throw** |
> | `_` / `a` / `A1` / `beat-0` | 🟢 | 🟢 |
>
> つまり今日動く id が、セレクタで触った瞬間に使えなくなり得ます。文字集合から生成した 152 通りで **受理側にセレクタ失敗ゼロ**を確認しました（棄却側には実は安全な 8 件 = `-a` 等があり、一文で言える形との交換として文書化しています）。

### 2. #1539 で入れた mermaid の id エスケープを外しています

検証はそれより**強い**（属性だけでなく JS 文字列文脈も覆う）ので、規則を1つにするために外しました。1PR 前の自分の変更を取り消す形なので、意図的である旨をここに明記しておきます。

### 3. 正規化ではなく throw にしました

不正文字を置換すると、異なる2つの beat id が同じ安全な id に潰れ得ます。**重複 element id はまさに `idPrefix` が防ごうとしているバグ**なので、黙って直すより落とす方を選びました。契約には「index から derive（`beat-3`、`3` ではなく — 数字始まりは不可）するか、自分で sanitize しろ」と書いています。

判断が分かれるところなので見てください。代案は「正規化する」「文脈別にエスケープする」「契約だけにして強制しない」です。

### 4. 到達性

`beat_html/index.ts` の契約は当初「beat の id か index を渡せ」と書いており、`mulmoBeatSchema.id`（"Unique identifier for the beat"）はスクリプト由来かつ無制約です。host が beat.id をそのまま渡すと属性を抜け出せます。

現行の Node 経路は `generateUniqueId("chart")` → `chart-[0-9a-f]{8}`（test モードでは `"id"`）なのでどちらも許可集合内で、**既存の呼び出し元は一切影響を受けません**。

### 5. スキーマ変更を含みます（on-disk 契約の変更）

`swipeElementSchema.id` に同じ正規表現を入れました。**以前は parse を通っていた id が parse で落ちます。**

これを入れた理由は、落ちるようになる id は**今日すでに壊れているから**です（実測）:

| id | 現状の生成 JS | 結果 |
|---|---|---|
| `a'b` | `animation.animate('#a'b', …)` | **JS 構文エラー**（スクリプト全体が死ぬ） |
| `swipe el` | `animation.animate('#swipe el', …)` | セレクタ不正で**無音の不発** |
| `-a` | `animation.animate('#-a', …)` | **動く**（← 実際の退行） |

`-a` / `--a` のような「CSS では有効だが本 PR の集合では不可」な id だけが本当の退行です。
`swipe` の element id にこの形を使っている例は考えにくいですが、判断が要るなら教えてください。

`beat.image.chartData` や `style` のようにスキーマが緩い箇所は他にもありますが、id は単純な字句制約で
zod で表現でき、外した場合の失敗（描画時 throw / 無音の不発）が分かりにくいので、ここは締める方を選びました。

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit`: clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1122 tests, 0 fail**
- 新テストは `NODE_ENV=test` あり／なし両方で緑
- browser-safety ゲート: 7/7 pass（`element_id.ts` が beat_html の依存グラフに入っても Node 依存なし）
- **変異検証で強制点3つすべてに穴が無いことを確認**。最初は2箇所が **fail=0（未カバー）** で、テストを足して埋めました:

  | 変異 | 追加前 | 追加後 |
  |---|---|---|
  | 許可集合を全許可にする | fail=23 | fail=19 |
  | `assert` を無効化 | fail=3 | fail=5 |
  | `chartHtml` から検証を外す | **fail=0 🔴** | fail=1 ✅ |
  | `mermaidHtml` から検証を外す | fail=1 | fail=1 |
  | `beatToHtml` 境界から外す | **fail=0 🔴** | fail=1 ✅ |

## User Prompt

> b

（「#1540 だけ決めて #1526 のブラウザ経路に戻る」を選択いただいたもの）

Closes #1540
Refs #1535, #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved safety and consistency for generated element IDs across charts, Mermaid diagrams, beat markup, and swipe content.
  - Invalid IDs now fail immediately with a clear error instead of being escaped or silently modified.
  - Valid IDs must start with a letter or underscore, followed by letters, numbers, hyphens, or underscores (`[A-Za-z_][A-Za-z0-9_-]*`).
  - Updated validation and guidance to recommend index-based IDs such as `beat-3` instead of `3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

_（上記2行は round 1 での集合の絞り込みを反映するよう手で修正しています。自動生成時点の内容は古くなっていました。）_



