### PR TITLE
test: assert a plugin exists once, instead of at 93 call sites

### DIFF
--- a/test/beat_html/test_html_tailwind.ts
+++ b/test/beat_html/test_html_tailwind.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 import { htmlTailwindToHtml } from "../../src/utils/beat_html/html_tailwind.js";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireImagePlugin } from "../image_plugins/utils.js";
 import { mulmoHtmlTailwindMediaSchema } from "../../src/types/schema.js";
 
 /**
@@ -62,7 +62,7 @@ test("elements that are not an array of objects fall back to html", () => {
 
 // One implementation, two callers: if they drift, the browser and the PNG dump disagree.
 test("the fragment is the same markup the document dump produces", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireImagePlugin("html_tailwind");
   for (const over of [{ html: "<div>a</div>" }, { html: ["a", "b"] }, { elements: [{ id: "p", text: "x" }] }]) {
     const image = media(over);
     assert.strictEqual(htmlTailwindToHtml(image)!.html, await plugin.html!({ beat: { image } }), JSON.stringify(over));

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 import { chartHtml, escapedChartTemplateValues, resolveChartPlugins, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireImagePlugin } from "./utils.js";
 
 /**
  * Characterization tests for the chart renderer, which is shared by the Node render path
@@ -15,7 +15,7 @@ import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
 const CHART_DATA = { type: "bar", data: { labels: ["a", "b"], datasets: [{ data: [1, 2] }] } };
 
 const chartPluginHtml = () => {
-  const plugin = findImagePlugin("chart");
+  const plugin = requireImagePlugin("chart");
   assert.ok(plugin?.html, "the chart plugin must expose an html method");
   return plugin.html;
 };

--- a/test/image_plugins/test_html_animation.ts
+++ b/test/image_plugins/test_html_animation.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireHtmlPlugin } from "./utils.js";
 import { mulmoHtmlTailwindMediaSchema, htmlTailwindAnimationSchema } from "../../src/types/schema.js";
 import { normalizeEvenDimensions } from "../../src/utils/ffmpeg_utils.js";
 import { MulmoBeatMethods } from "../../src/methods/index.js";
@@ -76,7 +76,7 @@ test("mulmoHtmlTailwindMediaSchema - rejects unknown fields (strict)", () => {
 // === Plugin tests (no Puppeteer, no FFmpeg) ===
 
 test("html_tailwind plugin - static beat returns correct path", () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -94,7 +94,7 @@ test("html_tailwind plugin - static beat returns correct path", () => {
 });
 
 test("html_tailwind plugin - animated beat returns correct path (parrotingImagePath)", () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   // When animated, imagePluginAgent passes the .mp4 path as imagePath
@@ -114,7 +114,7 @@ test("html_tailwind plugin - animated beat returns correct path (parrotingImageP
 });
 
 test("html_tailwind plugin - html dump works for static beat", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
@@ -133,7 +133,7 @@ test("html_tailwind plugin - html dump works for static beat", async () => {
 });
 
 test("html_tailwind plugin - html dump works for animated beat", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
@@ -169,7 +169,7 @@ test("mulmoHtmlTailwindMediaSchema - animation: false is rejected by schema", ()
 });
 
 test("html_tailwind plugin - animation: false treated as static", () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {

--- a/test/image_plugins/test_html_tailwind_plugin.ts
+++ b/test/image_plugins/test_html_tailwind_plugin.ts
@@ -1,16 +1,16 @@
 import test from "node:test";
 import assert from "node:assert";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireHtmlPlugin } from "./utils.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
 
 test("html_tailwind plugin basic functionality", () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
   assert.strictEqual(plugin.imageType, "html_tailwind");
 });
 
 test("html_tailwind plugin path function", () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -28,7 +28,7 @@ test("html_tailwind plugin path function", () => {
 });
 
 test("html_tailwind plugin html generation with string html", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
@@ -47,7 +47,7 @@ test("html_tailwind plugin html generation with string html", async () => {
 });
 
 test("html_tailwind plugin html generation with array html", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
@@ -82,7 +82,7 @@ test("html_tailwind plugin html generation with array html", async () => {
 });
 
 test("html_tailwind plugin with complex tailwind classes", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -115,7 +115,7 @@ test("html_tailwind plugin with complex tailwind classes", async () => {
 });
 
 test("html_tailwind plugin with form elements", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -156,7 +156,7 @@ test("html_tailwind plugin with form elements", async () => {
 });
 
 test("html_tailwind plugin with grid layout", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -192,7 +192,7 @@ test("html_tailwind plugin with grid layout", async () => {
 });
 
 test("html_tailwind plugin with empty html string", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -210,7 +210,7 @@ test("html_tailwind plugin with empty html string", async () => {
 });
 
 test("html_tailwind plugin with empty html array", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
   const mockParams: ImageProcessorParams = {

--- a/test/image_plugins/test_image_plugin.ts
+++ b/test/image_plugins/test_image_plugin.ts
@@ -1,11 +1,11 @@
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireImagePlugin } from "./utils.js";
 import { resolve } from "node:path";
 
 import test from "node:test";
 import assert from "node:assert";
 
 test("test imagePlugin mermaid", async () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireImagePlugin("mermaid");
   assert.equal(plugin.imageType, "mermaid");
 
   const path = plugin.path({ imagePath: "expectImagePath" });
@@ -13,7 +13,7 @@ test("test imagePlugin mermaid", async () => {
 });
 
 test("test imagePlugin image url", async () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert.equal(plugin.imageType, "image");
 
   const path = plugin.path(
@@ -32,7 +32,7 @@ test("test imagePlugin image url", async () => {
 });
 
 test("test imagePlugin image path", async () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert.equal(plugin.imageType, "image");
 
   const path = plugin.path({
@@ -49,7 +49,7 @@ test("test imagePlugin image path", async () => {
 });
 
 test("test imagePlugin beat", async () => {
-  const plugin = findImagePlugin("beat");
+  const plugin = requireImagePlugin("beat");
   assert.equal(plugin.imageType, "beat");
 
   const path = plugin.path({ type: "beat", imagePath: "expectImagePath" });

--- a/test/image_plugins/test_image_plugin_html.ts
+++ b/test/image_plugins/test_image_plugin_html.ts
@@ -1,15 +1,15 @@
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireHtmlPlugin } from "./utils.js";
 
 import test from "node:test";
 import assert from "node:assert";
 
 test("test imagePlugin html_tailwind - basic functionality", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   assert.equal(plugin.imageType, "html_tailwind");
 });
 
 test("test imagePlugin html_tailwind - html method with string", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   const beat = {
     image: {
       type: "html_tailwind",
@@ -22,7 +22,7 @@ test("test imagePlugin html_tailwind - html method with string", async () => {
 });
 
 test("test imagePlugin html_tailwind - html method with array", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   const beat = {
     image: {
       type: "html_tailwind",
@@ -35,7 +35,7 @@ test("test imagePlugin html_tailwind - html method with array", async () => {
 });
 
 test("test imagePlugin html_tailwind - html method with wrong type", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   const beat = {
     image: {
       type: "markdown",
@@ -48,7 +48,7 @@ test("test imagePlugin html_tailwind - html method with wrong type", async () =>
 });
 
 test("test imagePlugin html_tailwind - html method with no image", async () => {
-  const plugin = findImagePlugin("html_tailwind");
+  const plugin = requireHtmlPlugin("html_tailwind");
   const beat = {};
 
   const result = await plugin.html({ beat });

--- a/test/image_plugins/test_image_plugin_markdown.ts
+++ b/test/image_plugins/test_image_plugin_markdown.ts
@@ -1,15 +1,15 @@
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireRenderingPlugin } from "./utils.js";
 
 import test from "node:test";
 import assert from "node:assert";
 
 test("test imagePlugin markdown - basic functionality", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   assert.equal(plugin.imageType, "markdown");
 });
 
 test("test imagePlugin markdown - markdown method with array", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {
     image: {
       type: "markdown",
@@ -25,7 +25,7 @@ test("test imagePlugin markdown - markdown method with array", async () => {
 });
 
 test("test imagePlugin markdown - markdown method with string", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {
     image: {
       type: "markdown",
@@ -38,7 +38,7 @@ test("test imagePlugin markdown - markdown method with string", async () => {
 });
 
 test("test imagePlugin markdown - html method converts markdown to html", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {
     image: {
       type: "markdown",
@@ -52,7 +52,7 @@ test("test imagePlugin markdown - html method converts markdown to html", async 
 });
 
 test("test imagePlugin markdown - methods with wrong type", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {
     image: {
       type: "html_tailwind",
@@ -68,7 +68,7 @@ test("test imagePlugin markdown - methods with wrong type", async () => {
 });
 
 test("test imagePlugin markdown - methods with no image", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {};
 
   const markdownResult = plugin.markdown({ beat });
@@ -79,7 +79,7 @@ test("test imagePlugin markdown - methods with no image", async () => {
 });
 
 test("test imagePlugin textSlide - markdown method with slide data", async () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   const beat = {
     image: {
       type: "textSlide",
@@ -96,7 +96,7 @@ test("test imagePlugin textSlide - markdown method with slide data", async () =>
 });
 
 test("test imagePlugin textSlide - markdown method with only title", async () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   const beat = {
     image: {
       type: "textSlide",
@@ -111,7 +111,7 @@ test("test imagePlugin textSlide - markdown method with only title", async () =>
 });
 
 test("test imagePlugin textSlide - markdown method with bullets only", async () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   const beat = {
     image: {
       type: "textSlide",
@@ -126,7 +126,7 @@ test("test imagePlugin textSlide - markdown method with bullets only", async () 
 });
 
 test("test imagePlugin textSlide - html method converts slide to html", async () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   const beat = {
     image: {
       type: "textSlide",
@@ -143,7 +143,7 @@ test("test imagePlugin textSlide - html method converts slide to html", async ()
 });
 
 test("test imagePlugin mermaid - markdown method with text code", async () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   const beat = {
     image: {
       type: "mermaid",
@@ -159,7 +159,7 @@ test("test imagePlugin mermaid - markdown method with text code", async () => {
 });
 
 test("test imagePlugin mermaid - markdown method with non-text code", async () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   const beat = {
     image: {
       type: "mermaid",
@@ -175,7 +175,7 @@ test("test imagePlugin mermaid - markdown method with non-text code", async () =
 });
 
 test("test imagePlugin mermaid - markdown method with wrong type", async () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   const beat = {
     image: {
       type: "chart",
@@ -191,7 +191,7 @@ test("test imagePlugin mermaid - markdown method with wrong type", async () => {
 });
 
 test("test imagePlugin markdown - markdown method with object", async () => {
-  const plugin = findImagePlugin("markdown");
+  const plugin = requireRenderingPlugin("markdown");
   const beat = {
     image: {
       type: "markdown",

--- a/test/image_plugins/test_image_plugin_vision.ts
+++ b/test/image_plugins/test_image_plugin_vision.ts
@@ -1,10 +1,10 @@
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireImagePlugin } from "./utils.js";
 
 import test from "node:test";
 import assert from "node:assert";
 
 test("test imagePlugin mermaid", async () => {
-  const plugin = findImagePlugin("vision");
+  const plugin = requireImagePlugin("vision");
   assert.equal(plugin.imageType, "vision");
 
   // const path = plugin.path({ imagePath: "expectImagePath" });

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -1,17 +1,17 @@
 import test from "node:test";
 import assert from "node:assert";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireRenderingPlugin } from "./utils.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
 import { escapedMermaidTemplateValues, mermaidHtml } from "../../src/utils/image_plugins/mermaid_html.js";
 
 test("mermaid plugin basic functionality", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert.strictEqual(plugin.imageType, "mermaid");
 });
 
 test("mermaid plugin path function", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -33,7 +33,7 @@ test("mermaid plugin path function", () => {
 });
 
 test("mermaid plugin markdown generation with text code", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -56,7 +56,7 @@ test("mermaid plugin markdown generation with text code", () => {
 });
 
 test("mermaid plugin markdown generation with simple flowchart", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -78,7 +78,7 @@ test("mermaid plugin markdown generation with simple flowchart", () => {
 });
 
 test("mermaid plugin markdown generation with sequence diagram", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -103,7 +103,7 @@ test("mermaid plugin markdown generation with sequence diagram", () => {
 });
 
 test("mermaid plugin markdown generation with class diagram", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -125,7 +125,7 @@ test("mermaid plugin markdown generation with class diagram", () => {
 });
 
 test("mermaid plugin markdown generation with non-text code returns undefined", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -147,7 +147,7 @@ test("mermaid plugin markdown generation with non-text code returns undefined", 
 });
 
 test("mermaid plugin markdown generation with wrong image type", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
@@ -166,7 +166,7 @@ test("mermaid plugin markdown generation with wrong image type", () => {
 });
 
 test("mermaid plugin with gantt chart", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -189,7 +189,7 @@ test("mermaid plugin with gantt chart", () => {
 });
 
 test("mermaid plugin with pie chart", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -212,7 +212,7 @@ test("mermaid plugin with pie chart", () => {
 });
 
 test("mermaid plugin with user journey", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -234,7 +234,7 @@ test("mermaid plugin with user journey", () => {
 });
 
 test("mermaid plugin with empty code", () => {
-  const plugin = findImagePlugin("mermaid");
+  const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
   const mockParams: ImageProcessorParams = {

--- a/test/image_plugins/test_slide_plugin.ts
+++ b/test/image_plugins/test_slide_plugin.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireHtmlPlugin } from "./utils.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
 
 const validTheme = {
@@ -42,13 +42,13 @@ const altTheme = {
 };
 
 test("slide plugin basic functionality", () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert.strictEqual(plugin.imageType, "slide");
 });
 
 test("slide plugin path function", () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
 
   const mockParams = {
@@ -67,7 +67,7 @@ test("slide plugin path function", () => {
 });
 
 test("slide plugin html uses beat.image.theme when provided", async () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
@@ -92,7 +92,7 @@ test("slide plugin html uses beat.image.theme when provided", async () => {
 });
 
 test("slide plugin html falls back to slideParams.theme when beat theme is missing", async () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
@@ -120,7 +120,7 @@ test("slide plugin html falls back to slideParams.theme when beat theme is missi
 });
 
 test("slide plugin html uses beat theme over slideParams theme (override)", async () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
@@ -149,7 +149,7 @@ test("slide plugin html uses beat theme over slideParams theme (override)", asyn
 });
 
 test("slide plugin html uses corporate theme as default when both themes are missing", async () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
@@ -172,7 +172,7 @@ test("slide plugin html uses corporate theme as default when both themes are mis
 });
 
 test("slide plugin html returns undefined for non-slide beat", async () => {
-  const plugin = findImagePlugin("slide");
+  const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 

--- a/test/image_plugins/test_source_plugins.ts
+++ b/test/image_plugins/test_source_plugins.ts
@@ -1,18 +1,18 @@
 import test from "node:test";
 import assert from "node:assert";
 import { resolve } from "node:path";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireImagePlugin } from "./utils.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
 
 // Image plugin tests
 test("image plugin basic functionality", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
   assert.strictEqual(plugin.imageType, "image");
 });
 
 test("image plugin path with URL source", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -33,7 +33,7 @@ test("image plugin path with URL source", () => {
 });
 
 test("image plugin path with path source", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -59,7 +59,7 @@ test("image plugin path with path source", () => {
 });
 
 test("image plugin path with relative path source", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -85,7 +85,7 @@ test("image plugin path with relative path source", () => {
 });
 
 test("image plugin path with wrong image type", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -104,13 +104,13 @@ test("image plugin path with wrong image type", () => {
 
 // Movie plugin tests
 test("movie plugin basic functionality", () => {
-  const plugin = findImagePlugin("movie");
+  const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
   assert.strictEqual(plugin.imageType, "movie");
 });
 
 test("movie plugin path with URL source", () => {
-  const plugin = findImagePlugin("movie");
+  const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -132,7 +132,7 @@ test("movie plugin path with URL source", () => {
 });
 
 test("movie plugin path with path source", () => {
-  const plugin = findImagePlugin("movie");
+  const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -158,7 +158,7 @@ test("movie plugin path with path source", () => {
 });
 
 test("movie plugin path extension fix", () => {
-  const plugin = findImagePlugin("movie");
+  const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -180,7 +180,7 @@ test("movie plugin path extension fix", () => {
 });
 
 test("movie plugin path with .mov already in imagePath", () => {
-  const plugin = findImagePlugin("movie");
+  const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -202,8 +202,8 @@ test("movie plugin path with .mov already in imagePath", () => {
 
 // Edge cases for both image and movie plugins
 test("source plugins with no image property", () => {
-  const imagePlugin = findImagePlugin("image");
-  const moviePlugin = findImagePlugin("movie");
+  const imagePlugin = requireImagePlugin("image");
+  const moviePlugin = requireImagePlugin("movie");
 
   const mockParams: ImageProcessorParams = {
     imagePath: "/test/path/file.png",
@@ -218,7 +218,7 @@ test("source plugins with no image property", () => {
 });
 
 test("source plugins with unknown source kind", () => {
-  const imagePlugin = findImagePlugin("image");
+  const imagePlugin = requireImagePlugin("image");
 
   const mockParams: ImageProcessorParams = {
     imagePath: "/test/path/image.png",
@@ -244,7 +244,7 @@ test("source plugins with unknown source kind", () => {
 });
 
 test("image plugin with absolute path source", () => {
-  const plugin = findImagePlugin("image");
+  const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
   const mockParams: ImageProcessorParams = {

--- a/test/image_plugins/test_text_slide_plugin.ts
+++ b/test/image_plugins/test_text_slide_plugin.ts
@@ -1,16 +1,16 @@
 import test from "node:test";
 import assert from "node:assert";
-import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+import { requireRenderingPlugin } from "./utils.js";
 import { ImageProcessorParams } from "../../src/types/index.js";
 
 test("text_slide plugin basic functionality", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert.strictEqual(plugin.imageType, "textSlide");
 });
 
 test("text_slide plugin path function", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
 
   const mockParams: ImageProcessorParams = {
@@ -30,7 +30,7 @@ test("text_slide plugin path function", () => {
 });
 
 test("text_slide plugin markdown generation with title only", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
@@ -51,7 +51,7 @@ test("text_slide plugin markdown generation with title only", () => {
 });
 
 test("text_slide plugin markdown generation with title and subtitle", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
@@ -73,7 +73,7 @@ test("text_slide plugin markdown generation with title and subtitle", () => {
 });
 
 test("text_slide plugin markdown generation with title, subtitle, and bullets", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
@@ -96,7 +96,7 @@ test("text_slide plugin markdown generation with title, subtitle, and bullets", 
 });
 
 test("text_slide plugin markdown generation with bullets only", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
@@ -117,7 +117,7 @@ test("text_slide plugin markdown generation with bullets only", () => {
 });
 
 test("text_slide plugin markdown generation with empty slide", () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
@@ -136,7 +136,7 @@ test("text_slide plugin markdown generation with empty slide", () => {
 });
 
 test("text_slide plugin html generation", async () => {
-  const plugin = findImagePlugin("textSlide");
+  const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.html, "textSlide plugin should have html function");
 

--- a/test/image_plugins/utils.ts
+++ b/test/image_plugins/utils.ts
@@ -1,0 +1,38 @@
+import { findImagePlugin } from "../../src/utils/image_plugins/index.js";
+
+/**
+ * The plugin registered for `imageType`, or a failed test.
+ *
+ * `findImagePlugin` answers `undefined` for a type it does not know, and production handles
+ * that — `getBeatPlugin` checks it before use. A test that names a plugin literally is
+ * asserting the plugin exists, so throwing here says that out loud; reading through the
+ * optional at every call site says it in 93 places and means it in none.
+ */
+export const requireImagePlugin = (imageType: string) => {
+  const plugin = findImagePlugin(imageType);
+  if (!plugin) throw new Error(`no image plugin registered for "${imageType}"`);
+  return plugin;
+};
+
+/**
+ * The plugin for `imageType`, with `html()` known to be present.
+ *
+ * `html` and `markdown` are optional on the plugin table because not every plugin renders
+ * both — `image` and `beat` render neither. A test that calls one is asserting this plugin
+ * has it, which is a fact about the plugin and belongs in one place rather than as an
+ * optional-chain at every call.
+ */
+export const requireHtmlPlugin = (imageType: string) => {
+  const plugin = requireImagePlugin(imageType);
+  const { html } = plugin;
+  if (!html) throw new Error(`image plugin "${imageType}" has no html()`);
+  return { ...plugin, html };
+};
+
+/** The plugin for `imageType`, with both `markdown()` and `html()` known to be present. */
+export const requireRenderingPlugin = (imageType: string) => {
+  const plugin = requireHtmlPlugin(imageType);
+  const { markdown } = plugin;
+  if (!markdown) throw new Error(`image plugin "${imageType}" has no markdown()`);
+  return { ...plugin, markdown };
+};


