### PR TITLE
feat(beat_html): render chart beats as a browser fragment

### DIFF
--- a/plans/feat-beat-html-chart.md
+++ b/plans/feat-beat-html-chart.md
@@ -1,0 +1,32 @@
+# feat(beat_html): chart beat をブラウザ用 fragment にする
+
+issue: #1526 の PR 4。
+
+## 設計
+
+`chartHtml()` は inline `<script>` を吐くが、**`innerHTML` 経由で注入された script は実行されない**し
+sanitize も生き残らない。したがってブラウザ用は config を canvas の属性に載せる。
+
+姉妹パッケージ `@mulmocast/deck` が既に同じ規約を持っているので**属性の形を厳密に合わせる**:
+
+```html
+<canvas id="..." data-chart-ready="false" data-mulmo-chart="{escapeHtml(compact JSON)}"></canvas>
+```
+
+これで `[data-mulmo-chart]` を駆動する host runtime が slide と beat の両方を1つの経路で扱える。
+プラグイン CDN の伝え方も deck の `SlideFragment.chartPlugins` に倣う。
+
+## 共有
+
+markup を書き直さず `image_plugins/chart_html.ts` を割る:
+
+- `chartCard(title, canvas, trailing)` — 両経路が使うカード
+- `chartHtml()` = カード + script（Node、**バイト不変**）
+- `chartFragmentHtml()` = カード + data 属性（ブラウザ）
+
+二重実装は必ずずれる（#1530 で、コピーした markdown 実装が同じバグを共有して parity テストが通った）。
+
+## 検証
+
+Node 側のバイト不変は origin/main との差分ハーネスで実測する。
+ブラウザ側は「host が実際に駆動できるか」を実ブラウザで確認する — build が通ることは動くことの証明にならない。

--- a/src/utils/beat_html/chart.ts
+++ b/src/utils/beat_html/chart.ts
@@ -1,0 +1,24 @@
+import type { MulmoChartMedia } from "../../types/index.js";
+import { chartFragmentHtml, chartPluginCdns, chartTypeOf } from "../image_plugins/chart_html.js";
+import type { BeatHtmlFragment } from "./type.js";
+
+/**
+ * A chart beat as markup a host can inject.
+ *
+ * The config rides on the canvas as `data-mulmo-chart` rather than in an inline `<script>`:
+ * a script injected through `innerHTML` does not execute, and does not survive sanitizing
+ * either. The attribute shape matches `@mulmocast/deck`'s, so a host that already drives
+ * `[data-mulmo-chart]` for slides drives this too without a second code path.
+ *
+ * The markup itself comes from `image_plugins/chart_html.ts`, the same module the Node
+ * render path uses — a second copy of it would drift, and the two paths have to draw the
+ * same chart.
+ */
+export const chartToHtml = (image: MulmoChartMedia, idPrefix: string): BeatHtmlFragment => {
+  const plugins = chartPluginCdns(chartTypeOf(image.chartData));
+  return {
+    html: chartFragmentHtml(image.chartData, image.title, `${idPrefix}-chart`),
+    requires: ["chart"],
+    ...(plugins.length > 0 ? { chartPlugins: plugins } : {}),
+  };
+};

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -1,6 +1,7 @@
 import type { MulmoBeat } from "../../types/index.js";
 import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
 import { textSlideToHtml } from "./text_slide.js";
+import { chartToHtml } from "./chart.js";
 import { markdownToHtml } from "./markdown.js";
 import { assertSafeElementId } from "../element_id.js";
 
@@ -14,7 +15,7 @@ export { markdownToHtml } from "./markdown.js";
  * a type added here without a case — or vice versa — fails rather than silently
  * rendering nothing.
  */
-export const supportedBeatTypes = ["textSlide", "markdown"] as const;
+export const supportedBeatTypes = ["textSlide", "markdown", "chart"] as const;
 
 /**
  * Render a beat as markup for a browser host.
@@ -45,6 +46,8 @@ export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlF
       return textSlideToHtml(image);
     case "markdown":
       return markdownToHtml(image, options.idPrefix);
+    case "chart":
+      return chartToHtml(image, options.idPrefix);
     default:
       return undefined;
   }

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -21,6 +21,12 @@ export type BeatHtmlFragment = {
   css?: string;
   /** External runtimes the host must load once for the page, not once per beat. */
   requires?: BeatRuntime[];
