### PR TITLE
feat(beat_html): render html_tailwind beats as a browser fragment

### DIFF
--- a/plans/feat-beat-html-tailwind.md
+++ b/plans/feat-beat-html-tailwind.md
@@ -1,0 +1,32 @@
+# feat(beat_html): html_tailwind beat をブラウザ用 fragment にする
+
+issue: #1526 の PR 13。これで対応 beat 種別は 8/8。
+
+## 設計判断は既に存在していた
+
+Node の `dumpHtml` は既に **script を出さず静的マークアップだけ**を返している
+（`elements` があれば `swipeElementsToHtml`、無ければ著者の `html`）。
+ブラウザ側も同じにするだけで、新しい判断は要らなかった。
+
+script を出せない理由はブラウザ側でさらに強い: `innerHTML` 経由で注入された `<script>` は実行されない。
+著者の `script`、swipe のアニメーション駆動、frame ベースの `animation` はいずれも
+スクリプト実行を要するので、両経路とも「静止状態の beat」を見せる。
+
+## 著者の html はエスケープしない
+
+この beat 種別では**マークアップが中身**で、スキーマは `script` も受け付ける。
+エスケープすると機能が消えるだけで、著者が持っていない能力を防ぐわけではない。
+`BeatHtmlFragment.html` の「サニタイズしない」契約が最も効く箇所。
+
+## `as` キャストを型ガードに置き換えた
+
+`dumpHtml` は `beat.image as { elements?: SwipeElement[] }` としていた。
+`swipeElementSchema` が `z.lazy` のため `z.ZodType` と注釈され、`z.array(...)` が `unknown[]` になるのが原因。
+
+`SwipeElement` は**全フィールドが optional** なので「各要素が非 null のオブジェクト」を確かめる
+`isSwipeElements` は構造的に健全な narrowing になる（キャストの言い換えではない）。
+zod は parse 時に既に形を検証しているので、これは型の穴を埋めるだけのもの。
+
+## 検証
+
+Node 経路の挙動不変を差分ハーネスで実測する。

--- a/src/utils/beat_html/html_tailwind.ts
+++ b/src/utils/beat_html/html_tailwind.ts
@@ -1,0 +1,23 @@
+import type { z } from "zod";
+import type { mulmoHtmlTailwindMediaSchema } from "../../types/schema.js";
+import { htmlTailwindMarkup } from "../image_plugins/html_tailwind_markup.js";
+import type { BeatHtmlFragment } from "./type.js";
+
+/**
+ * An html_tailwind beat as markup a host can inject.
+ *
+ * The beat at rest, with no script — the same thing the Node dump path shows. The author's
+ * `script`, the swipe animation driver and the frame-based `animation` all need script
+ * execution, which a fragment injected through `innerHTML` cannot do and which the dump
+ * path has never emitted either. A beat whose only content is an animation therefore shows
+ * its elements in their starting positions rather than nothing.
+ *
+ * The author's html is emitted as written. On this beat type markup IS the content — the
+ * schema also accepts `script` — so escaping it would remove the feature rather than a
+ * capability the author lacks. `BeatHtmlFragment.html` says the markup is not sanitized;
+ * this is the beat type where that matters most.
+ */
+export const htmlTailwindToHtml = (image: z.infer<typeof mulmoHtmlTailwindMediaSchema>): BeatHtmlFragment | undefined => {
+  const html = htmlTailwindMarkup(image);
+  return html === "" ? undefined : { html };
+};

--- a/src/utils/beat_html/index.ts
+++ b/src/utils/beat_html/index.ts
@@ -3,6 +3,7 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
 import { textSlideToHtml } from "./text_slide.js";
 import { chartToHtml } from "./chart.js";
 import { markdownToHtml } from "./markdown.js";
+import { htmlTailwindToHtml } from "./html_tailwind.js";
 import { imageToHtml, movieToHtml } from "./media.js";
 import { mermaidToHtml } from "./mermaid.js";
 import { slideToHtml } from "./slide.js";
@@ -18,7 +19,7 @@ export { markdownToHtml } from "./markdown.js";
  * a type added here without a case — or vice versa — fails rather than silently
  * rendering nothing.
  */
