### PR TITLE
feat: export beatToHtml from mulmocast/browser

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,32 +22,85 @@ Node 22+ required. The package is ESM-only (`"type": "module"`).
 
 What `import { … } from "mulmocast"` gives you, by area:
 
-| Area | Exports |
-|---|---|
-| Context / scripts | `getFileObject`, `initializeContextFromFiles`, `MulmoStudioContext`, `MulmoStudioContextMethods`, `MulmoScript`, `mulmoScriptSchema`, `MulmoScriptMethods` |
-| Actions (full-pipeline) | `images`, `audio`, `movie`, `pdf`, `captions`, `translate`, `bundle`, `markdown`, `html`, `mulmoViewerBundle` |
-| Per-beat (granular) | `generateBeatImage`, `generateBeatAudio`, `generateReferenceImage`, `getBeatAudioPathOrUrl`, `translateBeat` |
-| Settings & i18n | `settings2GraphAIConfig` (via `args.settings`), `setMulmoErrorFormatter`, `bundleTargetLang` |
-| Progress callbacks | `addSessionProgressCallback`, `removeSessionProgressCallback` |
-| Logging | `setGraphAILogger` |
-| Path helpers | `getOutputStudioFilePath`, `getOutputMultilingualFilePath`, `getOutputVideoFilePath`, `getOutputPdfFilePath`, `getReferenceImagePath`, `getBeatPngImagePath`, `getCaptionImagePath`, `getBeatMoviePaths` |
-| Usage tracking | `UsageCollector`, `UsageRecord`, `UsageCollectorAPI`, `AgentUsage` (see [Usage tracking](#usage-tracking) below) |
-| Usage estimation | `estimateUsage`, `UsageEstimate`, `EstimatedMetric`, `modelPricing`, `ModelPricing` (see [Pre-run estimation](#pre-run-estimation-estimateusage) below) |
-| Agents (direct use) | `puppeteerCrawlerAgent`, `validateSchemaAgent`, all `image*Agent` / `tts*Agent` / `movie*Agent` / `lipsync*Agent` agents |
+| Area                    | Exports                                                                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Context / scripts       | `getFileObject`, `initializeContextFromFiles`, `MulmoStudioContext`, `MulmoStudioContextMethods`, `MulmoScript`, `mulmoScriptSchema`, `MulmoScriptMethods`                                               |
+| Actions (full-pipeline) | `images`, `audio`, `movie`, `pdf`, `captions`, `translate`, `bundle`, `markdown`, `html`, `mulmoViewerBundle`                                                                                            |
+| Per-beat (granular)     | `generateBeatImage`, `generateBeatAudio`, `generateReferenceImage`, `getBeatAudioPathOrUrl`, `translateBeat`                                                                                             |
+| Settings & i18n         | `settings2GraphAIConfig` (via `args.settings`), `setMulmoErrorFormatter`, `bundleTargetLang`                                                                                                             |
+| Progress callbacks      | `addSessionProgressCallback`, `removeSessionProgressCallback`                                                                                                                                            |
+| Logging                 | `setGraphAILogger`                                                                                                                                                                                       |
+| Path helpers            | `getOutputStudioFilePath`, `getOutputMultilingualFilePath`, `getOutputVideoFilePath`, `getOutputPdfFilePath`, `getReferenceImagePath`, `getBeatPngImagePath`, `getCaptionImagePath`, `getBeatMoviePaths` |
+| Usage tracking          | `UsageCollector`, `UsageRecord`, `UsageCollectorAPI`, `AgentUsage` (see [Usage tracking](#usage-tracking) below)                                                                                         |
+| Usage estimation        | `estimateUsage`, `UsageEstimate`, `EstimatedMetric`, `modelPricing`, `ModelPricing` (see [Pre-run estimation](#pre-run-estimation-estimateusage) below)                                                  |
+| Agents (direct use)     | `puppeteerCrawlerAgent`, `validateSchemaAgent`, all `image*Agent` / `tts*Agent` / `movie*Agent` / `lipsync*Agent` agents                                                                                 |
+
+## Browser: rendering beats as HTML fragments
+
+`import { … } from "mulmocast/browser"` — a separate entry point with no Node dependencies,
+so it bundles for the browser. Everything above is Node-only; this is not.
+
+| Export                                               | What it is                                                |
+| ---------------------------------------------------- | --------------------------------------------------------- |
+| `beatToHtml(beat, { idPrefix })`                     | A beat as markup, or `undefined` for one it cannot render |
+| `supportedBeatTypes`                                 | The `image.type` values it renders                        |
+| `BeatHtmlFragment`, `BeatHtmlOptions`, `BeatRuntime` | Its types                                                 |
+
+```ts
+import { beatToHtml, supportedBeatTypes } from "mulmocast/browser";
+
+const fragments = script.beats.map((beat, index) => beatToHtml(beat, { idPrefix: `beat-${index}` }));
+```
+
+`idPrefix` must match `[A-Za-z_][A-Za-z0-9_-]*` and `beatToHtml` throws otherwise. Derive it
+from the beat's index (`beat-3`, not `3` — an element id cannot start with a digit); a beat's
+own `id` comes from the script and is unrestricted. The prefix has to be unique per beat and
+stable across re-renders, which is why the library cannot pick it.
+
+### What the host is responsible for
+
+**Sanitizing.** A beat is user data and the markup is not sanitized — `html_tailwind` beats
+are raw author markup by design. Sanitize before inserting into a DOM.
+
+**Loading the shared runtimes once for the page**, not once per beat. A fragment names what
+it needs rather than pulling it in:
+
+| Field          | Meaning                                                                         |
+| -------------- | ------------------------------------------------------------------------------- |
+| `requires`     | `"chart"` → Chart.js, `"mermaid"` → mermaid. Absent when the beat needs neither |
+| `chartPlugins` | Extra Chart.js plugin CDNs for this beat's chart type                           |
+| `css`          | Rules the fragment needs, already scoped. Absent when it needs none             |
+| `mermaidTheme` | Which mermaid theme suits the beat's background                                 |
+
+**Driving what a `<script>` would have driven.** Fragments carry no `<script>`, because one
+injected through `innerHTML` does not execute and does not survive sanitizing. A chart's
+config rides on its canvas as `data-mulmo-chart` instead — the same shape `@mulmocast/deck`
+uses, so one host loop drives slides and beats alike:
+
+```ts
+document.querySelectorAll("canvas[data-mulmo-chart]").forEach((canvas) => {
+  new Chart(canvas.getContext("2d"), JSON.parse(canvas.dataset.mulmoChart));
+});
+mermaid.init(undefined, document.querySelectorAll(".mermaid"));
+```
+
+### What renders, and what does not
+
+All eight `image.type` values render. Two carry limits from the browser rather than choice:
+
+- **`mermaid`** renders `code.kind === "text"` only; `url`, `path` and `base64` are resolved
+  by a Node fetch/filesystem path.
+- **`image` / `movie`** emit the src the source names. A `base64` source renders nothing —
+  the schema carries no media type to build a `data:` URI from.
+
+`html_tailwind` renders the beat at rest: an author `script`, swipe animations and
+frame-based `animation` all need script execution. The Node HTML dump has never emitted
+those either.
 
 ## Lifecycle: from MulmoScript JSON to rendered video
 
 ```ts
-import {
-  getFileObject,
-  initializeContextFromFiles,
-  audio,
-  images,
-  captions,
-  movie,
-  setGraphAILogger,
-  UsageCollector,
-} from "mulmocast";
+import { getFileObject, initializeContextFromFiles, audio, images, captions, movie, setGraphAILogger, UsageCollector } from "mulmocast";
 
 setGraphAILogger(false); // suppress noisy debug logs from GraphAI
 
@@ -83,25 +136,25 @@ console.log(usage); // UsageRecord[]
 
 All actions take `(context, args?)` and mutate `context.studio` in place. The optional `args.settings` lets you pass per-call API keys instead of relying on `process.env`.
 
-| Action | Purpose | Required dependencies |
-|---|---|---|
-| `audio(context, args?)` | TTS per beat → combined mp3 | TTS provider key (`OPENAI_API_KEY` etc.) |
-| `images(context, args?)` | Generate per-beat images (and html/movie media) | Image provider key |
-| `captions(context, args?)` | Render caption overlays for the video | none (ffmpeg only) |
-| `movie(context, args?)` | Combine audio + images + captions into mp4 | ffmpeg |
-| `pdf(context, mode, size, args?)` | Render PDF (`slide`/`talk`/`handout` × `a4`/`letter`/…) | puppeteer |
-| `translate(context, args?)` | LLM-translate beat text into `args.targetLangs` (default: context.lang + captionParams.lang) | LLM key |
-| `bundle(context, args?)` | Translate + render + zip up `<filename>_viewer.html` + assets | All of the above |
-| `markdown(context, imageWidth?)` | Emit a Markdown rendering | image keys (if not cached) |
-| `html(context, imageWidth?)` | Emit a standalone HTML rendering | image keys (if not cached) |
-| `mulmoViewerBundle(context)` | Zip the bundle artifact (no AI; runs after bundle) | none |
+| Action                            | Purpose                                                                                      | Required dependencies                    |
+| --------------------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| `audio(context, args?)`           | TTS per beat → combined mp3                                                                  | TTS provider key (`OPENAI_API_KEY` etc.) |
+| `images(context, args?)`          | Generate per-beat images (and html/movie media)                                              | Image provider key                       |
+| `captions(context, args?)`        | Render caption overlays for the video                                                        | none (ffmpeg only)                       |
+| `movie(context, args?)`           | Combine audio + images + captions into mp4                                                   | ffmpeg                                   |
+| `pdf(context, mode, size, args?)` | Render PDF (`slide`/`talk`/`handout` × `a4`/`letter`/…)                                      | puppeteer                                |
+| `translate(context, args?)`       | LLM-translate beat text into `args.targetLangs` (default: context.lang + captionParams.lang) | LLM key                                  |
+| `bundle(context, args?)`          | Translate + render + zip up `<filename>_viewer.html` + assets                                | All of the above                         |
+| `markdown(context, imageWidth?)`  | Emit a Markdown rendering                                                                    | image keys (if not cached)               |
+| `html(context, imageWidth?)`      | Emit a standalone HTML rendering                                                             | image keys (if not cached)               |
+| `mulmoViewerBundle(context)`      | Zip the bundle artifact (no AI; runs after bundle)                                           | none                                     |
 
 ### Args shape
 
 ```ts
 type PublicAPIArgs = {
-  settings?: Record<string, string>;   // API keys keyed by env-var name
-  callbacks?: CallbackFunction[];      // GraphAI per-node callbacks (passed to every GraphAI in the action)
+  settings?: Record<string, string>; // API keys keyed by env-var name
+  callbacks?: CallbackFunction[]; // GraphAI per-node callbacks (passed to every GraphAI in the action)
 };
 ```
 
@@ -218,18 +271,18 @@ A `UsageCollector` is automatically created inside `initializeContextFromFiles` 
 
 ```ts
 type UsageRecord = {
-  agent: string;          // "imageOpenaiAgent" | "ttsGeminiAgent" | "openAIAgent" | …
-  provider: string;       // "openai" | "google" | "replicate" | "elevenlabs" | "kotodama" | "gemini" | "anthropic" | "groq"
-  model: string;          // resolved model name as actually used
-  beatIndex?: number;     // from the mapAgent that dispatched the call
-  inputTokens?: number;   // LLM / token-billed image / Gemini TTS
+  agent: string; // "imageOpenaiAgent" | "ttsGeminiAgent" | "openAIAgent" | …
+  provider: string; // "openai" | "google" | "replicate" | "elevenlabs" | "kotodama" | "gemini" | "anthropic" | "groq"
+  model: string; // resolved model name as actually used
+  beatIndex?: number; // from the mapAgent that dispatched the call
+  inputTokens?: number; // LLM / token-billed image / Gemini TTS
   outputTokens?: number;
   totalTokens?: number;
-  predictSec?: number;    // Replicate (metrics.predict_time) and Veo (ffprobed mp4)
-  inputChars?: number;    // char-billed TTS (openai legacy / google / kotodama / elevenlabs)
-  cached: boolean;        // always false in practice — cache hits don't fire the callback at all
-  retryAttempt?: number;  // from log.retryCount
-  timestamp: string;      // ISO-8601
+  predictSec?: number; // Replicate (metrics.predict_time) and Veo (ffprobed mp4)
+  inputChars?: number; // char-billed TTS (openai legacy / google / kotodama / elevenlabs)
+  cached: boolean; // always false in practice — cache hits don't fire the callback at all
+  retryAttempt?: number; // from log.retryCount
+  timestamp: string; // ISO-8601
 };
 ```
 
@@ -251,25 +304,25 @@ type AgentUsage = {
 
 ### What each agent populates
 
-| Agent | Provider | Model(s) | inputTokens | outputTokens | totalTokens | predictSec | inputChars |
-|---|---|---|---|---|---|---|---|
-| `imageOpenaiAgent` | openai | `gpt-image-1`, `gpt-image-1-mini`, … | ✅ | ✅ | ✅ | — | — |
-| `imageGenAIAgent` | google | `gemini-2.5-flash-image`, `gemini-3.x-image-preview` | ✅ | ✅ | ✅ | — | — |
-| `imageReplicateAgent` | replicate | `black-forest-labs/flux-*`, `ideogram-ai/*`, `recraft-ai/*`, … | — | — | — | ✅ | — |
-| `movieGenAIAgent` | google | `veo-3.1-*` | — | — | — | ✅ (ffprobed mp4) | — |
-| `movieReplicateAgent` | replicate | `kwaivgi/kling-*`, `bytedance/seedance-*`, … | — | — | — | ✅ | — |
-| `soundEffectReplicateAgent` | replicate | mmaudio etc. | — | — | — | ✅ | — |
-| `lipSyncReplicateAgent` | replicate | sync-* | — | — | — | ✅ | — |
-| `ttsOpenaiAgent` (tts-1, tts-1-hd) | openai | `tts-1`, `tts-1-hd` | — | — | — | — | ✅ |
-| `ttsOpenaiAgent` (gpt-4o-mini-tts) | openai | `gpt-4o-mini-tts` | — | — | — | — | ✅ (token billing — see [Known gaps](#known-gaps)) |
-| `ttsGoogleAgent` | google | voice tier name | — | — | — | — | ✅ |
-| `ttsKotodamaAgent` | kotodama | speaker_id | — | — | — | — | ✅ |
-| `ttsElevenlabsAgent` | elevenlabs | `eleven_*` | — | — | — | — | ✅ (`character-cost` HTTP header, already post-discount) |
-| `ttsGeminiAgent` | gemini | `gemini-2.5-flash-preview-tts` | ✅ | ✅ | ✅ | — | — |
-| `openAIAgent` (`@graphai/openai_agent`) | openai | `gpt-4o-*`, etc. | ✅ | ✅ | ✅ | — | — |
-| `geminiAgent` (`@graphai/gemini_agent`) | google | `gemini-*` | ✅ | ✅ | ✅ | — | — |
-| `anthropicAgent` (`@graphai/anthropic_agent`) | anthropic | `claude-*` | ✅ | ✅ | ✅ | — | — |
-| `groqAgent` (`@graphai/groq_agent`) | groq | (Groq-hosted) | ✅ | ✅ | ✅ | — | — |
+| Agent                                         | Provider   | Model(s)                                                       | inputTokens | outputTokens | totalTokens | predictSec        | inputChars                                               |
+| --------------------------------------------- | ---------- | -------------------------------------------------------------- | ----------- | ------------ | ----------- | ----------------- | -------------------------------------------------------- |
+| `imageOpenaiAgent`                            | openai     | `gpt-image-1`, `gpt-image-1-mini`, …                           | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `imageGenAIAgent`                             | google     | `gemini-2.5-flash-image`, `gemini-3.x-image-preview`           | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `imageReplicateAgent`                         | replicate  | `black-forest-labs/flux-*`, `ideogram-ai/*`, `recraft-ai/*`, … | —           | —            | —           | ✅                | —                                                        |
+| `movieGenAIAgent`                             | google     | `veo-3.1-*`                                                    | —           | —            | —           | ✅ (ffprobed mp4) | —                                                        |
+| `movieReplicateAgent`                         | replicate  | `kwaivgi/kling-*`, `bytedance/seedance-*`, …                   | —           | —            | —           | ✅                | —                                                        |
+| `soundEffectReplicateAgent`                   | replicate  | mmaudio etc.                                                   | —           | —            | —           | ✅                | —                                                        |
+| `lipSyncReplicateAgent`                       | replicate  | sync-*                                                         | —           | —            | —           | ✅                | —                                                        |
+| `ttsOpenaiAgent` (tts-1, tts-1-hd)            | openai     | `tts-1`, `tts-1-hd`                                            | —           | —            | —           | —                 | ✅                                                       |
+| `ttsOpenaiAgent` (gpt-4o-mini-tts)            | openai     | `gpt-4o-mini-tts`                                              | —           | —            | —           | —                 | ✅ (token billing — see [Known gaps](#known-gaps))       |
+| `ttsGoogleAgent`                              | google     | voice tier name                                                | —           | —            | —           | —                 | ✅                                                       |
+| `ttsKotodamaAgent`                            | kotodama   | speaker_id                                                     | —           | —            | —           | —                 | ✅                                                       |
+| `ttsElevenlabsAgent`                          | elevenlabs | `eleven_*`                                                     | —           | —            | —           | —                 | ✅ (`character-cost` HTTP header, already post-discount) |
+| `ttsGeminiAgent`                              | gemini     | `gemini-2.5-flash-preview-tts`                                 | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `openAIAgent` (`@graphai/openai_agent`)       | openai     | `gpt-4o-*`, etc.                                               | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `geminiAgent` (`@graphai/gemini_agent`)       | google     | `gemini-*`                                                     | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `anthropicAgent` (`@graphai/anthropic_agent`) | anthropic  | `claude-*`                                                     | ✅          | ✅           | ✅          | —                 | —                                                        |
+| `groqAgent` (`@graphai/groq_agent`)           | groq       | (Groq-hosted)                                                  | ✅          | ✅           | ✅          | —                 | —                                                        |
 
 ### CLI dump (no code change required)
 
@@ -289,10 +342,28 @@ Payload shape:
 {
   "records": 5,
   "byModel": [
-    { "provider": "openai",   "model": "gpt-4o-mini-tts", "records": 1, "inputChars": 20, "inputTokens": 0, "outputTokens": 0, "totalTokens": 0, "predictSec": 0 },
-    { "provider": "gemini",   "model": "gemini-2.5-flash-preview-tts", "records": 1, "inputTokens": 9, "outputTokens": 59, "totalTokens": 68, "inputChars": 0, "predictSec": 0 }
+    {
+      "provider": "openai",
+      "model": "gpt-4o-mini-tts",
+      "records": 1,
+      "inputChars": 20,
+      "inputTokens": 0,
+      "outputTokens": 0,
+      "totalTokens": 0,
+      "predictSec": 0
+    },
+    {
+      "provider": "gemini",
+      "model": "gemini-2.5-flash-preview-tts",
+      "records": 1,
+      "inputTokens": 9,
+      "outputTokens": 59,
+      "totalTokens": 68,
+      "inputChars": 0,
+      "predictSec": 0
+    }
   ],
-  "snapshot": [ /* raw UsageRecord[] */ ]
+  "snapshot": [/* raw UsageRecord[] */]
 }
 ```
 
@@ -308,7 +379,7 @@ context.usageCollector = collector;
 
 await audio(context).then(images).then(captions).then(movie);
 
-const records = collector.snapshot();        // UsageRecord[]
+const records = collector.snapshot(); // UsageRecord[]
 // Send to your billing layer:
 await fetch("https://billing/ingest", {
   method: "POST",

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,11 +73,9 @@ it needs rather than pulling it in:
 | `mermaidTheme` | Which mermaid theme suits the beat's background                                 |
 
 **Driving what a `<script>` would have driven.** Fragments carry no `<script>`, because one
-injected through `innerHTML` does not execute and does not survive sanitizing. (A `slide`
-beat's chart block arrives from `@mulmocast/deck` with an inline driver for the standalone
-document; it is stripped here rather than shipped as markup that cannot run.) A chart's
+injected through `innerHTML` does not execute and does not survive sanitizing. A chart's
 config rides on its canvas as `data-mulmo-chart` instead — the same shape `@mulmocast/deck`
-uses, so one host loop drives slides and beats alike:
+uses for slides, so one host loop drives slides and beats alike:
 
 ```ts
 document.querySelectorAll("canvas[data-mulmo-chart]").forEach((canvas) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,9 @@ it needs rather than pulling it in:
 | `mermaidTheme` | Which mermaid theme suits the beat's background                                 |
 
 **Driving what a `<script>` would have driven.** Fragments carry no `<script>`, because one
-injected through `innerHTML` does not execute and does not survive sanitizing. A chart's
+injected through `innerHTML` does not execute and does not survive sanitizing. (A `slide`
+beat's chart block arrives from `@mulmocast/deck` with an inline driver for the standalone
+document; it is stripped here rather than shipped as markup that cannot run.) A chart's
 config rides on its canvas as `data-mulmo-chart` instead — the same shape `@mulmocast/deck`
 uses, so one host loop drives slides and beats alike:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,12 @@ stable across re-renders, which is why the library cannot pick it.
 **Sanitizing.** A beat is user data and the markup is not sanitized — `html_tailwind` beats
 are raw author markup by design. Sanitize before inserting into a DOM.
 
+**Providing Tailwind.** Most fragments are styled with Tailwind utility classes — measured,
+five of the eight beat types use them, and `slide` needs `slideUtilityCss` from
+`@mulmocast/deck` as well. This is _not_ in `requires`, which names only the JavaScript
+runtimes a fragment needs a host to load and execute. A page without Tailwind renders the
+markup unstyled rather than failing, which is why it is worth saying out loud.
+
 **Loading the shared runtimes once for the page**, not once per beat. A fragment names what
 it needs rather than pulling it in:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,11 +62,20 @@ stable across re-renders, which is why the library cannot pick it.
 **Sanitizing.** A beat is user data and the markup is not sanitized — `html_tailwind` beats
 are raw author markup by design. Sanitize before inserting into a DOM.
 
-**Providing Tailwind.** Most fragments are styled with Tailwind utility classes — measured,
-five of the eight beat types use them, and `slide` needs `slideUtilityCss` from
-`@mulmocast/deck` as well. This is _not_ in `requires`, which names only the JavaScript
-runtimes a fragment needs a host to load and execute. A page without Tailwind renders the
-markup unstyled rather than failing, which is why it is worth saying out loud.
+**Providing Tailwind.** Most fragments are styled with Tailwind utility classes. This is
+_not_ in `requires`, which names only the JavaScript runtimes a host must load and execute.
+A page without Tailwind renders the markup unstyled rather than failing, which is why it is
+worth saying rather than leaving to be discovered.
+
+Measured per beat, because it varies by the shape of the beat and not only by its type:
+
+| Beat                                 | Utility classes                                                                                                   |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `chart`, `mermaid`, `image`, `movie` | always                                                                                                            |
+| `slide`                              | always, and it also needs `slideUtilityCss` from `@mulmocast/deck`                                                |
+| `markdown`                           | when the markdown is a layout object, a `2x2`, or contains a mermaid fence; a plain markdown string produces none |
+| `textSlide`                          | none                                                                                                              |
+| `html_tailwind`                      | whatever the author wrote — the name is a promise the author makes, not one this module keeps                     |
 
 **Loading the shared runtimes once for the page**, not once per beat. A fragment names what
 it needs rather than pulling it in:

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,10 +87,13 @@ it needs rather than pulling it in:
 | `css`          | Rules the fragment needs, already scoped. Absent when it needs none             |
 | `mermaidTheme` | Which mermaid theme suits the beat's background                                 |
 
-**Driving what a `<script>` would have driven.** Fragments carry no `<script>`, because one
-injected through `innerHTML` does not execute and does not survive sanitizing. A chart's
-config rides on its canvas as `data-mulmo-chart` instead — the same shape `@mulmocast/deck`
-uses for slides, so one host loop drives slides and beats alike:
+**Driving what a `<script>` would have driven.** This module generates no `<script>` —
+one injected through `innerHTML` does not execute and does not survive sanitizing, so a
+chart's config rides on its canvas as `data-mulmo-chart` instead, the same shape
+`@mulmocast/deck` uses for slides. That says nothing about a script an author _wrote_: a
+`<script>` in an `html_tailwind` beat's markup, in raw HTML inside a `markdown` beat, or in
+a `textSlide` field reaches the fragment verbatim, because this module does not sanitize.
+Sanitize before inserting, as above. One host loop drives what this module does generate:
 
 ```ts
 document.querySelectorAll<HTMLCanvasElement>("canvas[data-mulmo-chart]").forEach((canvas) => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -78,11 +78,18 @@ config rides on its canvas as `data-mulmo-chart` instead — the same shape `@mu
 uses for slides, so one host loop drives slides and beats alike:
 
 ```ts
-document.querySelectorAll("canvas[data-mulmo-chart]").forEach((canvas) => {
-  new Chart(canvas.getContext("2d"), JSON.parse(canvas.dataset.mulmoChart));
+document.querySelectorAll<HTMLCanvasElement>("canvas[data-mulmo-chart]").forEach((canvas) => {
+  const config = canvas.dataset.mulmoChart;
+  const context = canvas.getContext("2d");
+  if (!config || !context) return;
+  new Chart(context, JSON.parse(config));
 });
 mermaid.init(undefined, document.querySelectorAll(".mermaid"));
 ```
+
+The two guards are not ceremony: `dataset.mulmoChart` is `string | undefined` and
+`getContext` returns `null` on a canvas that already has a context of another kind, and
+Chart.js throws on either.
 
 ### What renders, and what does not
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@modernized/fluent-ffmpeg": "^1.0.3",
     "@mozilla/readability": "^0.6.0",
-    "@mulmocast/deck": "^1.2.0",
+    "@mulmocast/deck": "^2.0.0",
     "@tavily/core": "^0.7.6",
     "archiver": "^8.0.0",
     "clipboardy": "^5.3.2",

--- a/plans/feat-beat-html-browser.md
+++ b/plans/feat-beat-html-browser.md
@@ -10,7 +10,9 @@ receptron/mulmocast-cli#1526
 
 ```ts
 export type BeatHtmlFragment = {
-  html: string;                          // body 相当のみ。<html>/<head>/<script> を含まない
+  html: string;                          // body 相当のみ。<html>/<head> は含まず、このモジュールが
+                                         // 生成する <script> も無い。著者が書いた <script> は
+                                         // sanitize しないのでそのまま通る
   css?: string;                          // コンテナ配下にスコープ済み
   requires?: ("chart" | "mermaid")[];    // 親が1回だけロードすべき外部ランタイム
 };
@@ -31,31 +33,31 @@ export const beatToHtml = (beat: MulmoBeat, options?: BeatHtmlOptions): BeatHtml
 
 人間レビュー前提のため細粒度に割る。各 PR は独立して revert 可能。
 
-| # | 内容 | 依存 |
-|---|---|---|
-| 1 | `beat_html/` 新設。型・dispatcher 骨格・**`textSlide`**・テスト。ここでパターン確定 | — |
-| 2 | `markdown` | 1 |
-| 3 | `image`（url のみ、新規） | 1 |
-| 4 | `movie`（url のみ） | 1 |
-| 5 | `chart`（`data-mulmo-chart`） | 1 |
-| 6 | `mermaid`（`data-mulmo-mermaid`、text のみ） | 1 |
-| 7 | `html_tailwind` | 1 |
-| 8 | `slide` | 1 ＋ mulmocast-deck#25 |
-| 9 | `index.browser.ts` から export ＋ README | 1–8 |
-| 10 | 既存 `image_plugins` の重複を新モジュールへ委譲 | 9 |
+| #   | 内容                                                                                | 依存                   |
+| --- | ----------------------------------------------------------------------------------- | ---------------------- |
+| 1   | `beat_html/` 新設。型・dispatcher 骨格・**`textSlide`**・テスト。ここでパターン確定 | —                      |
+| 2   | `markdown`                                                                          | 1                      |
+| 3   | `image`（url のみ、新規）                                                           | 1                      |
+| 4   | `movie`（url のみ）                                                                 | 1                      |
+| 5   | `chart`（`data-mulmo-chart`）                                                       | 1                      |
+| 6   | `mermaid`（`data-mulmo-mermaid`、text のみ）                                        | 1                      |
+| 7   | `html_tailwind`                                                                     | 1                      |
+| 8   | `slide`                                                                             | 1 ＋ mulmocast-deck#25 |
+| 9   | `index.browser.ts` から export ＋ README                                            | 1–8                    |
+| 10  | 既存 `image_plugins` の重複を新モジュールへ委譲                                     | 9                      |
 
 ## 種別ごとの方針
 
-| beat | 現状の Node 依存 | 断片化の方針 |
-|---|---|---|
-| `textSlide` | 無し（`marked` のみ） | `dumpMarkdown` を移設し `marked.parse` |
-| `markdown` | `dumpHtml` 経路は純粋 | `markdown_layout.ts` の純粋部分を移設 |
-| `image` | — (`html()` が無い) | `source.kind === "url"` のみ → `<img>` |
-| `movie` | `MulmoMediaSourceMethods.resolve` (fs) | `url` のみ → `<video>` |
-| `chart` | `generateUniqueId` が `node:crypto` | `<canvas data-mulmo-chart='...'>`。`requires: ["chart"]` |
-| `mermaid` | `MulmoMediaSourceMethods.getText` (fs/fetch) | `code.kind === "text"` のみ → `<div data-mulmo-mermaid="...">`。`requires: ["mermaid"]` |
-| `html_tailwind` | 無し | `joinHtml` / `swipeElementsToHtml` を移設 |
-| `slide` | `pathToDataUrl` / branding の `toDataUrl` | `generateSlideFragment()` に委譲。branding / imageRefs は解決済みを受け取る |
+| beat            | 現状の Node 依存                             | 断片化の方針                                                                            |
+| --------------- | -------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `textSlide`     | 無し（`marked` のみ）                        | `dumpMarkdown` を移設し `marked.parse`                                                  |
+| `markdown`      | `dumpHtml` 経路は純粋                        | `markdown_layout.ts` の純粋部分を移設                                                   |
+| `image`         | — (`html()` が無い)                          | `source.kind === "url"` のみ → `<img>`                                                  |
+| `movie`         | `MulmoMediaSourceMethods.resolve` (fs)       | `url` のみ → `<video>`                                                                  |
+| `chart`         | `generateUniqueId` が `node:crypto`          | `<canvas data-mulmo-chart='...'>`。`requires: ["chart"]`                                |
+| `mermaid`       | `MulmoMediaSourceMethods.getText` (fs/fetch) | `code.kind === "text"` のみ → `<div data-mulmo-mermaid="...">`。`requires: ["mermaid"]` |
+| `html_tailwind` | 無し                                         | `joinHtml` / `swipeElementsToHtml` を移設                                               |
+| `slide`         | `pathToDataUrl` / branding の `toDataUrl`    | `generateSlideFragment()` に委譲。branding / imageRefs は解決済みを受け取る             |
 
 `chart` / `mermaid` が `<script>` をやめる理由: 消費側は断片を sanitize してから
 `<div>` に注入するので `<script>` は落ちるし、そもそも `innerHTML` 経由では実行されない。

--- a/plans/feat-beat-html-export.md
+++ b/plans/feat-beat-html-export.md
@@ -1,0 +1,31 @@
+# feat: beatToHtml を mulmocast/browser から公開する
+
+issue: #1526 の PR 14（最終）。
+
+## 何を公開するか
+
+`src/index.browser.ts`（package.json の `"./browser"` 経路）から:
+
+- `beatToHtml` / `supportedBeatTypes`
+- 型: `BeatHtmlFragment` / `BeatHtmlOptions` / `BeatRuntime`
+
+`index.common.ts` ではなく browser entry から出すのは、`test_browser_safety.ts` が
+このモジュールの import グラフを見張っているため。Node 依存が紛れ込めば利用者のビルドではなく
+そのテストが落ちる。
+
+## バンドルの増分（実測）
+
+|                      | 入力    | サイズ        |
+| -------------------- | ------- | ------------- |
+| 現状の index.browser | 147     | 3052 KB       |
+| 本PR適用後           | 164     | 3169.8 KB     |
+| **増分**             | **+17** | **+117.7 KB** |
+
+deck の 19 ファイルは既存分と共有されるので、実質は marked と自リポジトリのコードのみ。
+Node 組み込みはゼロ。
+
+## 検証
+
+公開経路 `mulmocast/browser` から全 8 種別を呼び、
+host が書くのと同じページ（requires から CDN を読み、fragment を innerHTML で注入し、
+`[data-mulmo-chart]` と `.mermaid` を駆動）を組み立てて実ブラウザで描画を確認する。

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -2,5 +2,13 @@
 
 export * from "./index.common.js";
 
+/**
+ * Beat markup for a browser host. Exported from the browser entry point rather than the
+ * common one because `test_browser_safety.ts` guards this module's import graph — a Node
+ * import creeping in fails there, not at a user's build.
+ */
+export { beatToHtml, supportedBeatTypes } from "./utils/beat_html/index.js";
+export type { BeatHtmlFragment, BeatHtmlOptions, BeatRuntime } from "./utils/beat_html/type.js";
+
 import validateSchemaAgent from "./agents/validate_schema_agent.js";
 export { validateSchemaAgent };

--- a/src/utils/beat_html/html_tailwind.ts
+++ b/src/utils/beat_html/html_tailwind.ts
@@ -6,10 +6,11 @@ import type { BeatHtmlFragment } from "./type.js";
 /**
  * An html_tailwind beat as markup a host can inject.
  *
- * The beat at rest, with no script — the same thing the Node dump path shows. The author's
- * `script`, the swipe animation driver and the frame-based `animation` all need script
- * execution, which a fragment injected through `innerHTML` cannot do and which the dump
- * path has never emitted either. A beat whose only content is an animation therefore shows
+ * The beat at rest — the same thing the Node dump path shows. This module generates no
+ * `<script>`: the author's `script` FIELD, the swipe animation driver and the frame-based
+ * `animation` all need script execution, which a fragment injected through `innerHTML`
+ * cannot do and which the dump path has never emitted either. A `<script>` the author wrote
+ * inside `html` is markup, and passes through unsanitized — see below. A beat whose only content is an animation therefore shows
  * its elements in their starting positions rather than nothing.
  *
  * The author's html is emitted as written. On this beat type markup IS the content — the

--- a/src/utils/beat_html/slide.ts
+++ b/src/utils/beat_html/slide.ts
@@ -10,7 +10,7 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
  *
  * `generateSlideFragment` is the body-only counterpart of the `generateSlideHTML` the Node
  * render path uses, so the two draw the same slide from the same layouts — the fragment is
- * not a second renderer. Its chart driver script is stripped: see `withoutScripts`.
+ * not a second renderer.
  *
  * The theme order matches `MulmoPresentationStyleMethods.getResolvedSlideTheme` on the Node
  * side: the beat's own theme, then the deck's, then the built-in corporate one. Repeating
@@ -23,35 +23,11 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
  * root of `html`, verified in a browser: injecting `html` and attaching `css`, with no
  * wrapper class of the host's own, resolves `--d-bg` to the beat's theme.
  */
-/**
- * deck's chart block emits an inline `<script>` that drives the canvas, because the same
- * markup has to work in the standalone document Puppeteer renders. A fragment injected
- * through `innerHTML` never runs it, and the config is on the canvas as `data-mulmo-chart`
- * for exactly that reason — so it is dropped rather than shipped as dead markup that
- * contradicts what BeatHtmlFragment promises.
- *
- * Written as a scan rather than a regex over `<script[^>]*>`: the config JSON inside the
- * block contains `<` sequences of its own, and a regex that has to be right about which one
- * closes the tag is the kind that is wrong once.
- */
-export const withoutScripts = (html: string): string => {
-  const parts: string[] = [];
-  let rest = html;
-  for (let open = rest.toLowerCase().indexOf("<script"); open !== -1; open = rest.toLowerCase().indexOf("<script")) {
-    const close = rest.toLowerCase().indexOf("</script>", open);
-    if (close === -1) break;
-    parts.push(rest.slice(0, open));
-    rest = rest.slice(close + "</script>".length);
-  }
-  parts.push(rest);
-  return parts.join("");
-};
-
 export const slideToHtml = (image: MulmoSlideMedia, options: BeatHtmlOptions): BeatHtmlFragment => {
   const theme = image.theme ?? options.slideTheme ?? slideThemes.corporate;
   const fragment = generateSlideFragment(theme, image.slide, { scopeClass: `${options.idPrefix}-slide` });
   return {
-    html: withoutScripts(fragment.html),
+    html: fragment.html,
     css: fragment.css,
     ...(fragment.requires.length > 0 ? { requires: fragment.requires } : {}),
     ...(fragment.chartPlugins.length > 0 ? { chartPlugins: fragment.chartPlugins } : {}),

--- a/src/utils/beat_html/slide.ts
+++ b/src/utils/beat_html/slide.ts
@@ -10,7 +10,7 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
  *
  * `generateSlideFragment` is the body-only counterpart of the `generateSlideHTML` the Node
  * render path uses, so the two draw the same slide from the same layouts — the fragment is
- * not a second renderer.
+ * not a second renderer. Its chart driver script is stripped: see `withoutScripts`.
  *
  * The theme order matches `MulmoPresentationStyleMethods.getResolvedSlideTheme` on the Node
  * side: the beat's own theme, then the deck's, then the built-in corporate one. Repeating
@@ -23,11 +23,35 @@ import type { BeatHtmlFragment, BeatHtmlOptions } from "./type.js";
  * root of `html`, verified in a browser: injecting `html` and attaching `css`, with no
  * wrapper class of the host's own, resolves `--d-bg` to the beat's theme.
  */
+/**
+ * deck's chart block emits an inline `<script>` that drives the canvas, because the same
+ * markup has to work in the standalone document Puppeteer renders. A fragment injected
+ * through `innerHTML` never runs it, and the config is on the canvas as `data-mulmo-chart`
+ * for exactly that reason — so it is dropped rather than shipped as dead markup that
+ * contradicts what BeatHtmlFragment promises.
+ *
+ * Written as a scan rather than a regex over `<script[^>]*>`: the config JSON inside the
+ * block contains `<` sequences of its own, and a regex that has to be right about which one
+ * closes the tag is the kind that is wrong once.
+ */
+export const withoutScripts = (html: string): string => {
+  const parts: string[] = [];
+  let rest = html;
+  for (let open = rest.toLowerCase().indexOf("<script"); open !== -1; open = rest.toLowerCase().indexOf("<script")) {
+    const close = rest.toLowerCase().indexOf("</script>", open);
+    if (close === -1) break;
+    parts.push(rest.slice(0, open));
+    rest = rest.slice(close + "</script>".length);
+  }
+  parts.push(rest);
+  return parts.join("");
+};
+
 export const slideToHtml = (image: MulmoSlideMedia, options: BeatHtmlOptions): BeatHtmlFragment => {
   const theme = image.theme ?? options.slideTheme ?? slideThemes.corporate;
   const fragment = generateSlideFragment(theme, image.slide, { scopeClass: `${options.idPrefix}-slide` });
   return {
-    html: fragment.html,
+    html: withoutScripts(fragment.html),
     css: fragment.css,
     ...(fragment.requires.length > 0 ? { requires: fragment.requires } : {}),
     ...(fragment.chartPlugins.length > 0 ? { chartPlugins: fragment.chartPlugins } : {}),

--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -10,7 +10,10 @@ import type { SlideTheme } from "@mulmocast/deck";
  */
 export type BeatHtmlFragment = {
   /**
-   * Body markup only — no `<html>`, `<head>`, `<style>` or `<script>`.
+   * Body markup only — no `<html>`, `<head>` or `<style>`, and no `<script>` that this
+   * module generated. An author's own script is a different matter: one written into an
+   * `html_tailwind` beat's markup, into raw HTML inside a `markdown` beat, or into a
+   * `textSlide` field arrives here verbatim, because nothing below sanitizes.
    *
    * **Not sanitized.** A beat is user data and `marked` does not sanitize: raw elements,
    * `onerror=` handlers and `javascript:` URLs written into a beat survive into this

--- a/src/utils/image_plugins/html_tailwind_markup.ts
+++ b/src/utils/image_plugins/html_tailwind_markup.ts
@@ -4,10 +4,13 @@ import { isSwipeElements, swipeElementsToHtml } from "../swipe_to_html.js";
  * The static markup an html_tailwind beat shows. Pure — no Node, no filesystem — because the
  * Node dump path and the browser fragment path show the same thing.
  *
- * Deliberately no `<script>`: the author's `script`, the swipe animation driver and the
- * frame-based `animation` all need script execution, which the dump path has never emitted
- * and which a fragment injected through `innerHTML` could not run anyway. Both paths show
- * the beat's markup at rest.
+ * Deliberately generates no `<script>`: the author's `script` FIELD, the swipe animation
+ * driver and the frame-based `animation` all need script execution, which the dump path has
+ * never emitted and which a fragment injected through `innerHTML` could not run anyway.
+ * Both paths show the beat's markup at rest.
+ *
+ * A `<script>` the author wrote inside `html` is another thing entirely: it is markup, and
+ * it passes through, because this beat type is raw author markup by design.
  *
  * The author's `html` is emitted as written. It is markup by design on this beat type — the
  * schema also accepts a `script` — so escaping it would break the feature rather than

--- a/test/beat_html/test_export.ts
+++ b/test/beat_html/test_export.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert";
+import { beatToHtml, supportedBeatTypes } from "../../src/index.browser.js";
+import { mulmoBeatSchema } from "../../src/types/schema.js";
+
+/**
+ * What `mulmocast/browser` promises. The unit tests for each beat type live beside it; this
+ * one exists so the export itself cannot be removed or renamed silently.
+ *
+ * Verified in a real browser through this entry point: all eight types rendered, Chart.js
+ * drew its canvas, mermaid produced two SVGs, and `#app` contained no <script>.
+ */
+
+const sample: Record<string, unknown> = {
+  textSlide: { type: "textSlide", slide: { title: "T" } },
+  markdown: { type: "markdown", markdown: "# T" },
+  chart: { type: "chart", title: "T", chartData: { type: "bar", data: { labels: ["a"], datasets: [{ data: [1] }] } } },
+  mermaid: { type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } },
+  image: { type: "image", source: { kind: "url", url: "https://example.com/a.png" } },
+  movie: { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } },
+  slide: { type: "slide", slide: { layout: "title", title: "T" } },
+  html_tailwind: { type: "html_tailwind", html: "<div>T</div>" },
+};
+
+test("the browser entry point exports beatToHtml and its supported types", () => {
+  assert.strictEqual(typeof beatToHtml, "function");
+  assert.deepStrictEqual([...supportedBeatTypes].sort(), Object.keys(sample).sort(), "the list and the samples must not drift apart");
+});
+
+test("every exported type renders through the public entry point", () => {
+  supportedBeatTypes.forEach((type, index) => {
+    const beat = mulmoBeatSchema.parse({ description: "d", image: sample[type] });
+    const fragment = beatToHtml(beat, { idPrefix: `beat-${index}` });
+    assert.ok(fragment, `${type} must render`);
+    assert.ok(fragment.html.length > 0, `${type} must produce markup`);
+    assert.ok(!fragment.html.toLowerCase().includes("<script"), `${type} must not carry a script — an injected one does not execute`);
+  });
+});
+
+test("the host is told which runtimes the whole page needs", () => {
+  const requires = supportedBeatTypes.flatMap(
+    (type, index) => beatToHtml(mulmoBeatSchema.parse({ image: sample[type] }), { idPrefix: `b-${index}` })?.requires ?? [],
+  );
+  assert.ok(requires.includes("chart"), "the chart beat asks for Chart.js");
+  assert.ok(requires.includes("mermaid"), "the mermaid beat asks for mermaid");
+});
+
+test("the id rule applies at the public boundary too", () => {
+  assert.throws(() => beatToHtml(mulmoBeatSchema.parse({ image: sample.textSlide }), { idPrefix: "beat 1" }), /element id must match/);
+});

--- a/test/beat_html/test_export.ts
+++ b/test/beat_html/test_export.ts
@@ -35,7 +35,7 @@ test("every exported type renders through the public entry point", () => {
     const fragment = beatToHtml(beat, { idPrefix: `beat-${index}` });
     assert.ok(fragment, `${type} must render`);
     assert.ok(fragment.html.length > 0, `${type} must produce markup`);
-    assert.ok(!fragment.html.toLowerCase().includes("<script"), `${type} must not carry a script — an injected one does not execute`);
+    assert.ok(!fragment.html.toLowerCase().includes("<script"), `${type} must not carry a GENERATED script — an injected one does not execute`);
   });
 });
 
@@ -49,4 +49,19 @@ test("the host is told which runtimes the whole page needs", () => {
 
 test("the id rule applies at the public boundary too", () => {
   assert.throws(() => beatToHtml(mulmoBeatSchema.parse({ image: sample.textSlide }), { idPrefix: "beat 1" }), /element id must match/);
+});
+
+// The claim above is about what this module generates, not about what an author writes.
+// Nothing is sanitized, so an author's own script reaches the fragment verbatim — which is
+// why the docs tell hosts to sanitize before inserting.
+test("an author's own script is passed through, because nothing here sanitizes", () => {
+  const authored: [string, unknown][] = [
+    ["html_tailwind", { type: "html_tailwind", html: "<div>a</div><script>alert(1)</script>" }],
+    ["markdown", { type: "markdown", markdown: "<script>alert(1)</script>" }],
+    ["textSlide", { type: "textSlide", slide: { title: "<script>alert(1)</script>" } }],
+  ];
+  authored.forEach(([type, image]) => {
+    const fragment = beatToHtml(mulmoBeatSchema.parse({ image }), { idPrefix: "b" });
+    assert.match(fragment?.html ?? "", /<script>alert\(1\)<\/script>/, `${type} passes the author's script through`);
+  });
 });

--- a/test/beat_html/test_export.ts
+++ b/test/beat_html/test_export.ts
@@ -18,8 +18,8 @@ const sample: Record<string, unknown> = {
   mermaid: { type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } },
   image: { type: "image", source: { kind: "url", url: "https://example.com/a.png" } },
   movie: { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } },
-  // A chart block on purpose: deck ships an inline driver script with it, and the no-script
-  // claim below is only worth making if the sample can violate it.
+  // A chart block on purpose: it is the shape that carried an inline driver before deck 2.0.0,
+  // so the no-script assertion below is checked against the case that used to violate it.
   slide: { type: "slide", slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { type: "bar" } }] }, right: { content: [] } } },
   html_tailwind: { type: "html_tailwind", html: "<div>T</div>" },
 };

