### PR TITLE
feat(beat_html): render mermaid beats as a browser fragment

### DIFF
--- a/plans/feat-beat-html-mermaid.md
+++ b/plans/feat-beat-html-mermaid.md
@@ -1,0 +1,24 @@
+# feat(beat_html): mermaid beat をブラウザ用 fragment にする
+
+issue: #1526 の PR 5。
+
+## refactor は不要だった
+
+issue の表には「refactor(mermaid) — code 解決を引数化」と書いていたが、実装を見ると不要だった:
+
+- `mermaid_html.ts` は #1530 で既に pure に切り出し済み
+- Node 依存は `MulmoMediaSourceMethods.getText`（fetch / fs）だけで、これは `mermaid.ts` 側にある
+- ブラウザ側は `code.kind === "text"` を直接読めばよい
+
+したがって PR 5 は fragment の追加だけ。
+
+## 対応する code.kind
+
+`text` のみ。`url` / `path` / `base64` は `getText` が fetch と fs で解決するのでブラウザから届かず、
+`beatToHtml` は `undefined` を返す（placeholder を勝手に作らない、というモジュールの契約どおり）。
+`mermaid.ts` の `dumpMarkdown` も既に同じ線を引いている。
+
+## 検証
+
+Node の dump 経路と同じ markup になることを実測で突き合わせ、
+host が実際に描画できることを実ブラウザで確認する。

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -3,6 +3,7 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
 import { textSlideToHtml } from "./text_slide.js";
 import { chartToHtml } from "./chart.js";
 import { markdownToHtml } from "./markdown.js";
+import { mermaidToHtml } from "./mermaid.js";
 import { assertSafeElementId } from "../element_id.js";
 
 export type { BeatHtmlFragment, BeatHtmlOptions, BeatRuntime } from "./type.js";
@@ -15,7 +16,7 @@ export { markdownToHtml } from "./markdown.js";
  * a type added here without a case — or vice versa — fails rather than silently
  * rendering nothing.
  */
-export const supportedBeatTypes = ["textSlide", "markdown", "chart"] as const;
+export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid"] as const;
 
 /**
  * Render a beat as markup for a browser host.
@@ -48,6 +49,8 @@ export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlF
       return markdownToHtml(image, options.idPrefix);
     case "chart":
       return chartToHtml(image, options.idPrefix);
+    case "mermaid":
+      return mermaidToHtml(image, options.idPrefix);
     default:
       return undefined;
   }

--- a/src/utils/beat_html/mermaid.ts
+++ b/src/utils/beat_html/mermaid.ts
@@ -1,0 +1,24 @@
+import type { MulmoMermaidMedia } from "../../types/index.js";
+import { mermaidHtml } from "../image_plugins/mermaid_html.js";
+import type { BeatHtmlFragment } from "./type.js";
+
+/**
+ * A mermaid beat as markup a host can inject.
+ *
+ * Only `code.kind === "text"` renders. The other kinds — `url`, `path`, `base64` — are
+ * resolved by `MulmoMediaSourceMethods.getText`, which fetches and reads files, so they
+ * cannot be reached from here and `beatToHtml` returns undefined rather than inventing a
+ * placeholder. `mermaid.ts`'s own markdown dump already draws the same line.
+ *
+ * The markup comes from `image_plugins/mermaid_html.ts`, the module the Node render path
+ * uses, so the browser and the PNG draw the same diagram.
+ */
+export const mermaidToHtml = (image: MulmoMermaidMedia, idPrefix: string): BeatHtmlFragment | undefined => {
+  if (image.code.kind !== "text") return undefined;
+  const appendix = image.appendix?.join("\n") ?? "";
+  const code = `${image.code.text}\n${appendix}`.trim();
+  return {
+    html: mermaidHtml(code, `${idPrefix}-mermaid`, image.title || "Diagram"),
+    requires: ["mermaid"],
+  };
+};

