### PR TITLE
feat(beat_html): render image and movie beats as browser fragments

### DIFF
--- a/plans/feat-beat-html-media.md
+++ b/plans/feat-beat-html-media.md
@@ -1,0 +1,39 @@
+# feat(beat_html): image / movie beat をブラウザ用 fragment にする
+
+issue: #1526 の PR 8-9（image と movie をまとめた）。
+
+## remote 判定は入れない
+
+ユーザー指示: 「remote の判定はとくにいれなくてもよい。ユーザが remote を指定する前提でよい」。
+
+したがって source が名指す src をそのまま出す:
+
+| kind     | src                                                               |
+| -------- | ----------------------------------------------------------------- |
+| `url`    | その URL                                                          |
+| `path`   | そのまま出し、host が自分のページ基準で解決する                   |
+| `base64` | スキーマに media type が無く `data:` URI を組めないので描画しない |
+
+## src はエスケープする（実測に基づく）
+
+`URLStringSchema` は `z.url()` だが、**引用符を通す**:
+
+```
+https://e.com/a.mp4" onerror="pwn()   → 🔴 スキーマを通る
+javascript:alert(1)                    → 🔴 スキーマを通る
+```
+
+既存 `movie.ts` の `src="${url}"` は無エスケープなので属性を抜け出せる。共有 markup 側でエスケープする。
+
+通常 URL への影響はゼロ: `?x=1&y=2` は属性上 `&amp;` になるが、**ブラウザは `?x=1&y=2` を取りに行く**
+（実測: リクエスト URL がバイト一致）。
+
+## alt
+
+`MulmoImageMedia` は `{ type, source }` だけで代替テキストを持たない。dispatcher が
+`beat.description ?? beat.text` を渡す — このモジュールが届く範囲で唯一の「絵の説明」。
+
+## image と movie を1つの PR にした理由
+
+`mediaSrc` と「メディア beat が要素になる」という同じ不変条件を共有しており、
+別々に revert する意味が薄いため。

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -3,6 +3,7 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
 import { textSlideToHtml } from "./text_slide.js";
 import { chartToHtml } from "./chart.js";
 import { markdownToHtml } from "./markdown.js";
+import { imageToHtml, movieToHtml } from "./media.js";
 import { mermaidToHtml } from "./mermaid.js";
 import { assertSafeElementId } from "../element_id.js";
 
@@ -16,7 +17,7 @@ export { markdownToHtml } from "./markdown.js";
  * a type added here without a case — or vice versa — fails rather than silently
  * rendering nothing.
  */
-export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid"] as const;
+export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid", "image", "movie"] as const;
 
 /**
  * Render a beat as markup for a browser host.
@@ -51,6 +52,12 @@ export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlF
       return chartToHtml(image, options.idPrefix);
     case "mermaid":
       return mermaidToHtml(image, options.idPrefix);
+    case "image":
+      // The only description of the picture this module can reach. A host with more should
+      // set its own alt; an <img> with none makes a screen reader read the file name.
+      return imageToHtml(image, beat.description ?? beat.text ?? "");
+    case "movie":
+      return movieToHtml(image);
     default:
       return undefined;
   }

--- a/src/utils/beat_html/media.ts
+++ b/src/utils/beat_html/media.ts
@@ -1,0 +1,23 @@
+import type { MulmoImageMedia, MulmoMovieMedia } from "../../types/index.js";
+import { imageHtml, mediaSrc, movieHtml } from "../image_plugins/media_html.js";
+import type { BeatHtmlFragment } from "./type.js";
+
+/**
+ * Image and movie beats as markup a host can inject.
+ *
+ * The src comes straight from the beat's source: a url is used as written, a path is
+ * emitted for the host to resolve against its own page, and a base64 source renders
+ * nothing because the schema carries no media type to build a `data:` URI from.
+ *
+ * Neither needs a runtime, so neither sets `requires` — an `<img>` and a `<video>` are
+ * markup the browser already knows.
+ */
+export const imageToHtml = (image: MulmoImageMedia, alt: string): BeatHtmlFragment | undefined => {
+  const src = mediaSrc(image.source);
+  return src === undefined ? undefined : { html: imageHtml(src, alt) };
+};
+
+export const movieToHtml = (image: MulmoMovieMedia): BeatHtmlFragment | undefined => {
+  const src = mediaSrc(image.source);
+  return src === undefined ? undefined : { html: movieHtml(src) };
+};