--- a/test/beat_html/test_export.ts
+++ b/test/beat_html/test_export.ts
@@ -18,7 +18,9 @@ const sample: Record<string, unknown> = {
   mermaid: { type: "mermaid", title: "T", code: { kind: "text", text: "graph TD; A-->B" } },
   image: { type: "image", source: { kind: "url", url: "https://example.com/a.png" } },
   movie: { type: "movie", source: { kind: "url", url: "https://example.com/a.mp4" } },
-  slide: { type: "slide", slide: { layout: "title", title: "T" } },
+  // A chart block on purpose: deck ships an inline driver script with it, and the no-script
+  // claim below is only worth making if the sample can violate it.
+  slide: { type: "slide", slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { type: "bar" } }] }, right: { content: [] } } },
   html_tailwind: { type: "html_tailwind", html: "<div>T</div>" },
 };
 

--- a/test/beat_html/test_slide.ts
+++ b/test/beat_html/test_slide.ts
@@ -73,13 +73,26 @@ test("a chart slide carries its config on the canvas and no script", () => {
 
 // A chart label containing `</script>` is schema-valid. It is why removing a script
 // downstream could not be made safe, and why deck stopped emitting one.
-test("a hostile chart config stays inside its attribute", () => {
+test("a hostile chart config stays inside its attribute, and survives it", () => {
+  const label = "</script><p>injected</p>";
   const hostile = media({
-    slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { label: "</script><p>injected</p>" } }] }, right: { content: [] } },
+    slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { label } }] }, right: { content: [] } },
   });
   const html = slideToHtml(hostile, options()).html;
   assert.strictEqual(html.toLowerCase().split("<script").length - 1, 0);
   assert.ok(!html.includes("<p>injected</p>"), "the payload must not become markup");