### PR DESCRIPTION
## Summary

`#1551` の 279 件のうち、**93 件を1つのヘルパー群で落とします**（279 → 186）。個別に型注釈を足す作業ではありません。

`Refs #1551`

## Items to Confirm / Review

### 1. 型は正直で、テストがそれを無視していました

```ts
const plugin = findImagePlugin("markdown");   // Plugin | undefined
assert.equal(plugin.imageType, "markdown");   // ← 93件はこの形
const result = plugin.markdown({ beat });     // markdown も html も optional
```

`undefined` になりうるのは事実ですし、`markdown` / `html` が optional なのも事実です — **`image` と `beat` はどちらも持ちません**。そして **本番側は正しく扱っています**（`getBeatPlugin` が `if (!plugin)` でチェック）。生で呼んでいるのはテストだけなので、直す場所はテスト側です。

### 2. ヘルパーは「テストが既に前提にしていること」を明文化したものです

| ヘルパー | 保証 |
|---|---|
| `requireImagePlugin` | plugin が存在する |
| `requireHtmlPlugin` | ＋ `html()` を持つ |
| `requireRenderingPlugin` | ＋ `markdown()` も持つ |

いずれも**その member を必須にした plugin を返す**ので、既存の `plugin.markdown(...)` / `plugin.html(...)` 51箇所は**一切書き換えていません**。変更は1ファイルにつき import と呼び出し名の1行だけです。