-export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid", "image", "movie", "slide"] as const;
+export const supportedBeatTypes = ["textSlide", "markdown", "chart", "mermaid", "image", "movie", "slide", "html_tailwind"] as const;
 
 /**
  * Render a beat as markup for a browser host.
@@ -61,6 +62,8 @@ export const beatToHtml = (beat: MulmoBeat, options: BeatHtmlOptions): BeatHtmlF
       return movieToHtml(image);
     case "slide":
       return slideToHtml(image, options);
+    case "html_tailwind":
+      return htmlTailwindToHtml(image);
     default:
       return undefined;
   }

--- a/src/utils/image_plugins/html_tailwind.ts
+++ b/src/utils/image_plugins/html_tailwind.ts
@@ -7,6 +7,7 @@ import { renderHTMLToImage, interpolate, renderHTMLToFrames, renderHTMLToVideo, 
 import { framesToVideo } from "../ffmpeg_utils.js";
 import { parrotingImagePath } from "./utils.js";
 import { swipeElementsToHtml, swipeElementsToScript, type SwipeElement } from "../swipe_to_html.js";
+import { htmlTailwindMarkup } from "./html_tailwind_markup.js";
 
 export const imageType = "html_tailwind";
 
@@ -251,11 +252,7 @@ const processHtmlTailwind = async (params: ImageProcessorParams) => {
 const dumpHtml = async (params: ImageProcessorParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
-  const imageData = beat.image as { html?: string | string[]; elements?: SwipeElement[] };
-  if (imageData.elements && Array.isArray(imageData.elements) && imageData.elements.length > 0) {
-    return swipeElementsToHtml(imageData.elements);
-  }
-  return joinHtml(imageData.html ?? "");
+  return htmlTailwindMarkup(beat.image);
 };
 
 export const process = processHtmlTailwind;

--- a/src/utils/image_plugins/html_tailwind_markup.ts
+++ b/src/utils/image_plugins/html_tailwind_markup.ts
@@ -1,0 +1,27 @@
+import { isSwipeElements, swipeElementsToHtml } from "../swipe_to_html.js";
+
+/**
+ * The static markup an html_tailwind beat shows. Pure — no Node, no filesystem — because the
+ * Node dump path and the browser fragment path show the same thing.
+ *
+ * Deliberately no `<script>`: the author's `script`, the swipe animation driver and the
+ * frame-based `animation` all need script execution, which the dump path has never emitted
+ * and which a fragment injected through `innerHTML` could not run anyway. Both paths show
+ * the beat's markup at rest.
+ *
+ * The author's `html` is emitted as written. It is markup by design on this beat type — the
+ * schema also accepts a `script` — so escaping it would break the feature rather than
+ * protect anything the author does not already have.
+ */
+export type HtmlTailwindMarkupSource = {
+  html?: string | string[];
+  elements?: unknown[];
+};
+
+export const htmlTailwindMarkup = (image: HtmlTailwindMarkupSource): string => {
+  if (image.elements && image.elements.length > 0 && isSwipeElements(image.elements)) {
+    return swipeElementsToHtml(image.elements);
+  }
+  const html = image.html ?? "";
+  return Array.isArray(html) ? html.join("\n") : html;
+};