--- a/src/utils/image_plugins/media_html.ts
+++ b/src/utils/image_plugins/media_html.ts
@@ -1,0 +1,43 @@
+import type { MulmoMediaSource } from "../../types/index.js";
+import { escapeHtml } from "@mulmocast/deck/lib/utils.js";
+
+/**
+ * Markup for image and movie media. Pure — no Node, no filesystem — because the Node dump
+ * path and the browser fragment path show the same media and must show it the same way.
+ *
+ * `src` is escaped: `z.url()` accepts a quote, so a url from a script can otherwise close
+ * the attribute. Measured — `https://e.com/a.mp4" onerror="pwn()` parses clean.
+ */
+
+/**
+ * The src a browser can load from a media source. A `base64` source has no media type in
+ * the schema, so there is nothing to build a `data:` URI from; a `path` is emitted as
+ * written and left for the host to resolve against its own page.
+ */
+export const mediaSrc = (source: MulmoMediaSource): string | undefined => {
+  if (source.kind === "url") return source.url;
+  if (source.kind === "path") return source.path;
+  return undefined;
+};
+
+export const imageHtml = (src: string, alt: string): string =>
+  `\n<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" class="w-full rounded-lg shadow-lg" />`;
+
+export const movieHtml = (src: string): string => {
+  const url = escapeHtml(src);
+  return `
+<div class="movie-container mb-6">
+  <div class="relative w-full" style="padding-bottom: 56.25%; /* 16:9 aspect ratio */">
+    <video
+      class="absolute top-0 left-0 w-full h-full rounded-lg shadow-lg"
+      controls
+      preload="metadata"
+    >
+      <source src="${url}" type="video/mp4">
+      <source src="${url}" type="video/webm">
+      <source src="${url}" type="video/ogg">
+      Your browser does not support the video tag.
+    </video>
+  </div>
+</div>`;
+};

--- a/src/utils/image_plugins/movie.ts
+++ b/src/utils/image_plugins/movie.ts
@@ -1,6 +1,7 @@
 import { ImageProcessorParams } from "../../types/index.js";
 import { processSource, pathSource } from "./source.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
+import { movieHtml } from "./media_html.js";
 
 export const imageType = "movie";
 
@@ -12,21 +13,7 @@ const dumpHtml = async (params: ImageProcessorParams) => {
 
   if (!moviePathOrUrl) return;
 
-  return `
-<div class="movie-container mb-6">
-  <div class="relative w-full" style="padding-bottom: 56.25%; /* 16:9 aspect ratio */">
-    <video
-      class="absolute top-0 left-0 w-full h-full rounded-lg shadow-lg"
-      controls
-      preload="metadata"
-    >
-      <source src="${moviePathOrUrl}" type="video/mp4">
-      <source src="${moviePathOrUrl}" type="video/webm">
-      <source src="${moviePathOrUrl}" type="video/ogg">
-      Your browser does not support the video tag.
-    </video>
-  </div>
-</div>`;
+  return movieHtml(moviePathOrUrl);
 };
 
 export const process = processSource(imageType);

--- a/test/beat_html/test_dispatch.ts
+++ b/test/beat_html/test_dispatch.ts
@@ -12,6 +12,8 @@ const minimalBeat: Record<(typeof supportedBeatTypes)[number], ReturnType<typeof
   markdown: beat({ type: "markdown", markdown: "# T" }),
   chart: beat({ type: "chart", title: "T", chartData: { type: "bar", data: { labels: ["a"], datasets: [{ data: [1] }] } } }),
   mermaid: beat({ type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } }),