### 3. 変換前に「テストが失われないこと」を確認しています

- **全 81 呼び出しが登録済みの種別**を指定している（`"beat"` も実在: `src/utils/image_plugins/beat.ts`）
- **`undefined` を検証しているテストは1件も無い** → throw に変えても失うカバレッジがありません

どちらも grep で確認しました。ここが逆だったら、ヘルパーは「テストを黙らせる装置」になっていたはずです。

### 4. ヘルパー自体が本当に落ちるかを確認しました

「throw するヘルパー」は、throw しなければただの黙認装置なので、実際に走らせています:

```
存在しない plugin         : throw 🟢 no image plugin registered for "nope"
html を持たない plugin    : throw 🟢 image plugin "beat" has no html()
markdown を持たない plugin: throw 🟢 image plugin "html_tailwind" has no markdown()
正常系 (markdown)         : 通る
```

### 5. どのファイルにどのヘルパーを当てるかは、plugin の実装を見て決めています

`html_tailwind` と `slide` は `markdown()` を持たないので `requireHtmlPlugin`、`markdown` / `mermaid` / `textSlide` は両方持つので `requireRenderingPlugin`。**一律に一番強いヘルパーを当てると、持っていない plugin で throw します。**

## 検証

- `test/` の型エラー: **279 → 186**（93件減、予測どおり）
- 触ったファイルのテスト: **180 pass / 0 fail**
- `lint` / `build` / `format`: green