+
+  // Neutralized, not dropped: the two assertions above also pass if the renderer throws the
+  // label away, which is chart configuration loss wearing a security fix's clothes.
+  const encoded = html.match(/data-mulmo-chart="([^"]*)"/)?.[1];
+  assert.ok(encoded, "the config must still be on the canvas");
+  const decoded = encoded
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+  assert.strictEqual(JSON.parse(decoded).label, label, "the host must read back exactly what the slide said");
 });
 
 test("a slide with no script is passed through untouched", () => {

--- a/test/beat_html/test_slide.ts
+++ b/test/beat_html/test_slide.ts
@@ -1,8 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import { slideToHtml } from "../../src/utils/beat_html/slide.js";
+import { slideToHtml, withoutScripts } from "../../src/utils/beat_html/slide.js";
 import { beatToHtml } from "../../src/utils/beat_html/index.js";
 import { generateSlideFragment } from "@mulmocast/deck/lib/fragment.js";
+
 import { slideThemes } from "../../src/data/slideThemes.js";
 import { mulmoBeatSchema, mulmoSlideMediaSchema } from "../../src/types/schema.js";
 
@@ -49,6 +50,41 @@ test("the beat's theme wins over the deck's, which wins over the built-in", () =
   assert.match(slideToHtml(media(), options({ slideTheme: deckTheme })).css ?? "", /222222/);
   const fallback = slideToHtml(media(), options()).css ?? "";
   assert.ok(!fallback.includes("111111") && !fallback.includes("222222"), "with neither, the built-in theme is used");
+});
+
+// deck's chart block ships an inline driver script, because the same markup has to work in
+// the standalone document Puppeteer renders. A fragment injected through innerHTML never
+// runs it, and the config is on the canvas as data-mulmo-chart for exactly that reason.
+// Verified in a browser: with the script gone, a host driving [data-mulmo-chart] still draws.
+test("deck's chart driver script is stripped, and only the script", () => {
+  const withChart = media({
+    slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { type: "bar" } }] }, right: { content: [] } },
+  });
+  const mine = slideToHtml(withChart, options()).html;
+  const theirs = generateSlideFragment(slideThemes.corporate, withChart.slide, { scopeClass: "beat-3-slide" }).html;
+
+  assert.strictEqual(mine.toLowerCase().split("<script").length - 1, 0, "no script may survive");
+  assert.ok(theirs.toLowerCase().includes("<script"), "deck's own fragment does carry one, or this test proves nothing");
+  assert.ok(mine.includes("data-mulmo-chart"), "the config the host drives from must remain");
+
+  // Only the script: every other element is still there, in the same number.
+  const count = (html: string, tag: string) => html.toLowerCase().split(`<${tag}`).length - 1;
+  ["div", "canvas", "p", "h2", "span"].forEach((tag) => {
+    assert.strictEqual(count(mine, tag), count(theirs, tag), `<${tag}> count must be unchanged`);
+  });
+});
+
+// Both halves case-insensitively. deck writes lower case today, but a guard that only
+// recognises the spelling it happens to see is weaker than the thing it guards — the same
+// point CodeQL made about an assertion earlier in this series.
+test("the strip is case-insensitive at both ends", () => {
+  const markup = "a<SCRIPT>x</SCRIPT>b<script>y</SCRIPT>c<SCRIPT>z</script>d";
+  assert.strictEqual(withoutScripts(markup), "abcd");
+});
+
+test("a slide with no script is passed through untouched", () => {
+  const plain = media();
+  assert.strictEqual(slideToHtml(plain, options()).html, generateSlideFragment(slideThemes.corporate, plain.slide, { scopeClass: "beat-3-slide" }).html);
 });
 
 test("runtimes and plugins are passed through, and absent when the slide needs none", () => {

--- a/test/beat_html/test_slide.ts
+++ b/test/beat_html/test_slide.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { slideToHtml, withoutScripts } from "../../src/utils/beat_html/slide.js";
+import { slideToHtml } from "../../src/utils/beat_html/slide.js";
 import { beatToHtml } from "../../src/utils/beat_html/index.js";
 import { generateSlideFragment } from "@mulmocast/deck/lib/fragment.js";
 
@@ -52,34 +52,34 @@ test("the beat's theme wins over the deck's, which wins over the built-in", () =
   assert.ok(!fallback.includes("111111") && !fallback.includes("222222"), "with neither, the built-in theme is used");
 });
 
-// deck's chart block ships an inline driver script, because the same markup has to work in
-// the standalone document Puppeteer renders. A fragment injected through innerHTML never
-// runs it, and the config is on the canvas as data-mulmo-chart for exactly that reason.
-// Verified in a browser: with the script gone, a host driving [data-mulmo-chart] still draws.
-test("deck's chart driver script is stripped, and only the script", () => {
+// deck emits no script from a block at all: its chart driver lives in generateSlideHTML,
+// the document API. So a fragment cannot carry one, rather than carrying one this module
+// has to remove — see receptron/mulmocast-deck#28 for why removal could not be made safe.
+test("a chart slide carries its config on the canvas and no script", () => {
   const withChart = media({
     slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { type: "bar" } }] }, right: { content: [] } },
   });
   const mine = slideToHtml(withChart, options()).html;
   const theirs = generateSlideFragment(slideThemes.corporate, withChart.slide, { scopeClass: "beat-3-slide" }).html;
 
-  assert.strictEqual(mine.toLowerCase().split("<script").length - 1, 0, "no script may survive");
-  assert.ok(theirs.toLowerCase().includes("<script"), "deck's own fragment does carry one, or this test proves nothing");
+  assert.strictEqual(mine.toLowerCase().split("<script").length - 1, 0, "no script in the fragment");
+  assert.strictEqual(theirs.toLowerCase().split("<script").length - 1, 0, "deck emits none either — this module removes nothing");
   assert.ok(mine.includes("data-mulmo-chart"), "the config the host drives from must remain");
-
-  // Only the script: every other element is still there, in the same number.
-  const count = (html: string, tag: string) => html.toLowerCase().split(`<${tag}`).length - 1;
-  ["div", "canvas", "p", "h2", "span"].forEach((tag) => {
-    assert.strictEqual(count(mine, tag), count(theirs, tag), `<${tag}> count must be unchanged`);
-  });
+  // deck's own id counter advances per call, so normalise it: what matters is that this
+  // module returns deck's markup rather than a processed copy of it.
+  const withoutIds = (html: string) => html.replace(/id="chart-\d+"/g, 'id="«chart»"');
+  assert.strictEqual(withoutIds(mine), withoutIds(theirs), "and the markup is deck's, untouched");
 });
 
