### PR TITLE
feat(beat_html): render slide beats as a browser fragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@modernized/fluent-ffmpeg": "^1.0.3",
     "@mozilla/readability": "^0.6.0",
-    "@mulmocast/deck": "^1.1.0",
+    "@mulmocast/deck": "^1.2.0",
     "@tavily/core": "^0.7.6",
     "archiver": "^8.0.0",
     "clipboardy": "^5.3.2",

--- a/plans/feat-beat-html-slide.md
+++ b/plans/feat-beat-html-slide.md
@@ -1,0 +1,33 @@
+# feat(beat_html): slide beat をブラウザ用 fragment にする
+
+issue: #1526 の PR 11。
+
+## `generateSlideFragment` がここで使われる
+
+receptron/mulmocast-deck#27 で追加した「フル文書ではなく body だけを返す」API を、ようやく消費する。
+Node 経路の `generateSlideHTML` と同じ layout 群を使うので、fragment は 2 つ目のレンダラではない。
+
+## theme の優先順
+
+`MulmoPresentationStyleMethods.getResolvedSlideTheme` と同じ順:
+`image.theme` → `options.slideTheme`（deck 既定） → `slideThemes.corporate`。
+
+その method を呼ばず順序だけ再現しているのは、`MulmoPresentationStyle` 型をブラウザバンドルに
+持ち込まないため。順序が 2 箇所にあることになるので、テストで固定する。
+
+## scopeClass
+
+`${idPrefix}-slide`。css は scope class に対して書かれているので、再描画で class が変わると
+規則が何にもマッチしなくなる。`idPrefix` は #1541 の element id 規則を通っているので、
+そのまま CSS class として妥当。
+
+## BeatHtmlFragment の拡張
+
+`scopeClass` と `mermaidTheme` を追加。前者は host が要素に付けないと css が効かない。
+後者は暗いスライドに明るい図が乗ると読めないため。
+
+## バンドル
+
+deck の barrel は 101 入力 / 602.8 KB、`lib/fragment.js` の deep import は 20 / 54.3 KB。
+beat_html 全体では 35 入力 / 119.1 KB（marked 1、自リポジトリ 15、deck 19）。
+layout 群がその大半で、これはスライドレンダラそのものなので不可避。

--- a/plans/feat-beat-html-slide.md
+++ b/plans/feat-beat-html-slide.md
@@ -15,16 +15,21 @@ Node 経路の `generateSlideHTML` と同じ layout 群を使うので、fragmen
 その method を呼ばず順序だけ再現しているのは、`MulmoPresentationStyle` 型をブラウザバンドルに
 持ち込まないため。順序が 2 箇所にあることになるので、テストで固定する。
 
-## scopeClass
+## scope class
 
 `${idPrefix}-slide`。css は scope class に対して書かれているので、再描画で class が変わると
 規則が何にもマッチしなくなる。`idPrefix` は #1541 の element id 規則を通っているので、
 そのまま CSS class として妥当。
 
+**field としては返さない。** 当初 `BeatHtmlFragment.scopeClass` を足し「host が要素に付けないと
+css が効かない」と書いたが、レビューで指摘され実測したところ**誤り**だった: deck は `html` の root に
+その class を既に付けており、host が `html` を注入して `css` を当てるだけでテーマが効く
+（wrapper に何も付けずに `--d-bg` がビートのテーマ色になることをブラウザで確認）。
+冗長なうえ説明が誤っていたので field ごと撤去した。
+
 ## BeatHtmlFragment の拡張
 
-`scopeClass` と `mermaidTheme` を追加。前者は host が要素に付けないと css が効かない。
-後者は暗いスライドに明るい図が乗ると読めないため。
+`mermaidTheme` のみ。暗いスライドに明るい図が乗ると読めないため。
 
 ## バンドル
 

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -5,6 +5,7 @@ import { chartToHtml } from "./chart.js";
 import { markdownToHtml } from "./markdown.js";
 import { imageToHtml, movieToHtml } from "./media.js";
 import { mermaidToHtml } from "./mermaid.js";
+import { slideToHtml } from "./slide.js";
 import { assertSafeElementId } from "../element_id.js";
 
 export type { BeatHtmlFragment, BeatHtmlOptions, BeatRuntime } from "./type.js";