## 残り 186 件（`#1551` の続き）

| 件数 | コード | 内容 |
|---:|---|---|
| 69 | TS2741 | `text` の無い beat を手で組んでいる |
| 37 | TS2345 | 部分的な MulmoScript を渡している |
| 30 | TS2739 | プロパティ不足 |
| 24 | TS2322 | 代入の型不一致 |

次は fixture builder です。ただしこちらは **「テストが実在しない形のデータを検証している」可能性がある**ので、機械的に `text: ""` を足すのではなく1ファイルずつ意図を確認しながら進めます。

## 余談（この PR の対象外）

`yarn run format` を走らせると `scripts/samples/bootcamp_v2_kickoff.json` と `scripts/slides/slide_deck_showcase.json` に差分が出ます（main に元からあるドリフト）。この PR では revert しました。CI が `format:check` ではなく `format` を走らせているので、**CI が黙って整形して緑にしている**状態です。別途直す価値があると思います。

## User Prompt

> mulmocast-cli#1551　のヘルパー対応もしよう

Refs #1551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test utilities for locating image, HTML, and rendering plugins.
  * Updated plugin tests to validate that required plugin renderers are available.
  * Preserved existing test coverage, assertions, and expected behavior across image, chart, animation, slide, text, and Mermaid scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->