-// Both halves case-insensitively. deck writes lower case today, but a guard that only
-// recognises the spelling it happens to see is weaker than the thing it guards — the same
-// point CodeQL made about an assertion earlier in this series.
-test("the strip is case-insensitive at both ends", () => {
-  const markup = "a<SCRIPT>x</SCRIPT>b<script>y</SCRIPT>c<SCRIPT>z</script>d";
-  assert.strictEqual(withoutScripts(markup), "abcd");
+// A chart label containing `</script>` is schema-valid. It is why removing a script
+// downstream could not be made safe, and why deck stopped emitting one.
+test("a hostile chart config stays inside its attribute", () => {
+  const hostile = media({
+    slide: { layout: "split", title: "T", left: { content: [{ type: "chart", chartData: { label: "</script><p>injected</p>" } }] }, right: { content: [] } },
+  });
+  const html = slideToHtml(hostile, options()).html;
+  assert.strictEqual(html.toLowerCase().split("<script").length - 1, 0);
+  assert.ok(!html.includes("<p>injected</p>"), "the payload must not become markup");
 });
 
 test("a slide with no script is passed through untouched", () => {

--- a/types/package.json
+++ b/types/package.json
@@ -13,7 +13,7 @@
     "lib"
   ],
   "dependencies": {
-    "@mulmocast/deck": "^1.2.0",
+    "@mulmocast/deck": "^2.0.0",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/types/yarn.lock
+++ b/types/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@mulmocast/deck@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-1.2.0.tgz#c8cf6de1a073f00fa1879ddbe99087692855b7e2"
-  integrity sha512-sDmAlXhKjORshQBNWOKblm1kX5nVrvziH7p45i0NeDZPisgJ1U62ZvHYKWjRNZ+lcRys1wCP57W5j9ojV+vCgA==
+"@mulmocast/deck@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-2.0.0.tgz#e4b6c7079c7100caf53d3f88525d84d361675b9a"
+  integrity sha512-XKpytrEidr86dQyJMXEWPEGDrWdHLi/ziECEPC34VugHmsWxu9L3r04T49gAvZMpqBLJ5H478bYrLT8yInET1w==
   dependencies:
     zod "^4.4.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -695,10 +695,10 @@
   resolved "https://registry.yarnpkg.com/@mozilla/readability/-/readability-0.6.0.tgz#134e3ce3ff1676716e550de0b8de957bcc59208b"
   integrity sha512-juG5VWh4qAivzTAeMzvY9xs9HY5rAcr2E4I7tiSSCokRFi7XIZCAu92ZkSTsIj1OPceCifL3cpfteP3pDT9/QQ==
 
-"@mulmocast/deck@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-1.2.0.tgz#c8cf6de1a073f00fa1879ddbe99087692855b7e2"
-  integrity sha512-sDmAlXhKjORshQBNWOKblm1kX5nVrvziH7p45i0NeDZPisgJ1U62ZvHYKWjRNZ+lcRys1wCP57W5j9ojV+vCgA==
+"@mulmocast/deck@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@mulmocast/deck/-/deck-2.0.0.tgz#e4b6c7079c7100caf53d3f88525d84d361675b9a"
+  integrity sha512-XKpytrEidr86dQyJMXEWPEGDrWdHLi/ziECEPC34VugHmsWxu9L3r04T49gAvZMpqBLJ5H478bYrLT8yInET1w==
   dependencies:
     zod "^4.4.3"
 


### PR DESCRIPTION
## Summary

`#1526` の最終 PR です。`beatToHtml` を公開経路 `mulmocast/browser` から出し、`docs/api.md` に host 契約を書きました。

- `src/index.browser.ts` から `beatToHtml` / `supportedBeatTypes` / 型3つ
- `docs/api.md` に「Browser: rendering beats as HTML fragments」節

**これで 8 beat 種別すべてがブラウザから使えます。**

## Items to Confirm / Review

### 1. なぜ `index.common.ts` ではなく browser entry か

`test_browser_safety.ts` が**このモジュールの import グラフを見張っている**ためです。Node 依存が紛れ込めば、利用者のビルドではなくそのテストが落ちます。common に置くと、その保証の外に出ます。

### 2. バンドルの増分（実測）

| | 入力 | サイズ |
|---|---|---|
| 現状の index.browser | 147 | 3052 KB |
| 本PR適用後 | 164 | 3169.8 KB |
| **増分** | **+17** | **+117.7 KB** |

**Node 組み込みはゼロ**。deck の 19 ファイルは既に既存グラフに入っているので、実質増えるのは marked と自リポジトリのコードだけです。

### 3. 実ブラウザで最終検証しました

公開経路から全 8 種別を呼び、**host が書くのと同じページ**（`requires` から CDN を読み、fragment を `innerHTML` で注入し、`[data-mulmo-chart]` と `.mermaid` を駆動）を組み立てて描画しました。

| beat | 描画 | 内容 |
|---|---|---|
| textSlide | 🟢 | `Text Slide one two` |
| markdown | 🟢 | `Markdown` + mermaid |
| chart | 🟢 | `Chart & Co` |
| mermaid | 🟢 | `Mermaid` |
| image | 🟢 | `<img>` |
| movie | 🟢 | `<video>` |
| slide | 🟢 | `Slide` |
| html_tailwind | 🟢 | `HTML Tailwind` |

**Chart.js が描いた canvas: 1、mermaid SVG: 2、`#app` 内の `<script>`: 0、pageerror: なし。**（deck 2.0.0 で再実行済み）

### 5. deck 2.0.0 に上げています（round 1-2 の結果）

Codex が「`fragments carry no <script>` が slide beat で偽」と指摘し、当初は cli 側で文字列除去しました。round 2 でその除去が**安全にできない**ことが判明します — chart label の `</script>`（スキーマを通る）が script 内 JSON のエスケープ不足により本物の終端になり、除去が早く止まって残骸が出ます。

オーナーの指示（「optionよりもapiをわけるとか、そういう安全な方法が良い。事故起きないように」）を受けて、**上流で API を分けました**:

| | 変更前 | 変更後 |
|---|---|---|
| `renderChart`（deck の block） | canvas + inline script | **canvas のみ** |
| `generateSlideHTML`（文書 API） | block の script に依存 | **ページに driver を1つ** |
| `generateSlideFragment`（断片 API） | script が混入 | **構造的に混入しえない** |

→ receptron/mulmocast-deck#28（Codex LGTM・指摘ゼロ）、**@mulmocast/deck@2.0.0 として公開済み**

これにより **cli 側の除去コードは不要になり、削除しました**。fragment は deck の markup をそのまま返します（テストで id 正規化のうえ同一性を固定）。deck は root と `types/` の両方で 2.0.0 に上げ、**クリーン install で検証**しています。

### 4. ドキュメントを書きました

`docs/api.md` に host の責務を明記しています — **サニタイズ**、`requires` の runtime を**ページに1回だけ**ロード、`[data-mulmo-chart]` と `.mermaid` を**自分で駆動**。型からは読み取れない契約なので書きました。

`idPrefix` の規則（`[A-Za-z_][A-Za-z0-9_-]*`、index から derive する）と、`mermaid` が text のみ・`image`/`movie` の base64 が非対応である理由も記載しています。

## 検証

- `npx prettier --check` / `npx eslint`: clean
- `npx tsc --noEmit` / `npx tsc` / `cd types && npx tsc`: すべて clean
- `NODE_ENV=test npx tsx --test test/*/test_*.ts`: **1165 tests, 0 fail**
- browser-safety ゲート 7/7 pass
- **変異2種で赤くなることを確認**: export を外す（fail=1）、`supportedBeatTypes` から1つ落とす（fail=1）

## User Prompt

> ちょっと、ここのdirをベースにして、../mulmocast-editorをつくり、mulmoscriptでslide, deck tailwind系のbeatのみで構成されたものを、vueのcomponentでreactiveにhtmlでbeatsを一覧で表示するものと、それを簡単にweb上で編集するようなツールを作り、componentとしてnpmで公開したい
>
> できれば、それらもiframeつかわないで、divで描写できないかな
>
> そのためのmulmocast-cliのimage pluginなんだ

cli 側はこれで完了です。次は `@mulmocast/deck-web` 側の一覧表示・編集 UI（receptron/mulmocast-deck-web#22, #23）。

Closes #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser-accessible exports for converting supported beat types into HTML.
  * Added access to supported beat types and related rendering types through the browser entry point.

* **Documentation**
  * Expanded API documentation with browser rendering exports, limitations, lifecycle guidance, and usage examples.
  * Clarified generated markup, author-provided scripts, Tailwind requirements, and chart initialization behavior.
  * Added a plan documenting HTML export coverage, browser compatibility, and validation requirements.

* **Tests**
  * Added browser checks for supported beat types, script-free markup, required rendering runtimes, and invalid ID prefixes.
  * Verified chart slide fragments preserve configuration safely without embedding executable scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