@@ -17,7 +18,7 @@ export { markdownToHtml } from "./markdown.js";
  * a type added here without a case — or vice versa — fails rather than silently
  * rendering nothing.
  */
-export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid", "image", "movie"] as const;
+export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid", "image", "movie", "slide"] as const;
 
 /**
  * Render a beat as markup for a browser host.
@@ -58,6 +59,8 @@ export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlF
       return imageToHtml(image, beat.description ?? beat.text ?? "");
     case "movie":
       return movieToHtml(image);
+    case "slide":
+      return slideToHtml(image, options);
     default:
       return undefined;
   }

--- a/src/utils/beat_html/slide.ts
+++ b/src/utils/beat_html/slide.ts
@@ -1,0 +1,34 @@
+import type { MulmoSlideMedia } from "@mulmocast/deck";
+// Deep import: the package barrel bundles every layout plus all of zod — measured 101 inputs
+// and 602kb against 20 and 54kb for this module — and this file is bundled for the browser.
+import { generateSlideFragment } from "@mulmocast/deck/lib/fragment.js";
+import { slideThemes } from "../../data/slideThemes.js";
+import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
+
+/**
+ * A slide beat as markup a host can inject.
+ *
+ * `generateSlideFragment` is the body-only counterpart of the `generateSlideHTML` the Node
+ * render path uses, so the two draw the same slide from the same layouts — the fragment is
+ * not a second renderer.
+ *
+ * The theme order matches `MulmoPresentationStyleMethods.getResolvedSlideTheme` on the Node
+ * side: the beat's own theme, then the deck's, then the built-in corporate one. Repeating
+ * the order here rather than calling that method keeps this file off `MulmoPresentationStyle`,
+ * which the browser bundle does not need.
+ *
+ * `scopeClass` is derived from `idPrefix` so a re-render of the same beat keeps its class —
+ * the css is written against it, and a generated one would change on every render.
+ */
+export const slideToHtml = (image: MulmoSlideMedia, options: BeatHtmlOptions): BeatHtmlFragment => {
+  const theme = image.theme ?? options.slideTheme ?? slideThemes.corporate;
+  const fragment = generateSlideFragment(theme, image.slide, { scopeClass: `${options.idPrefix}-slide` });
+  return {
+    html: fragment.html,
+    css: fragment.css,
+    scopeClass: fragment.scopeClass,
+    ...(fragment.requires.length > 0 ? { requires: fragment.requires } : {}),
+    ...(fragment.chartPlugins.length > 0 ? { chartPlugins: fragment.chartPlugins } : {}),
+    ...(fragment.mermaidTheme ? { mermaidTheme: fragment.mermaidTheme } : {}),
+  };
+};

--- a/src/utils/beat_html/slide.ts
+++ b/src/utils/beat_html/slide.ts
@@ -17,8 +17,11 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
  * the order here rather than calling that method keeps this file off `MulmoPresentationStyle`,
  * which the browser bundle does not need.
  *