--- a/src/utils/image_plugins/html_tailwind_markup.ts
+++ b/src/utils/image_plugins/html_tailwind_markup.ts
@@ -15,11 +15,11 @@ import { isSwipeElements, swipeElementsToHtml } from "../swipe_to_html.js";
  */
 export type HtmlTailwindMarkupSource = {
   html?: string | string[];
-  elements?: unknown[];
+  elements?: unknown;
 };
 
 export const htmlTailwindMarkup = (image: HtmlTailwindMarkupSource): string => {
-  if (image.elements && image.elements.length > 0 && isSwipeElements(image.elements)) {
+  if (isSwipeElements(image.elements) && image.elements.length > 0) {
     return swipeElementsToHtml(image.elements);
   }
   const html = image.html ?? "";

--- a/src/utils/swipe_to_html.ts
+++ b/src/utils/swipe_to_html.ts
@@ -69,6 +69,15 @@ const escapeHtml = (str: string): string => {
  * Not a privilege boundary: `html_tailwind` accepts an author's own `script` by design, so
  * an author already has that capability. This is here so the two contexts agree.
  */
+/**
+ * Bridges a TypeScript gap, not a validation gap: `swipeElementSchema` is declared
+ * `z.ZodType` because it is recursive through `z.lazy`, so `z.array(...)` infers `unknown[]`
+ * and the shape zod already checked at parse time is lost to the compiler. Every field of
+ * SwipeElement is optional, so any object satisfies it structurally — which is what makes
+ * this a sound narrowing rather than a cast wearing a guard's clothes.
+ */
+export const isSwipeElements = (value: unknown[]): value is SwipeElement[] => value.every((entry) => typeof entry === "object" && entry !== null);
+
 const elementId = (el: SwipeElement, index: number): string => {
   const id = el.id ?? `swipe_el_${index}`;
   assertSafeElementId(id);

--- a/src/utils/swipe_to_html.ts
+++ b/src/utils/swipe_to_html.ts
@@ -76,7 +76,8 @@ const escapeHtml = (str: string): string => {
  * SwipeElement is optional, so any object satisfies it structurally — which is what makes
  * this a sound narrowing rather than a cast wearing a guard's clothes.
  */
-export const isSwipeElements = (value: unknown[]): value is SwipeElement[] => value.every((entry) => typeof entry === "object" && entry !== null);
+export const isSwipeElements = (value: unknown): value is SwipeElement[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "object" && entry !== null);
 
 const elementId = (el: SwipeElement, index: number): string => {
   const id = el.id ?? `swipe_el_${index}`;

--- a/test/beat_html/test_dispatch.ts
+++ b/test/beat_html/test_dispatch.ts
@@ -15,6 +15,7 @@ const minimalBeat: Record<(typeof supportedBeatTypes)[number], ReturnType<typeof
   image: beat({ type: "image", source: { kind: "url", url: "https://example.com/a.png" } }),
   movie: beat({ type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } }),
   slide: beat({ type: "slide", slide: { layout: "title", title: "T" } }),
+  html_tailwind: beat({ type: "html_tailwind", html: "<div>T</div>" }),
 };
 
 test("every type in supportedBeatTypes actually renders", () => {
@@ -29,10 +30,7 @@ test("types not on the list render nothing, rather than something wrong", () => 
   // The list and the dispatcher are separate declarations; this is what keeps them honest.
   // As each of these lands in a later PR it moves into supportedBeatTypes and out of here.
   // Real beats, not stubs: a stub could fail to render for the wrong reason.
-  const notYetSupported: [string, unknown][] = [
-    ["html_tailwind", { type: "html_tailwind", html: "<div></div>" }],
-    ["beat", { type: "beat" }],
-  ];
+  const notYetSupported: [string, unknown][] = [["beat", { type: "beat" }]];
   notYetSupported.forEach(([type, image]) => {
     assert.ok(!supportedBeatTypes.some((t) => t === type), `${type} is on supportedBeatTypes — move it out of this list and give it a minimal beat`);
     assert.strictEqual(beatToHtml(beat(image), { idPrefix: "t" }), undefined, `${type} should not render yet`);

--- a/test/beat_html/test_html_tailwind.ts
+++ b/test/beat_html/test_html_tailwind.ts
@@ -50,6 +50,16 @@ test("and refused again at render time, for a caller that did not parse", () => 
   assert.throws(() => htmlTailwindToHtml({ type: "html_tailwind", elements: [{ id: "bad id", text: "x" }] }), /element id must match/);
 });
 
+// A caller that skipped zod. Every one of these is rejected at parse time, so this is not a
+// path the pipeline reaches — but the guard decides what happens when someone bypasses it,
+// and before this PR `[null]` threw and `["str"]` rendered garbage from a string.
+test("elements that are not an array of objects fall back to html", () => {
+  const unparsed = (elements: unknown) => htmlTailwindToHtml({ type: "html_tailwind", elements, html: "<div>fallback</div>" });
+  ["not-an-array", 7, {}, null, [null], ["str"], [undefined]].forEach((elements) => {
+    assert.strictEqual(unparsed(elements)?.html, "<div>fallback</div>", `${JSON.stringify(elements)} must fall back`);
+  });
+});
+
 // One implementation, two callers: if they drift, the browser and the PNG dump disagree.
 test("the fragment is the same markup the document dump produces", async () => {
   const plugin = findImagePlugin("html_tailwind");

--- a/test/beat_html/test_html_tailwind.ts
+++ b/test/beat_html/test_html_tailwind.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert";
+import { htmlTailwindToHtml } from "../../src/utils/beat_html/html_tailwind.js";
+import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { mulmoHtmlTailwindMediaSchema } from "../../src/types/schema.js";
+
+/**
+ * This beat type is where "the markup is not sanitized" matters most: the author's html IS
+ * the content and the schema also accepts a `script`, so escaping it would remove the
+ * feature rather than a capability the author lacks.
+ */
+
+const media = (over: Record<string, unknown>) => mulmoHtmlTailwindMediaSchema.parse({ type: "html_tailwind", ...over });
+
+test("the author's html is emitted as written", () => {
+  assert.strictEqual(htmlTailwindToHtml(media({ html: "<div>a</div>" }))!.html, "<div>a</div>");
+  assert.strictEqual(htmlTailwindToHtml(media({ html: ["<div>a</div>", "<div>b</div>"] }))!.html, "<div>a</div>\n<div>b</div>");
+});
+
+test("swipe elements win over html, and render at rest", () => {
+  const fragment = htmlTailwindToHtml(media({ html: "<div>ignored</div>", elements: [{ id: "panel_1", text: "x" }] }));
+  assert.ok(fragment);
+  assert.match(fragment.html, /<div id="panel_1"/);
+  assert.ok(!fragment.html.includes("ignored"), "elements take precedence");
+});
+
+// The animation driver, the author's script and the frame-based animation all need script
+// execution, which a fragment injected through innerHTML cannot do.
+test("no script is emitted, whatever the beat asks for", () => {
+  [{ html: "<div>a</div>", script: "alert(1)" }, { elements: [{ id: "a", text: "x", to: { opacity: 1 } }] }, { html: "<div>a</div>", animation: true }].forEach(
+    (over) => {
+      const fragment = htmlTailwindToHtml(media(over));
+      assert.strictEqual((fragment?.html ?? "").toLowerCase().split("<script").length - 1, 0, `${JSON.stringify(over)} must emit no script`);
+    },
+  );
+});
+
+test("nothing to show renders nothing, rather than an empty element", () => {
+  [{}, { html: "" }, { html: [] }, { elements: [] }, { script: "alert(1)" }].forEach((over) => {
+    assert.strictEqual(htmlTailwindToHtml(media(over)), undefined, `${JSON.stringify(over)} must render nothing`);
+  });
+});
+
+// Two layers, and the schema is the earlier one — that is what #1541 added it for.
+test("a bad swipe element id is refused at parse time", () => {
+  assert.throws(() => media({ elements: [{ id: "bad id", text: "x" }] }), /must start with a letter or underscore/);
+});
+
+test("and refused again at render time, for a caller that did not parse", () => {
+  assert.throws(() => htmlTailwindToHtml({ type: "html_tailwind", elements: [{ id: "bad id", text: "x" }] }), /element id must match/);
+});
+
+// One implementation, two callers: if they drift, the browser and the PNG dump disagree.
+test("the fragment is the same markup the document dump produces", async () => {
+  const plugin = findImagePlugin("html_tailwind");
+  for (const over of [{ html: "<div>a</div>" }, { html: ["a", "b"] }, { elements: [{ id: "p", text: "x" }] }]) {
+    const image = media(over);
+    assert.strictEqual(htmlTailwindToHtml(image)!.html, await plugin.html!({ beat: { image } }), JSON.stringify(over));
+  }
+});


### PR DESCRIPTION
## Summary

html_tailwind beat をブラウザ用 fragment にしました。**これで対応 beat 種別は 8/8** です（`#1526` の PR 13）。

- `src/utils/image_plugins/html_tailwind_markup.ts`（新規, pure）— 両経路が共有する規則
- `src/utils/beat_html/html_tailwind.ts`（新規）
- `dumpHtml` の `as` キャストを型ガードに置換

## Items to Confirm / Review

### 1. 設計判断は既に存在していました

script をどう扱うか悩みましたが、**Node の `dumpHtml` は既に script を出さず静的マークアップだけを返していました**（`elements` があれば `swipeElementsToHtml`、無ければ著者の `html`）。ブラウザ側も同じにするだけで、新しい判断は不要でした。

理由はブラウザ側でさらに強くなります — `innerHTML` 経由の `<script>` は実行されません。著者の `script`、swipe のアニメーション駆動、frame ベースの `animation` はいずれもスクリプト実行を要するので、**両経路とも「静止状態の beat」**を見せます。アニメーションだけの beat は、要素が初期位置で表示されます（何も出ないよりは preview として有用という判断）。

### 2. 著者の html はエスケープしません

この beat 種別では**マークアップが中身**で、スキーマは `script` も受け付けます。エスケープすると機能が消えるだけで、著者が持っていない能力を防ぐわけではありません。`BeatHtmlFragment.html` の「サニタイズしない」契約が最も効く箇所なので、そのことをコードのコメントに明記しました。

**ここは判断が要ります** — host 側でのサニタイズを前提にしてよいか、確認してください。

### 3. `as` キャストを型ガードに置き換えました

`dumpHtml` は `beat.image as { elements?: SwipeElement[] }` としていました。原因は `swipeElementSchema` が `z.lazy` の再帰のため `z.ZodType` と注釈され、`z.array(...)` が `unknown[]` になることです。

`SwipeElement` は**全フィールドが optional** なので、「各要素が非 null のオブジェクト」を確かめる `isSwipeElements` は**構造的に健全な narrowing** です（キャストの言い換えではありません）。zod は parse 時に既に形を検証しているので、これは型の穴を埋めるだけのものです — その旨をコメントに書いています。

### 4. Node 経路は「不変」ではありませんでした（round 1 で訂正）

当初「11 ケースで差分 0」と書きましたが、**生成器に配列以外の `elements` が無く**、Codex に指摘されました。旧コードの `Array.isArray` チェックを落としていたのが原因です。ガードに取り込んだうえで生成器を 17 ケースに広げ、throw も結果として比較したところ **2 件差分**が出ます:

| 入力 | main | 本PR |
|---|---|---|
| `elements: [null]` | **throw**（`Cannot read properties of null`） | html にフォールバック |
| `elements: ["str"]` | 文字列からゴミ markup を生成 | html にフォールバック |

**どちらも zod が parse 時に弾く形**なので実経路からは到達しません（5形すべて確認済み）。差分が出るのは parse を経ない呼び出しだけで、そこでは新挙動の方が良い（throw やゴミではなくフォールバック）ため、そのまま採用しテストで固定しました。

残る 15 ケースは差分 0 です。ハーネスが差分を見られることは変異（結合子 `\n`→`|`）でも確認しています。

### 5. id は2層で守られています

swipe element id は **parse 時（#1541 のスキーマ制約）** と **描画時（`assertSafeElementId`）** の両方で弾かれます。テストを書いていて、私が描画時だと思っていたものが実は parse 時に弾かれていたと分かったので、両方をテストに分けました。

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1158 tests, 0 fail**
- browser-safety ゲート **7/7 pass**、バンドルは **38 入力 / 121.9 KB**（slide 時点から +3 / +2.8 KB）
- **変異3種すべてで赤くなることを確認**:

  | 変異 | 結果 |
  |---|---|
  | `elements` の優先を外す | fail=3 |
  | 配列の結合子を変える | fail=2 |
  | 空を `undefined` にしない | fail=1 |

## User Prompt

> b

Refs #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering `html_tailwind` content as browser-ready HTML fragments.
  * Supports raw HTML, multiple HTML entries, and swipe-based elements.
  * Produces static markup without scripts or animation-driven behavior.

* **Bug Fixes**
  * Improved consistency between fragment rendering and full document output.
  * Handles empty content and invalid element identifiers more reliably.

* **Tests**
  * Added coverage for rendering modes, script suppression, validation, and output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