+  image: beat({ type: "image", source: { kind: "url", url: "https://example.com/a.png" } }),
+  movie: beat({ type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }),
 };
 
 test("every type in supportedBeatTypes actually renders", () => {
@@ -27,8 +29,6 @@ test("types not on the list render nothing, rather than something wrong", () => 
   // As each of these lands in a later PR it moves into supportedBeatTypes and out of here.
   // Real beats, not stubs: a stub could fail to render for the wrong reason.
   const notYetSupported: [string, unknown][] = [
-    ["image", { type: "image", source: { kind: "url", url: "https://example.com/a.png" } }],
-    ["movie", { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }],
     ["html_tailwind", { type: "html_tailwind", html: "<div></div>" }],
     ["slide", { type: "slide", slide: { layout: "title", title: "T" } }],
     ["beat", { type: "beat" }],

--- a/test/beat_html/test_media.ts
+++ b/test/beat_html/test_media.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert";
+import { imageToHtml, movieToHtml } from "../../src/utils/beat_html/media.js";
+import { beatToHtml } from "../../src/utils/beat_html/index.js";
+import { mulmoBeatSchema, mulmoImageMediaSchema, mulmoMovieMediaSchema } from "../../src/types/schema.js";
+
+/**
+ * `z.url()` accepts a quote — `https://e.com/a.mp4" onerror="pwn()` parses clean — so the src
+ * is escaped rather than trusted. Verified in a browser that this costs nothing for ordinary
+ * urls: `src="…?x=1&amp;y=2"` issues a request for `?x=1&y=2`, byte for byte the old URL.
+ */
+
+const image = (source: Record<string, unknown>) => mulmoImageMediaSchema.parse({ type: "image", source });
+const movie = (source: Record<string, unknown>) => mulmoMovieMediaSchema.parse({ type: "movie", source });
+const URL_SRC = { kind: "url", url: "https://example.com/a.png" };
+
+test("a url source becomes the element's src", () => {
+  assert.match(imageToHtml(image(URL_SRC), "a cat")!.html, /<img src="https:\/\/example\.com\/a\.png" alt="a cat"/);
+  assert.match(movieToHtml(movie({ kind: "url", url: "https://example.com/a.mp4" }))!.html, /<source src="https:\/\/example\.com\/a\.mp4" type="video\/mp4">/);
+});
+
+test("a path is emitted for the host to resolve, a base64 source renders nothing", () => {
+  assert.match(imageToHtml(image({ kind: "path", path: "images/a.png" }), "")!.html, /src="images\/a\.png"/);
+  assert.strictEqual(imageToHtml(image({ kind: "base64", data: "AAAA" }), ""), undefined, "no media type, so no data URI");
+  assert.strictEqual(movieToHtml(movie({ kind: "base64", data: "AAAA" })), undefined);
+});
+
+test("neither needs a runtime from the host", () => {
+  assert.strictEqual(imageToHtml(image(URL_SRC), "").requires, undefined);
+  assert.strictEqual(movieToHtml(movie({ kind: "url", url: "https://e.com/a.mp4" }))!.requires, undefined);
+});
+
+test("a url that closes the attribute is neutralized", () => {
+  const hostile = { kind: "url", url: 'https://e.com/a.png" onerror="pwn()' };
+  const html = imageToHtml(image(hostile), "")!.html;
+  assert.ok(!/<img[^>]*"\s+onerror=/.test(html), "no event handler may be introduced");
+  assert.match(html, /src="https:\/\/e\.com\/a\.png&quot; onerror=&quot;pwn\(\)"/);
+});
+
+test("a hostile movie url is neutralized in all three source tags", () => {
+  const html = movieToHtml(movie({ kind: "url", url: 'https://e.com/a.mp4" onerror="pwn()' }))!.html;
+  assert.strictEqual(html.split("&quot; onerror=&quot;pwn()").length - 1, 3, "every <source> must be escaped, not just the first");
+  assert.ok(!/<source[^>]*"\s+onerror=/.test(html), "no event handler may be introduced");
+});
+
+test("a hostile alt cannot escape its attribute", () => {
+  const html = imageToHtml(image(URL_SRC), '" onload="pwn()')!.html;
+  assert.match(html, /alt="&quot; onload=&quot;pwn\(\)"/);
+  assert.ok(!/<img[^>]*\salt="[^"]*"\s+onload=/.test(html), "no event handler may be introduced");
+});
+
+// The alt is the only description of the picture this module can reach.
+test("the dispatcher uses the beat's description, falling back to its text", () => {
+  const withDescription = mulmoBeatSchema.parse({ description: "a cat", text: "spoken", image: { type: "image", source: URL_SRC } });
+  assert.match(beatToHtml(withDescription, { idPrefix: "b" })!.html, /alt="a cat"/);
+  const withText = mulmoBeatSchema.parse({ text: "spoken", image: { type: "image", source: URL_SRC } });
+  assert.match(beatToHtml(withText, { idPrefix: "b" })!.html, /alt="spoken"/);
+  const withNeither = mulmoBeatSchema.parse({ image: { type: "image", source: URL_SRC } });
+  assert.match(beatToHtml(withNeither, { idPrefix: "b" })!.html, /alt=""/);
+});


### PR DESCRIPTION
## Summary

image / movie beat をブラウザ host が注入できる fragment にしました。`#1526` の PR 8-9 です。

- `src/utils/image_plugins/media_html.ts`（新規, pure）— `mediaSrc` / `imageHtml` / `movieHtml`
- `src/utils/beat_html/media.ts`（新規）— `imageToHtml` / `movieToHtml`
- `movie.ts` を共有 markup 経由に（**src のエスケープが入ります**）
- `supportedBeatTypes` に `image` / `movie` を登録

## Items to Confirm / Review

### 1. remote 判定は入れていません（ご指示どおり）

> remoteの判定はとくにいれなくてもよいかも。ユーザがremoteを指定する前提でよい！！

source が名指す src をそのまま出します:

| kind | src |
|---|---|
| `url` | その URL |
| `path` | そのまま出し、**host が自分のページ基準で解決** |
| `base64` | スキーマに media type が無く `data:` URI を組めないので描画しない |

### 2. `movie.ts` の src が無エスケープでした（Node 経路の変更を含みます）

`URLStringSchema` は `z.url()` ですが、**引用符を通します**（実測）:

| URL | スキーマ |
|---|---|
| `https://e.com/a.mp4" onerror="pwn()` | 🔴 通る |
| `javascript:alert(1)` | 🔴 通る |

既存 `movie.ts` の `src="${url}"` は属性を抜け出せます。#1535 の一族なので、共有 markup 側で塞ぎました。

**通常 URL への影響はゼロです**（実測）: `?x=1&y=2` は属性上 `&amp;` になりますが、**ブラウザは `?x=1&y=2` を取りに行きます**。

| | |
|---|---|
| HTML 上の属性値 | `https://e.com/a.mp4?x=1&y=2`（パーサが復号） |
| 実際のリクエスト URL | `https://e.com/a.mp4?x=1&y=2` ← **変化なし** |

URL 8 種で測って**バイトが変わるのは 3 件**、うち通常コンテンツは `&` を含む1件だけで、上記のとおり機能影響はありません。

### 3. alt をどこから取るか

`MulmoImageMedia` は `{ type, source }` だけで代替テキストを持ちません。dispatcher が `beat.description ?? beat.text ?? ""` を渡します — このモジュールが届く範囲で唯一の「絵の説明」です。`alt` 無しの `<img>` はスクリーンリーダーがファイル名を読み上げるので、空でも付ける方がましという判断です。

**より良い出所があればそちらに変えます。**

### 4. image と movie を 1 PR にしました

`mediaSrc` と「メディア beat が要素になる」という同じ不変条件を共有しており、別々に revert する意味が薄いためです。細かく分ける方針に反するので、判断が違えば分けます。

### 5. 実ブラウザで確認しました

| | 結果 |
|---|---|
| fragment | 4 beat 中 3 件（base64 は想定どおり `undefined`） |
| 敵対的 URL | 🟢 XSS なし（属性内に留まり percent-encode されてリクエスト） |
| `?x=1&y=2` | **リクエスト URL がバイト一致** |
| alt | `description` から取得、無ければ空 |
| 描画 | img 2件 / video 1件、pageerror なし |

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1142 tests, 0 fail**
- browser-safety ゲート **7/7 pass**
- **変異5種すべてで赤くなることを確認**。最初 `<video>` の src エスケープが **fail=0（未カバー）** で、`<img>` しか敵対的 URL を試していませんでした。3つの `<source>` すべてを見るテストを足して埋めています。

  | 変異 | 追加前 | 追加後 |
  |---|---|---|
  | `<img>` の src エスケープを外す | fail=1 | fail=1 |
  | alt エスケープを外す | fail=1 | fail=1 |
  | **`<video>` の src エスケープを外す** | **fail=0 🔴** | fail=1 ✅ |
  | `path` 対応を外す | fail=1 | fail=1 |
  | alt を常に空にする | fail=1 | fail=1 |

## User Prompt

> b
>
> remoteの判定はとくにいれなくてもよいかも。ユーザがremoteを指定する前提でよい！！

Refs #1526, #1535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML rendering for image and movie content.
  * Supports media from URLs, local paths, and embedded data sources.
  * Images include accessible alternate text with sensible fallbacks.
  * Movie output supports multiple video formats and responsive display.

* **Bug Fixes**
  * Escapes media URLs and alternate text to prevent malformed or unsafe HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->