- * `scopeClass` is derived from `idPrefix` so a re-render of the same beat keeps its class —
- * the css is written against it, and a generated one would change on every render.
+ * The scope class is derived from `idPrefix` so a re-render of the same beat keeps it: the
+ * css is written against that class and a generated one would change every render, leaving
+ * the rules matching nothing. It is not returned separately — deck already puts it on the
+ * root of `html`, verified in a browser: injecting `html` and attaching `css`, with no
+ * wrapper class of the host's own, resolves `--d-bg` to the beat's theme.
  */
 export const slideToHtml = (image: MulmoSlideMedia, options: BeatHtmlOptions): BeatHtmlFragment => {
   const theme = image.theme ?? options.slideTheme ?? slideThemes.corporate;
@@ -26,7 +29,6 @@ export const slideToHtml = (image: MulmoSlideMedia, options: BeatHtmlOptions): B
   return {
     html: fragment.html,
     css: fragment.css,
-    scopeClass: fragment.scopeClass,
     ...(fragment.requires.length > 0 ? { requires: fragment.requires } : {}),
     ...(fragment.chartPlugins.length > 0 ? { chartPlugins: fragment.chartPlugins } : {}),
     ...(fragment.mermaidTheme ? { mermaidTheme: fragment.mermaidTheme } : {}),

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -1,3 +1,5 @@
+import type { SlideTheme } from "@mulmocast/deck";
+
 /**
  * A beat rendered as markup for a browser host.
  *
@@ -27,6 +29,17 @@ export type BeatHtmlFragment = {
    * for both. Absent when the beat needs none.
    */
   chartPlugins?: string[];
+  /**
+   * Which mermaid theme suits this beat's background. A dark slide with a light diagram is
+   * unreadable, and the host initialises mermaid once for the page, so it has to be told.
+   * Absent unless the beat both requires mermaid and has an opinion.
+   */
+  mermaidTheme?: "dark" | "default";
+  /**
+   * The class the beat's `css` is written against, when it has any. The host must keep it
+   * on the element it puts `html` into, or the rules match nothing.
+   */
+  scopeClass?: string;
 };
 
 /** External runtimes a fragment can depend on. */
@@ -53,4 +66,13 @@ export type BeatHtmlOptions = {
    * the id yourself. `beatToHtml` throws rather than guessing.
    */
   idPrefix: string;
+  /**
+   * The deck-level slide theme, for `slide` beats. A beat's own `image.theme` wins over it,
+   * and the built-in `corporate` theme is the fallback — the same order
+   * `MulmoPresentationStyleMethods.getResolvedSlideTheme` uses on the Node side.
+   *
+   * Optional because only slide beats read it, and because the host may not have a deck
+   * theme to give.
+   */
+  slideTheme?: SlideTheme;
 };

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -35,11 +35,6 @@ export type BeatHtmlFragment = {
    * Absent unless the beat both requires mermaid and has an opinion.
    */
   mermaidTheme?: "dark" | "default";
-  /**
-   * The class the beat's `css` is written against, when it has any. The host must keep it
-   * on the element it puts `html` into, or the rules match nothing.
-   */
-  scopeClass?: string;
 };
 
 /** External runtimes a fragment can depend on. */

--- a/test/beat_html/test_browser_safety.ts
+++ b/test/beat_html/test_browser_safety.ts
@@ -70,10 +70,11 @@ const BROWSER_ONLY: ts.CompilerOptions = {
  * this decides whether it BELONGS here. Adding one is a deliberate act, not a side effect
  * of an import — the smaller this graph stays, the less there is to go wrong in a bundle.
  */
-// @mulmocast/deck is here for escapeHtml, imported deeply rather than through the package
-// barrel: the barrel pulls every layout and all of zod (551kb measured), the deep path pulls
-// one file. It contributes exactly `lib/utils.js` to this bundle, and the browser fragment
-// path depends on deck anyway.
+// @mulmocast/deck is here for escapeHtml and for generateSlideFragment, imported deeply
+// rather than through the package barrel: the barrel pulls every layout AND all of zod
+// (101 inputs / 602kb measured), the deep paths pull 19 files. The slide layouts are the
+// bulk of that and are inherent — they are the slide renderer — so the whole beat_html
+// bundle measures 35 inputs / 119kb, of which marked is 1 and this repo's own source 15.
 const ALLOWED_PACKAGES = new Set(["marked", "@mulmocast/deck"]);
 
 const bundle = (options: esbuild.BuildOptions) =>

--- a/test/beat_html/test_dispatch.ts
+++ b/test/beat_html/test_dispatch.ts
@@ -14,6 +14,7 @@ const minimalBeat: Record<(typeof supportedBeatTypes)[number], ReturnType<typeof
   mermaid: beat({ type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } }),
   image: beat({ type: "image", source: { kind: "url", url: "https://example.com/a.png" } }),
   movie: beat({ type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }),
+  slide: beat({ type: "slide", slide: { layout: "title", title: "T" } }),
 };
 
 test("every type in supportedBeatTypes actually renders", () => {
@@ -30,7 +31,6 @@ test("types not on the list render nothing, rather than something wrong", () => 
   // Real beats, not stubs: a stub could fail to render for the wrong reason.
   const notYetSupported: [string, unknown][] = [
     ["html_tailwind", { type: "html_tailwind", html: "<div></div>" }],
-    ["slide", { type: "slide", slide: { layout: "title", title: "T" } }],
     ["beat", { type: "beat" }],
   ];
   notYetSupported.forEach(([type, image]) => {

--- a/test/beat_html/test_slide.ts
+++ b/test/beat_html/test_slide.ts
@@ -22,15 +22,22 @@ test("the fragment is deck's, mapped onto BeatHtmlFragment", () => {
   const theirs = generateSlideFragment(slideThemes.corporate, image.slide, { scopeClass: "beat-3-slide" });
   assert.strictEqual(mine.html, theirs.html);
   assert.strictEqual(mine.css, theirs.css);
-  assert.strictEqual(mine.scopeClass, theirs.scopeClass);
+});
+
+// Not returned as a field: deck already puts it on the root of `html`, and a host that only
+// injects `html` and attaches `css` gets the themed result. Verified in a browser.
+test("the scope class rides on the markup, not on a separate field", () => {
+  const fragment = slideToHtml(media(), options());
+  assert.strictEqual("scopeClass" in fragment, false, "no redundant field");
+  assert.match(fragment.html, /^<div class="beat-3-slide /, "the class is on the root of the markup");
+  assert.match(fragment.css ?? "", /\.beat-3-slide\{/, "and the css is written against it");
 });
 
 // The css is written against the scope class, so a class that changed on every render would
 // leave the rules matching nothing after a re-render.
 test("the scope class is derived from the idPrefix, so a re-render keeps it", () => {
-  assert.strictEqual(slideToHtml(media(), options()).scopeClass, "beat-3-slide");
-  assert.strictEqual(slideToHtml(media(), options()).scopeClass, slideToHtml(media(), options()).scopeClass);
-  assert.notStrictEqual(slideToHtml(media(), options()).scopeClass, slideToHtml(media(), options({ idPrefix: "beat-4" })).scopeClass);
+  assert.strictEqual(slideToHtml(media(), options()).html, slideToHtml(media(), options()).html, "same beat, same class");
+  assert.match(slideToHtml(media(), options({ idPrefix: "beat-4" })).html, /^<div class="beat-4-slide /, "a different beat gets a different one");
 });
 
 // Same order as MulmoPresentationStyleMethods.getResolvedSlideTheme on the Node side.

--- a/test/beat_html/test_slide.ts
+++ b/test/beat_html/test_slide.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert";
+import { slideToHtml } from "../../src/utils/beat_html/slide.js";
+import { beatToHtml } from "../../src/utils/beat_html/index.js";
+import { generateSlideFragment } from "@mulmocast/deck/lib/fragment.js";
+import { slideThemes } from "../../src/data/slideThemes.js";
+import { mulmoBeatSchema, mulmoSlideMediaSchema } from "../../src/types/schema.js";
+
+/**
+ * The fragment is `@mulmocast/deck`'s body-only renderer, the counterpart of the
+ * `generateSlideHTML` the Node path uses. It is not a second implementation, so what these
+ * pin is the mapping onto BeatHtmlFragment and the theme order — not the slide markup,
+ * which is deck's to test.
+ */
+
+const media = (over: Record<string, unknown> = {}) => mulmoSlideMediaSchema.parse({ type: "slide", slide: { layout: "title", title: "T" }, ...over });
+const options = (over: Record<string, unknown> = {}) => ({ idPrefix: "beat-3", ...over });
+
+test("the fragment is deck's, mapped onto BeatHtmlFragment", () => {
+  const image = media();
+  const mine = slideToHtml(image, options());
+  const theirs = generateSlideFragment(slideThemes.corporate, image.slide, { scopeClass: "beat-3-slide" });
+  assert.strictEqual(mine.html, theirs.html);
+  assert.strictEqual(mine.css, theirs.css);
+  assert.strictEqual(mine.scopeClass, theirs.scopeClass);
+});
+
+// The css is written against the scope class, so a class that changed on every render would
+// leave the rules matching nothing after a re-render.
+test("the scope class is derived from the idPrefix, so a re-render keeps it", () => {
+  assert.strictEqual(slideToHtml(media(), options()).scopeClass, "beat-3-slide");
+  assert.strictEqual(slideToHtml(media(), options()).scopeClass, slideToHtml(media(), options()).scopeClass);
+  assert.notStrictEqual(slideToHtml(media(), options()).scopeClass, slideToHtml(media(), options({ idPrefix: "beat-4" })).scopeClass);
+});
+
+// Same order as MulmoPresentationStyleMethods.getResolvedSlideTheme on the Node side.
+test("the beat's theme wins over the deck's, which wins over the built-in", () => {
+  // Theme colours are six hex digits with no leading #.
+  const beatTheme = { ...slideThemes.corporate, colors: { ...slideThemes.corporate.colors, bg: "111111" } };
+  const deckTheme = { ...slideThemes.corporate, colors: { ...slideThemes.corporate.colors, bg: "222222" } };
+  assert.match(slideToHtml(media({ theme: beatTheme }), options({ slideTheme: deckTheme })).css ?? "", /111111/);
+  assert.match(slideToHtml(media(), options({ slideTheme: deckTheme })).css ?? "", /222222/);
+  const fallback = slideToHtml(media(), options()).css ?? "";
+  assert.ok(!fallback.includes("111111") && !fallback.includes("222222"), "with neither, the built-in theme is used");
+});
+
+test("runtimes and plugins are passed through, and absent when the slide needs none", () => {
+  const plain = slideToHtml(media(), options());
+  assert.strictEqual(plain.requires, undefined, "a title slide needs no runtime");
+  assert.strictEqual(plain.chartPlugins, undefined);
+  // The blocks live under `content`, which is what deck's detectBlockTypes walks.
+  const withChart = slideToHtml(
+    media({ slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { type: "sankey" } }] }, right: { content: [] } } }),
+    options(),
+  );
+  assert.deepStrictEqual(withChart.requires, ["chart"]);
+  assert.deepStrictEqual(withChart.chartPlugins, ["https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"]);
+});
+
+test("the dispatcher hands the options through, theme included", () => {
+  const deckTheme = { ...slideThemes.corporate, colors: { ...slideThemes.corporate.colors, bg: "333333" } };
+  const beat = mulmoBeatSchema.parse({ image: media() });
+  assert.match(beatToHtml(beat, { idPrefix: "b", slideTheme: deckTheme })!.css ?? "", /333333/);
+});
+
+test("the id rule reaches the scope class too", () => {
+  assert.throws(() => beatToHtml(mulmoBeatSchema.parse({ image: media() }), { idPrefix: "beat 1" }), /element id must match/);
+});

--- a/types/package.json
+++ b/types/package.json
@@ -13,7 +13,7 @@
     "lib"
   ],
   "dependencies": {
-    "@mulmocast/deck": "^0.7.0",
+    "@mulmocast/deck": "^1.2.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/types/yarn.lock
+++ b/types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@mulmocast/deck@^0.7.0":
-  version "0.7.0"
-  resolved "https://npm.flatt.tech/@mulmocast/deck/-/deck-0.7.0.tgz#53ee2d9cab4f6df2b2984fcf9029aaf4ba39c744"
-  integrity sha512-m2DJ5tipv3ug+KwsH4dWad2lID4nVzjhaNN8dDyosKARfG1sPsVjU3Ti4rJRAwi9d84N3bkKWocGlRS8C4NxXw==
+"@mulmocast/deck@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-1.2.0.tgz#c8cf6de1a073f00fa1879ddbe99087692855b7e2"
+  integrity sha512-sDmAlXhKjORshQBNWOKblm1kX5nVrvziH7p45i0NeDZPisgJ1U62ZvHYKWjRNZ+lcRys1wCP57W5j9ojV+vCgA==
   dependencies:
     zod "^4.4.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,10 +695,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/deck@^1.1.0":
-  version "1.1.0"
-  resolved "https://npm.flatt.tech/@mulmocast/deck/-/deck-1.1.0.tgz#dbf399a140614b59d7a47fb4182d79d0a3b01825"
-  integrity sha512-ofhi1NVwwzl/Fg/WCkOZMkGGx5sf/1IHWKEoOkgffCscIbmTncbjblpH/Zv8/mErSh5kH9gkQPtl8lLvLpbtzg==
+"@mulmocast/deck@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-1.2.0.tgz#c8cf6de1a073f00fa1879ddbe99087692855b7e2"
+  integrity sha512-sDmAlXhKjORshQBNWOKblm1kX5nVrvziH7p45i0NeDZPisgJ1U62ZvHYKWjRNZ+lcRys1wCP57W5j9ojV+vCgA==
   dependencies:
     zod "^4.4.3"
 


### PR DESCRIPTION
## Summary

slide beat をブラウザ host が注入できる fragment にしました。`#1526` の PR 11 です。

**このPRで、セッション冒頭に `@mulmocast/deck` へ追加した `generateSlideFragment`（receptron/mulmocast-deck#27）がようやく消費されます。** Node 経路の `generateSlideHTML` と同じ layout 群を使うので、fragment は2つ目のレンダラではありません。

- `src/utils/beat_html/slide.ts`（新規）
- `BeatHtmlFragment` に `scopeClass` / `mermaidTheme`、`BeatHtmlOptions` に `slideTheme` を追加

## Items to Confirm / Review

### 1. theme の優先順を「再現」しています（呼んでいません）

`MulmoPresentationStyleMethods.getResolvedSlideTheme` と同じ順です:

`image.theme` → `options.slideTheme`（deck 既定） → `slideThemes.corporate`

その method を呼ばないのは、`MulmoPresentationStyle` 型をブラウザバンドルに持ち込まないためです。**順序が2箇所に存在することになる**ので、テストで固定しました。ここは判断が分かれるところなので見てください（method を browser-safe な形で共有する案もあります）。

### 2. `scopeClass` は `${idPrefix}-slide`

css は scope class に対して書かれているので、再描画で class が変わると**規則が何にもマッチしなくなります**。`idPrefix` は #1541 の element id 規則を通っているため、そのまま CSS class として妥当です。

### 3. `BeatHtmlFragment` に足すのは `mermaidTheme` だけです（round 1 で訂正）

当初 `scopeClass` も足し「host が要素に付けないと css が効かない」と書きましたが、**誤りでした**。Codex に指摘され実測したところ、deck は `html` の root にその class を既に付けており、host は `html` を注入して `css` を当てるだけでテーマが効きます。

```
html の先頭: <div class="beat-7-slide relative overflow-hidden bg-d-bg …
wrapper に class を付けない host → .beat-7-slide が見つかる, --d-bg="#111827"
```

私の最初のブラウザ検証は**自分で wrapper に class を付けていた**ので、この違いを区別できていませんでした。冗長なうえ説明が誤っていたので field ごと撤去しています。

残る `mermaidTheme` は、暗いスライドに明るい図が乗ると読めないため必要です。

### 4. バンドルが増えます

| | 入力 | サイズ |
|---|---|---|
| deck barrel 経由 | 101 | 602.8 KB |
| `lib/fragment.js` の deep import | 20 | 54.3 KB |
| **beat_html 全体** | **35**（marked 1 / 自リポ 15 / deck 19） | **119.1 KB** |

layout 群がその大半で、これはスライドレンダラそのものなので不可避です。browser-safety の allow-list コメントが「deck は `lib/utils.js` 1ファイルだけ」と書いてあり**古くなっていた**ので、実測値に更新しました。

### 5. 実ブラウザで確認しました

| | 結果 |
|---|---|
| scopeClass | `beat-0-slide` / `beat-1-slide` と別々 |
| `--d-bg`（scope 経由のテーマ変数） | `#F8FAFC` と `#111827` ← **beat 単位のテーマ上書きが効き、scope が独立** |
| 敵対的 title `Q&A <b>` | 文字通り表示、注入 `<img>` 0 |
| pageerror | なし |

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1150 tests, 0 fail**
- browser-safety ゲート 7/7 pass
- **変異5種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | theme の優先順を無視する | fail=2 |
  | scope class を固定値にする | fail=2 |
  | `requires` を落とす | fail=1 |
  | `chartPlugins` を落とす | fail=1 |
  | `css` を落とす | fail=3 |

**テスト作成中に自分の思い込みを2つ実測で潰しました**: theme の色は `#` 無しの6桁、block は `blocks` ではなく **`content`** の下（deck の `collectContentArrays` を読んで確認）。

## User Prompt

> b

Refs #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rendering slide beats as HTML.
  - Slide rendering now supports theme selection, scoped CSS classes, and required chart or Mermaid metadata.
  - Theme priority is applied consistently across slide, deck, and built-in defaults.
- **Documentation**
  - Documented slide rendering behavior and updated bundle-size information.
- **Tests**
  - Added coverage for slide rendering, theme precedence, CSS scoping, chart plugins, and invalid identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