--- a/test/beat_html/test_dispatch.ts
+++ b/test/beat_html/test_dispatch.ts
@@ -11,6 +11,7 @@ const minimalBeat: Record<(typeof supportedBeatTypes)[number], ReturnType<typeof
   textSlide: beat({ type: "textSlide", slide: { title: "T" } }),
   markdown: beat({ type: "markdown", markdown: "# T" }),
   chart: beat({ type: "chart", title: "T", chartData: { type: "bar", data: { labels: ["a"], datasets: [{ data: [1] }] } } }),
+  mermaid: beat({ type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } }),
 };
 
 test("every type in supportedBeatTypes actually renders", () => {
@@ -28,7 +29,6 @@ test("types not on the list render nothing, rather than something wrong", () => 
   const notYetSupported: [string, unknown][] = [
     ["image", { type: "image", source: { kind: "url", url: "https://example.com/a.png" } }],
     ["movie", { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }],
-    ["mermaid", { type: "mermaid", title: "t", code: { kind: "text", text: "graph TD; A-->B" } }],
     ["html_tailwind", { type: "html_tailwind", html: "<div></div>" }],
     ["slide", { type: "slide", slide: { layout: "title", title: "T" } }],
     ["beat", { type: "beat" }],

--- a/test/beat_html/test_mermaid.ts
+++ b/test/beat_html/test_mermaid.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert";
+import { mermaidToHtml } from "../../src/utils/beat_html/mermaid.js";
+import { mermaidHtml } from "../../src/utils/image_plugins/mermaid_html.js";
+import { mulmoMermaidMediaSchema } from "../../src/types/schema.js";
+
+/**
+ * Verified in a browser: the fragment injected through `innerHTML`, a host loading mermaid
+ * from `requires` and calling `mermaid.init` on `.mermaid` elements. The diagram drew and a
+ * hostile title produced no element.
+ */
+
+const media = (over: Record<string, unknown> = {}) =>
+  mulmoMermaidMediaSchema.parse({ type: "mermaid", title: "Flow", code: { kind: "text", text: "graph TD; A-->B" }, ...over });
+
+test("a text diagram renders and asks the host for the mermaid runtime", () => {
+  const fragment = mermaidToHtml(media(), "beat-0");
+  assert.ok(fragment);
+  assert.deepStrictEqual(fragment.requires, ["mermaid"]);
+  assert.match(fragment.html, /<div id="beat-0-mermaid" class="mermaid">/);
+  assert.match(fragment.html, /graph TD; A--&gt;B/, "the source is escaped for its text context");
+});
+
+// getText fetches and reads files, so these cannot be reached from a browser. The module
+// returns undefined rather than inventing a placeholder — the caller decides what to show.
+test("code kinds that need the filesystem or network render nothing", () => {
+  [
+    { kind: "url", url: "https://example.com/d.mmd" },
+    { kind: "path", path: "d.mmd" },
+    { kind: "base64", data: "Z3JhcGggVEQ7" },
+  ].forEach((code) => {
+    assert.strictEqual(mermaidToHtml(media({ code }), "b"), undefined, `${code.kind} must render nothing`);
+  });
+});
+
+test("the appendix is appended to the diagram source, as the document path does", () => {
+  const appendix = ["style A fill:#f9f", "style B fill:#bbf"];
+  const fragment = mermaidToHtml(media({ appendix }), "b");
+  assert.ok(fragment);
+  // The document path builds `${code}\n${appendix.join("\n")}`.trim() and hands the whole
+  // thing to the same renderer, so only the first line carries the template's indentation.
+  assert.strictEqual(fragment.html, mermaidHtml(`graph TD; A-->B\n${appendix.join("\n")}`, "b-mermaid", "Flow"));
+  assert.match(fragment.html, /graph TD; A--&gt;B\nstyle A fill:#f9f\nstyle B fill:#bbf/);
+});
+
+test("an empty title falls back to Diagram, matching the document path", () => {
+  const fragment = mermaidToHtml(media({ title: "" }), "b");
+  assert.ok(fragment);
+  assert.match(fragment.html, /<h3 class="text-xl font-semibold mb-4">Diagram<\/h3>/);
+});
+
+test("a hostile title and hostile source cannot escape their contexts", () => {
+  const fragment = mermaidToHtml(
+    media({ title: '</h3><img src=x onerror="pwn()">', code: { kind: "text", text: 'graph TD; A-->B;</DIV ><img src=x onerror="pwn()">' } }),
+    "b",
+  );
+  assert.ok(fragment);
+  const lower = fragment.html.toLowerCase();
+  assert.strictEqual(lower.split("<img").length - 1, 0, "no injected element may survive");
+  assert.strictEqual(lower.split("<h3").length - 1, 1, "the heading must not be closed early");
+  assert.strictEqual(lower.split("</div").length - 1, 3, "the containers must not be closed early");
+});
+
+test("the id goes through the element id rule", () => {
+  assert.throws(() => mermaidToHtml(media(), "beat 1"), /element id must match/);
+});
+
+// One implementation, two callers. If they drift, the browser and the PNG show different
+// diagrams for the same beat.
+test("the fragment is the shared markup, not a second copy", () => {
+  const image = media();
+  const fragment = mermaidToHtml(image, "beat-9");
+  assert.ok(fragment);
+  assert.strictEqual(fragment.html, mermaidHtml("graph TD; A-->B", "beat-9-mermaid", "Flow"));
+});


### PR DESCRIPTION
## Summary

mermaid beat をブラウザ host が注入できる fragment にしました。`#1526` の PR 5 です。

- `src/utils/beat_html/mermaid.ts`（新規）— `mermaidToHtml(image, idPrefix)`
- `supportedBeatTypes` に `mermaid` を登録

## Items to Confirm / Review

### 1. 予定していた refactor は不要でした

issue の表には「PR 5: **refactor(mermaid)** — code 解決を引数化」と書いていましたが、実装を読むと不要でした:

- `mermaid_html.ts` は #1530 で**既に pure に切り出し済み**
- Node 依存は `MulmoMediaSourceMethods.getText`（fetch / fs）だけで、それは `mermaid.ts` 側にある
- ブラウザ側は `code.kind === "text"` を直接読めばよい

なので本PRは fragment の追加だけです。**予定を実装に合わせて縮めた**ので、その旨をここに記録します。

### 2. 対応する `code.kind` は `text` のみ

`url` / `path` / `base64` は `getText` が fetch と fs で解決するのでブラウザから届きません。`beatToHtml` は `undefined` を返します（「placeholder を勝手に作らない」というモジュールの契約どおり）。`mermaid.ts` の `dumpMarkdown` も既に同じ線を引いています。

`base64` は `atob` で同期的に復号できるので対応可能ですが、失敗経路が増えるので既存の線に合わせました。必要なら別途。

### 3. Node の dump 経路と同じ markup になることを実測しました

「同じ図を描く」が主張なので、両方を実行して突き合わせました — **3ケースすべてで、生成 id を正規化すれば完全一致**。テストでも `mermaidHtml(...)` と同一であることを固定しています（コピーが増えていないことの担保）。

### 4. 実ブラウザで host が駆動できることを確認しました

| | 結果 |
|---|---|
| fragment | 3 beat 中 2 件（`url` は想定どおり `undefined`） |
| `#app` 内の `<script>` | **0** |
| 描画された SVG | **2 件** |
| 敵対的 title (`</h3><img onerror>`) | 文字通り表示、**XSS なし・注入 `<img>` 0** |
| pageerror | なし |

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1136 tests, 0 fail**
- browser-safety ゲート **7/7 pass**
- **変異4種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | `text` 以外の拒否を外す | fail=1 |
  | `requires` を落とす | fail=1 |
  | id を固定値にする | fail=4 |
  | title の既定値 `"Diagram"` を外す | fail=1 |

## User Prompt

> b

（#1526 のブラウザ経路。#1543 の chart に続く2本目）

Refs #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering Mermaid diagrams as browser-ready HTML fragments.
  * Mermaid text diagrams now support titles, appendices, unique element IDs, and required runtime loading.
  * Unsupported Mermaid source types are safely skipped.

* **Bug Fixes**
  * Improved HTML escaping and validation for generated Mermaid content.
  * Ensured browser-rendered diagrams match existing Mermaid output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->