+  /**
+   * Extra Chart.js plugin CDNs this beat's chart type needs, on top of Chart.js itself.
+   * Same shape as `@mulmocast/deck`'s `SlideFragment.chartPlugins`, so one host can load
+   * for both. Absent when the beat needs none.
+   */
+  chartPlugins?: string[];
 };
 
 /** External runtimes a fragment can depend on. */

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -31,23 +31,50 @@ export const resolveChartPlugins = (chartType: string): string => {
 
 export const stringifyChartData = (chartData: MulmoChartMedia["chartData"]): string => JSON.stringify(chartData, null, 2);
 
+/** The card both paths draw: a heading and a fixed-height canvas. `trailing` is where the
+ * document path puts its driver script; the fragment path leaves it empty. */
+const chartCard = (title: string, canvas: string, trailing: string): string => `
+<div class="chart-container mb-6">
+  <h3 class="text-xl font-semibold mb-4">${escapeHtml(title || "Chart")}</h3>
+  <div class="w-full" style="position: relative; height: 400px;">
+    ${canvas}
+  </div>${trailing}
+</div>`;
+
+/** For a standalone document, where the inline script runs. */
 export const chartHtml = (chartDataJson: string, title: string, chartId: string): string => {
   assertSafeElementId(chartId);
-  const heading = escapeHtml(title || "Chart");
-
-  return `
-<div class="chart-container mb-6">
-  <h3 class="text-xl font-semibold mb-4">${heading}</h3>
-  <div class="w-full" style="position: relative; height: 400px;">
-    <canvas id="${chartId}"></canvas>
-  </div>
+  const script = `
   <script>
     (function() {
       const ctx = document.getElementById('${chartId}').getContext('2d');
       new Chart(ctx, ${escapeJsonForScript(chartDataJson)});
     })();
-  </script>
-</div>`;
+  </script>`;
+  return chartCard(title, `<canvas id="${chartId}"></canvas>`, script);
+};
+
+/**
+ * For a host that injects the markup into its own page, where an injected `<script>`
+ * neither survives sanitizing nor executes via innerHTML. The config rides on the canvas
+ * instead, in the shape `@mulmocast/deck` already uses so one host runtime drives both.
+ */
+export const chartFragmentHtml = (chartData: MulmoChartMedia["chartData"], title: string, chartId: string): string => {
+  assertSafeElementId(chartId);
+  const config = escapeHtml(JSON.stringify(chartData));
+  return chartCard(title, `<canvas id="${chartId}" data-chart-ready="false" data-mulmo-chart="${config}"></canvas>`, "");
+};
+
+/** `chartData` is a free record, so the type may be absent or not a string. */
+export const chartTypeOf = (chartData: MulmoChartMedia["chartData"]): string => {
+  const type = chartData?.type;
+  return typeof type === "string" ? type : "";
+};
+
+/** The Chart.js plugin CDNs a chart type needs, for a host that loads them once per page. */
+export const chartPluginCdns = (chartType: string): string[] => {
+  const cdn = CHART_PLUGIN_CDNS[chartType];
+  return cdn ? [cdn] : [];
 };
 
 /**

--- a/src/utils/image_plugins/chart_html.ts
+++ b/src/utils/image_plugins/chart_html.ts
@@ -16,15 +16,19 @@ import { assertSafeElementId } from "../element_id.js";
  * every render.
  */
 
-/** Chart.js plugin CDN URLs keyed by chart type */
-const CHART_PLUGIN_CDNS: Record<string, string> = {
-  sankey: "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey",
-  treemap: "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3",
-};
+/**
+ * Chart.js plugin CDN URLs keyed by chart type. A Map rather than an object literal: the
+ * chart type comes from the script, so an object lookup resolves `constructor` and
+ * `__proto__` through the prototype chain and hands back a function.
+ */
+const CHART_PLUGIN_CDNS = new Map([
+  ["sankey", "https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"],
+  ["treemap", "https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3"],
+]);
 
 /** Resolve CDN script tags for Chart.js plugins based on chart type */
 export const resolveChartPlugins = (chartType: string): string => {
-  const cdn = CHART_PLUGIN_CDNS[chartType];
+  const cdn = CHART_PLUGIN_CDNS.get(chartType);
   if (!cdn) return "";
   return `<script src="${cdn}"></script>`;
 };
@@ -73,7 +77,7 @@ export const chartTypeOf = (chartData: MulmoChartMedia["chartData"]): string => 
 
 /** The Chart.js plugin CDNs a chart type needs, for a host that loads them once per page. */
 export const chartPluginCdns = (chartType: string): string[] => {
-  const cdn = CHART_PLUGIN_CDNS[chartType];
+  const cdn = CHART_PLUGIN_CDNS.get(chartType);
   return cdn ? [cdn] : [];
 };
 

--- a/test/beat_html/test_chart.ts
+++ b/test/beat_html/test_chart.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert";
+import { chartToHtml } from "../../src/utils/beat_html/chart.js";
+import { chartHtml, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
+import { mulmoChartMediaSchema } from "../../src/types/schema.js";
+
+/**
+ * Verified end to end in a browser: two fragments injected through `innerHTML`, a host that
+ * loads Chart.js from `requires` and drives every `[data-mulmo-chart]` canvas. Both charts
+ * drew, `#app` contained no `<script>` at all, and a hostile title produced no element.
+ */
+
+const media = (over: Record<string, unknown> = {}) =>
+  mulmoChartMediaSchema.parse({ type: "chart", title: "Sales", chartData: { type: "bar", data: { labels: ["a"], datasets: [{ data: [1] }] } }, ...over });
+
+test("the fragment carries no script, because an injected one would not run", () => {
+  const { html } = chartToHtml(media(), "beat-0");
+  assert.strictEqual(html.toLowerCase().split("<script").length - 1, 0, "a fragment must not carry a script tag");
+  assert.match(html, /<canvas id="beat-0-chart" data-chart-ready="false" data-mulmo-chart="/);
+});
+
+test("the config rides on the canvas and parses back to the original", () => {
+  const chartData = { type: "bar", data: { labels: ["Q&A", "<b>"], datasets: [{ data: [1, 2] }] } };
+  const { html } = chartToHtml(media({ chartData }), "beat-1");
+  const attr = html.match(/data-mulmo-chart="([^"]*)"/)?.[1];
+  assert.ok(attr, "the attribute must be present");
+  const decoded = attr
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+  assert.deepStrictEqual(JSON.parse(decoded), chartData, "the host must read back exactly what the beat said");
+});
+
+test("the host is told which runtime and which plugins to load", () => {
+  assert.deepStrictEqual(chartToHtml(media(), "b").requires, ["chart"]);
+  assert.strictEqual(chartToHtml(media(), "b").chartPlugins, undefined, "a plain bar chart needs no plugin");
+  assert.deepStrictEqual(chartToHtml(media({ chartData: { type: "sankey" } }), "b").chartPlugins, ["https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"]);
+  assert.deepStrictEqual(chartToHtml(media({ chartData: { type: "treemap" } }), "b").chartPlugins, ["https://cdn.jsdelivr.net/npm/chartjs-chart-treemap@3"]);
+});
+
+test("a chart type that is absent or not a string asks for no plugin", () => {
+  [{}, { type: 7 }, { type: null }].forEach((chartData) => {
+    assert.strictEqual(chartToHtml(media({ chartData }), "b").chartPlugins, undefined, `${JSON.stringify(chartData)} must ask for nothing`);
+  });
+});
+
+test("a hostile title and hostile config cannot escape their contexts", () => {
+  const { html } = chartToHtml(media({ title: '</h3><img src=x onerror="pwn()">', chartData: { s: '"><img src=x onerror="pwn()">' } }), "b");
+  assert.strictEqual(html.toLowerCase().split("<img").length - 1, 0, "no injected element may survive");
+  assert.strictEqual(html.toLowerCase().split("<h3").length - 1, 1, "the heading must not be closed early");
+  assert.strictEqual(html.toLowerCase().split("<canvas").length - 1, 1, "the attribute must not start a second element");
+});
+
+test("the id goes through the element id rule", () => {
+  assert.throws(() => chartToHtml(media(), "beat 1"), /element id must match/);
+  assert.throws(() => chartToHtml(media(), "0"), /element id must match/);
+});
+
+// The point of sharing image_plugins/chart_html.ts: one card, two wrappers. If they drift,
+// the browser and the PNG show different charts for the same beat.
+test("the fragment and the document path draw the same card", () => {
+  const image = media();
+  const fragment = chartToHtml(image, "beat-9").html;
+  const document = chartHtml(stringifyChartData(image.chartData), image.title, "beat-9-chart");
+  const withoutCanvasAndScript = (html: string) => html.replace(/<canvas[^>]*><\/canvas>/, "«canvas»").replace(/\n {2}<script>[\s\S]*<\/script>/, "");
+  assert.strictEqual(withoutCanvasAndScript(fragment), withoutCanvasAndScript(document));
+});

--- a/test/beat_html/test_dispatch.ts
+++ b/test/beat_html/test_dispatch.ts
@@ -10,6 +10,7 @@ const beat = (image: unknown) => mulmoBeatSchema.parse({ image });
 const minimalBeat: Record<(typeof supportedBeatTypes)[number], ReturnType<typeof beat>> = {
   textSlide: beat({ type: "textSlide", slide: { title: "T" } }),
   markdown: beat({ type: "markdown", markdown: "# T" }),
+  chart: beat({ type: "chart", title: "T", chartData: { type: "bar", data: { labels: ["a"], datasets: [{ data: [1] }] } } }),
 };
 
 test("every type in supportedBeatTypes actually renders", () => {
@@ -27,7 +28,6 @@ test("types not on the list render nothing, rather than something wrong", () => 
   const notYetSupported: [string, unknown][] = [
     ["image", { type: "image", source: { kind: "url", url: "https://example.com/a.png" } }],
     ["movie", { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }],
-    ["chart", { type: "chart", title: "t", chartData: { type: "bar", data: { labels: ["a"], datasets: [] } } }],
     ["mermaid", { type: "mermaid", title: "t", code: { kind: "text", text: "graph TD; A-->B" } }],
     ["html_tailwind", { type: "html_tailwind", html: "<div></div>" }],
     ["slide", { type: "slide", slide: { layout: "title", title: "T" } }],

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -94,12 +94,14 @@ test("plugin CDNs are resolved per chart type, and unknown types get nothing", (
   });
 });
 
-// Pre-existing on main: the lookup is a plain object literal, so a chart type naming an
-// Object.prototype member resolves through the prototype chain. Pinned to make a fix visible,
-// not because it is wanted.
-test("prototype member names leak through the plugin lookup", () => {
-  assert.strictEqual(resolveChartPlugins("constructor"), '<script src="function Object() { [native code] }"></script>');
-  assert.strictEqual(resolveChartPlugins("__proto__"), '<script src="[object Object]"></script>');
+// The lookup is a Map, so a chart type naming an Object.prototype member resolves to
+// nothing instead of to a function. This was #1534, filed when the table was an object
+// literal; it closed here because the new chartPluginCdns would otherwise have returned a
+// function from an array typed string[].
+test("prototype member names resolve to no plugin", () => {
+  ["constructor", "__proto__", "toString", "valueOf", "hasOwnProperty"].forEach((type) => {
+    assert.strictEqual(resolveChartPlugins(type), "", `${type} must resolve to no plugin`);
+  });
 });
 
 test("the plugin passes the beat straight through to the renderer", async () => {


### PR DESCRIPTION
## Summary

chart beat をブラウザ host が注入できる fragment にしました。`#1526` の PR 4 です。

- `src/utils/beat_html/chart.ts`（新規）— `chartToHtml(image, idPrefix)`
- `chart_html.ts` を「カード」と「script / data 属性」に分割（**markup は書き直していません**）
- `BeatHtmlFragment.chartPlugins` を追加、`supportedBeatTypes` に `chart` を登録

## Items to Confirm / Review

### 1. なぜ `<script>` ではなく `data-mulmo-chart` か

**`innerHTML` 経由で注入された `<script>` は実行されません**し、sanitize も生き残りません。なので config は canvas の属性に載せます。

姉妹パッケージ `@mulmocast/deck` が既に同じ規約を持っているので**属性の形を厳密に合わせました**:

```html
<canvas id="..." data-chart-ready="false" data-mulmo-chart="{escapeHtml(compact JSON)}"></canvas>
```

これで `[data-mulmo-chart]` を駆動する host runtime が slide と beat を**1つの経路**で扱えます。`chartPlugins` も deck の `SlideFragment.chartPlugins` に倣いました。

### 2. markup を共有しています（書き直していません）

`chart_html.ts` を割りました:

| | 中身 |
|---|---|
| `chartCard(title, canvas, trailing)` | 両経路が使うカード |
| `chartHtml()` | カード + script（Node、**バイト不変**） |
| `chartFragmentHtml()` | カード + data 属性（ブラウザ） |

二重実装は必ずずれます — #1530 でコピーした markdown 実装が同じバグを共有し、parity テストが通ってしまった前例があります。「両経路が同じカードを描く」ことをテストで固定しています。

### 3. Node 経路のバイト不変を実測しました

`origin/main` の `chart_html.ts` と突き合わせ: **825 件（title 11 × chartData 15 × id 5）で差分 0**。ハーネスが差分を見られることは変異（`mb-6`→`mb-5`）で **825 件差分**を確認済みです。

### 4. 実ブラウザで host が駆動できることを確認しました

build が通ることは動くことの証明にならないので、host がやることを実際にやりました — `requires` を見て Chart.js を1回だけ読み、fragment を `innerHTML` で注入し、`[data-mulmo-chart]` を駆動する。

| | 結果 |
|---|---|
| `#app` 内の `<script>` | **0**（＝前提どおり実行されない形） |
| canvas | 2件すべて **実際に描画** |
| 敵対的 title (`</h3><img onerror>`) | 文字通り表示。**XSS なし・注入 `<img>` 0** |
| pageerror | なし |

### 5. 判断が要る点

- **`chartPlugins` を `BeatHtmlFragment` に足しました**（deck に倣った公開型の追加）。`BeatRuntime` を `"chart-sankey"` のように増やす案もありますが、deck と揃える方を採りました。
- `data-chart-ready="false"` も deck に合わせて出しています。cli 側の host はまだ使いませんが、同じ runtime で駆動するなら合わせておく方が良いと判断しました。不要なら外します。

### 6. round 1 で #1534 を閉じました（Node 経路の挙動が12種だけ変わります）

Codex が、私が新しく書いた `chartPluginCdns` が **`string[]` と宣言しながら関数を返し得る**ことを見つけました。#1534 として自分で filed した穴を、1つ後の PR で自分のコードに作っていた形です。

1箇所だけ直すと同じファイルに「安全な参照」と「危険な参照」が同居するので、**テーブルごと Map** にしました。結果として #1534 も閉じます。

**Node 経路 (`resolveChartPlugins`) の挙動が変わる範囲を実測しました**: chart type 29 種を試して **差分は 12 件、それは `Object.prototype` のメンバ12個ちょうど**です。

| chart type | main | 本PR |
|---|---|---|
| `bar` / `line` / `pie` / `sankey` / `treemap` など実在の型 | — | **不変** |
| `constructor` / `toString` / `__proto__` など12個 | `<script src="function Object() { [native code] }">` | `""` |

`chartHtml` 自体は 825 件のハーネスで**依然バイト不変**です。

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean（#1541 で CI に捕まった types ビルドも回しています）
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1129 tests, 0 fail**
- browser-safety ゲート **7/7 pass**（`chart_html.ts` が beat_html の依存グラフに入っても Node 依存なし）
- **変異4種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | `requires` を落とす | fail=1 |
  | `chartPlugins` を落とす | fail=1 |
  | `data-mulmo-chart` を壊す | fail=2 |
  | 属性のエスケープを外す | fail=2 |

## User Prompt

> b

（「#1540 だけ決めて #1526 のブラウザ経路に戻る」を選択いただき、#1541 マージ後に本来の目的へ復帰したものです）

Refs #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering chart beats in browser HTML fragments.
  * Chart fragments now include serialized configuration and automatically load required chart plugins.
  * Preserved standalone chart document rendering while enabling shared browser initialization.

* **Bug Fixes**
  * Improved validation and escaping for chart types, element IDs, and embedded configuration.

* **Tests**
  * Added coverage for chart rendering, plugin loading, escaping, validation, and consistency across rendering modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
