### PR TITLE
ci: report type errors in test/ without gating on them

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -63,6 +63,47 @@ jobs:
         yarn run build
     - run: yarn run ci_test
 
+  # Reports type errors in test/ WITHOUT gating the PR. tsconfig.json's `include` is `src`,
+  # so the tests have never been typechecked and have accumulated a backlog. Blocking on it
+  # today would block every unrelated PR; leaving it unmeasured lets it grow silently. The
+  # count in the job summary is the middle ground until the backlog is cleared (issue #1551).
+  typecheck_tests:
+    name: typecheck test/ (warn, non-blocking)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v5
+      with:
+        node-version: 22.x
+        cache: 'yarn'
+    - name: Install dependencies
+      env:
+        PUPPETEER_SKIP_DOWNLOAD: true
+      run: yarn install --frozen-lockfile
+    - name: Typecheck test/
+      continue-on-error: true
+      run: |
+        set -o pipefail
+        yarn run typecheck:test 2>&1 | tee typecheck-test.log || true
+        COUNT=$(grep -cE "error TS[0-9]+" typecheck-test.log || true)
+        {
+          echo "## \`test/\` typecheck: ${COUNT} error(s)"
+          echo
+          echo "Non-blocking. See the tracking issue for the backlog."
+          echo
+          echo "### By error code"
+          echo '```'
+          grep -oE "error TS[0-9]+" typecheck-test.log | sort | uniq -c | sort -rn | head -15 || true
+          echo '```'
+          echo "### By file"
+          echo '```'
+          grep -E "error TS[0-9]+" typecheck-test.log | cut -d'(' -f1 | sort | uniq -c | sort -rn | head -15 || true
+          echo '```'
+        } >> "$GITHUB_STEP_SUMMARY"
+
   lint_test_cross_platform:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ci_test": "cross-env NODE_ENV=test tsx --test --experimental-test-coverage ./test/*/test_*.ts",
     "lint": "eslint src test assets/html/js",
     "build": "tsc",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "build_test": "tsc && git checkout -- lib/*",
     "cli": "npx tsx ./src/cli/bin.ts",
     "scripting": "npx tsx ./src/cli/bin.ts tool scripting",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    /* The base config emits the published package: rootDir pins it to src/ and declaration
+       describes the output. Neither applies to a type-only pass over the tests. */
+    "rootDir": ".",
+    "declaration": false,
+    "types": ["archiver", "jsdom", "yargs", "node"]
+  },
+  "include": ["test/**/*.ts"],
+  "exclude": ["node_modules", "lib"]
+}


### PR DESCRIPTION
## Summary

**`test/` は一度も型検査されたことがなく、有効化すると 279 件出ます。** 一括修正は1 PR には大きすぎるので、**非ブロッキングの CI job** で件数を可視化するところまでを入れました。PR は止めません。

バックログと解消プランは `#1551` に書いています。

## Items to Confirm / Review

### 1. これは「直す PR」ではなく「見えるようにする PR」です

ブロッキングにすると無関係な PR まで全部止まります。放置すると増え続けます。その中間として、job summary に**件数・エラーコード別・ファイル別**を出します:

```
## \`test/\` typecheck: 279 error(s)

### By error code
  71 error TS18048
  69 error TS2741
  37 error TS2345
  ...
### By file
  76 test/image_plugins/test_image_plugin_markdown.ts
  21 test/methods/test_presentation_style_movie.ts
  ...
```

これは**ローカルで実際に `GITHUB_STEP_SUMMARY` を渡して実行した実出力**です。シェルのクォート事故は CI で初めて出ると気づきにくいので、読むだけで済ませていません。

### 2. 279 件は 279 個の別問題ではありません（`#1551` に詳述）

サンプリングすると **2パターンで 6 割超**です:

| パターン | 件数 | 内容 |
|---|---:|---|
| `findImagePlugin` の戻り値を narrowing せず使用 | ≒101 | `Plugin \| undefined` を生で `plugin.imageType` |
| `text` の無い beat を手で組んでいる | ≒69 | `MulmoBeat.text` は必須 |

ヘルパー2つでほぼ落ちる見込みです。

**本番のバグは隠れていませんでした** — `findImagePlugin` を生で呼んでいるのはテストだけで、`getBeatPlugin` は `if (!plugin)` で正しく扱っています。つまり型は正直で、テストがそれを無視していた形です。ここは確認済みとして報告します。

一方で `text` の無い beat は、**テストが実在しない形のデータを組んでいる**ということなので、機械的に `text: ""` を足すのではなく1ファイルずつ意図を確認すべきだと考えています。

### 3. 独立した job にした理由

`lint_test` は ffmpeg / Chromium / Puppeteer 用のシステムライブラリを入れます。型検査だけならどれも不要なので、checkout + node + install だけの軽い job にしました。

### 4. `continue-on-error` の位置

step 側に付けています（job 側ではなく）。job 自体は success で終わるので、required check の設定に手を入れずに済みます。

## 検証

- `lint` / `build`: green
- `typecheck:test`: 279 errors（**意図どおり非ゼロ**。ゼロなら「何も見ていない」を疑うべき値です）
- break-check: `test/` に型エラーを仕込むと**変更前は無言、変更後は報告される**ことを確認

## 残タスク

`#1551` を消化したら、この job をブロッキングに切り替えるか `lint_test` に統合します。最終形は `mulmoterminal`（`tsconfig.test.json` を `references` に入れて `test/` を型検査している唯一のリポ）に合わせる想定です。

## User Prompt

> test/ が typecheck ってチェックしてほしいし、他のmulmocast-cliとかdeckけいもかくにんして
>
> ok そのじゅんで。3はwarnにできるならwarnで一旦回避したいね

（mulmo 系 6 リポを調査 → `mulmoterminal` 以外すべて未検査。エラー 0 の viewer / deck-web / movie、4件の deck を先に対応済み。これが最後の cli で、指示どおり warn 運用）

Refs #1551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated TypeScript checks for test files.
  * Test type-check results are summarized in CI without blocking builds.

* **Chores**
  * Added configuration to validate test code without generating output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->