### PR TITLE
refactor: let a plugin's markdown/html/path declare what they read

### DIFF
--- a/src/actions/image_agents.ts
+++ b/src/actions/image_agents.ts
@@ -295,8 +295,8 @@ export const imagePreprocessAgent = async (namedInputs: {
     const plugin = MulmoBeatMethods.getPlugin(beat);
     const pluginPath = plugin.path({ beat, context, imagePath, ...htmlStyle(context, beat) });
 
-    const markdown = plugin.markdown ? plugin.markdown({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
-    const html = plugin.html ? await plugin.html({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
+    const markdown = plugin.markdown ? plugin.markdown({ beat, context }) : undefined;
+    const html = plugin.html ? await plugin.html({ beat, context }) : undefined;
 
     const isTypeMovie = beat.image.type === ImageMediaType.Movie;
     const isAnimatedHtml = MulmoBeatMethods.isAnimatedHtmlTailwind(beat);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -161,6 +161,16 @@ export type ImageProcessorParams = {
   beatDuration?: number; // Computed duration: beat.duration ?? studioBeat.duration (audio-derived)
 };
 
+/**
+ * What a plugin's `markdown()` / `html()` reads. They return a string and touch no file, so
+ * the paths and sizes `process()` needs are not theirs. `imageRefs` is here because a slide
+ * resolves image references while rendering; it is optional, so a caller with none omits it.
+ */
+export type BeatRenderParams = Pick<ImageProcessorParams, "beat" | "context" | "imageRefs">;
+
+/** What a plugin's `path()` reads: the source-backed ones resolve against beat and context. */
+export type BeatPathParams = Pick<ImageProcessorParams, "beat" | "context" | "imagePath">;
+
 export type PDFMode = (typeof pdf_modes)[number];
 export type PDFSize = (typeof pdf_sizes)[number];
 

--- a/src/utils/image_plugins/beat.ts
+++ b/src/utils/image_plugins/beat.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatPathParams, ImageProcessorParams } from "../../types/index.js";
 
 export const imageType = "beat";
 
@@ -9,6 +9,6 @@ export const processBeatReference = async (__: ImageProcessorParams) => {
 };
 
 export const process = processBeatReference;
-export const path = (__: ImageProcessorParams) => {
+export const path = (__: BeatPathParams) => {
   return undefined;
 };

--- a/src/utils/image_plugins/chart.ts
+++ b/src/utils/image_plugins/chart.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
@@ -26,7 +26,7 @@ const processChart = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 

--- a/src/utils/image_plugins/html_tailwind.ts
+++ b/src/utils/image_plugins/html_tailwind.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import nodePath from "node:path";
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { MulmoBeatMethods } from "../../methods/mulmo_beat.js";
 import { getHTMLFile, getJSFile } from "../file.js";
 import { renderHTMLToImage, interpolate, renderHTMLToFrames, renderHTMLToVideo, renderHTMLToFinalFrame } from "../html_render.js";
@@ -249,7 +249,7 @@ const processHtmlTailwind = async (params: ImageProcessorParams) => {
   return processHtmlTailwindStatic(params);
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
   return htmlTailwindMarkup(beat.image);

--- a/src/utils/image_plugins/index.ts
+++ b/src/utils/image_plugins/index.ts
@@ -9,14 +9,14 @@ import * as pluginBeat from "./beat.js";
 import * as pluginVoiceOver from "./voice_over.js";
 import * as pluginVision from "./vision.js";
 import * as pluginSlide from "./slide.js";
-import { ImageProcessorParams, MulmoBeat } from "../../types/index.js";
+import { BeatPathParams, BeatRenderParams, ImageProcessorParams, MulmoBeat } from "../../types/index.js";
 
 const imagePlugins: {
   imageType: string;
   process: (params: ImageProcessorParams) => Promise<string | undefined> | void;
-  path: (params: ImageProcessorParams) => string | undefined;
-  markdown?: (params: ImageProcessorParams) => string | undefined;
-  html?: (params: ImageProcessorParams) => Promise<string | undefined>;
+  path: (params: BeatPathParams) => string | undefined;
+  markdown?: (params: BeatRenderParams) => string | undefined;
+  html?: (params: BeatRenderParams) => Promise<string | undefined>;
 }[] = [
   pluginTextSlide,
   pluginMarkdown,

--- a/src/utils/image_plugins/markdown.ts
+++ b/src/utils/image_plugins/markdown.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
 import { parrotingImagePath, generateUniqueId } from "./utils.js";
@@ -24,7 +24,7 @@ const isMarkdownLayout = (md: unknown): md is MulmoMarkdownLayout => {
 };
 
 // Generate markdown in order: header → sidebar-left → content
-const dumpMarkdown = (params: ImageProcessorParams): string | undefined => {
+const dumpMarkdown = (params: BeatRenderParams): string | undefined => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 
@@ -97,7 +97,7 @@ const processMarkdown = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return "";
 

--- a/src/utils/image_plugins/mermaid.ts
+++ b/src/utils/image_plugins/mermaid.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/index.js";
 import { getHTMLFile } from "../file.js";
 import { renderHTMLToImage, interpolate } from "../html_render.js";
@@ -32,14 +32,14 @@ const processMermaid = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpMarkdown = (params: ImageProcessorParams) => {
+const dumpMarkdown = (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
   if (beat.image.code.kind !== "text") return; // support only text for now
   return `\`\`\`mermaid\n${beat.image.code.text}\n\`\`\``;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 

--- a/src/utils/image_plugins/movie.ts
+++ b/src/utils/image_plugins/movie.ts
@@ -1,11 +1,11 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams } from "../../types/index.js";
 import { processSource, pathSource } from "./source.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 import { movieHtml } from "./media_html.js";
 
 export const imageType = "movie";
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat, context } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 

--- a/src/utils/image_plugins/slide.ts
+++ b/src/utils/image_plugins/slide.ts
@@ -1,6 +1,6 @@
 import nodePath from "node:path";
 import { pathToFileURL } from "node:url";
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { generateSlideHTML } from "@mulmocast/deck";
 import type { SlideLayout, SlideTheme, ContentBlock, MulmoSlideMedia, SlideBranding, ResolvedBranding } from "@mulmocast/deck";
 import { renderHTMLToImage } from "../html_render.js";
@@ -94,7 +94,7 @@ export const resolveSlideImageRefs = (
   return cloned;
 };
 
-const resolveTheme = (params: ImageProcessorParams): SlideTheme => {
+const resolveTheme = (params: BeatRenderParams): SlideTheme => {
   const { beat, context } = params;
   if (!beat.image || beat.image.type !== imageType) {
     throw new Error("resolveTheme called on non-slide beat");
@@ -107,7 +107,7 @@ const resolveTheme = (params: ImageProcessorParams): SlideTheme => {
   return MulmoPresentationStyleMethods.getResolvedSlideTheme(context.presentationStyle, beat);
 };
 
-const resolveSlide = (params: ImageProcessorParams, converter: (filePath: string) => string = pathToDataUrl): SlideLayout => {
+const resolveSlide = (params: BeatRenderParams, converter: (filePath: string) => string = pathToDataUrl): SlideLayout => {
   const { beat, imageRefs } = params;
   if (!beat.image || beat.image.type !== imageType) {
     throw new Error("resolveSlide called on non-slide beat");
@@ -125,7 +125,7 @@ const resolveSlide = (params: ImageProcessorParams, converter: (filePath: string
  * - beat.image.branding defined → use it
  * - otherwise → fall back to slideParams.branding
  */
-const resolveBranding = (params: ImageProcessorParams): SlideBranding | undefined => {
+const resolveBranding = (params: BeatRenderParams): SlideBranding | undefined => {
   const { beat, context } = params;
   if (!beat.image || beat.image.type !== imageType) return undefined;
   const beatBranding = (beat.image as MulmoSlideMedia).branding;
@@ -137,7 +137,7 @@ const resolveBranding = (params: ImageProcessorParams): SlideBranding | undefine
 /**
  * Convert SlideBranding to ResolvedBranding (all sources → data URLs).
  */
-const convertBrandingToResolved = async (branding: SlideBranding, params: ImageProcessorParams): Promise<ResolvedBranding> => {
+const convertBrandingToResolved = async (branding: SlideBranding, params: BeatRenderParams): Promise<ResolvedBranding> => {
   const { context } = params;
   const resolved: ResolvedBranding = {};
 
@@ -163,7 +163,7 @@ const convertBrandingToResolved = async (branding: SlideBranding, params: ImageP
   return resolved;
 };
 
-const resolveAndConvertBranding = async (params: ImageProcessorParams): Promise<ResolvedBranding | undefined> => {
+const resolveAndConvertBranding = async (params: BeatRenderParams): Promise<ResolvedBranding | undefined> => {
   const branding = resolveBranding(params);
   return branding ? await convertBrandingToResolved(branding, params) : undefined;
 };
@@ -181,7 +181,7 @@ const processSlide = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
 

--- a/src/utils/image_plugins/source.ts
+++ b/src/utils/image_plugins/source.ts
@@ -1,4 +1,4 @@
-import { type ImageProcessorParams, type ImageType } from "../../types/index.js";
+import { BeatPathParams, type ImageProcessorParams, type ImageType } from "../../types/index.js";
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 
 export const processSource = (imageType: ImageType) => {
@@ -11,7 +11,7 @@ export const processSource = (imageType: ImageType) => {
 };
 
 export const pathSource = (imageType: ImageType) => {
-  return (params: ImageProcessorParams) => {
+  return (params: BeatPathParams) => {
     const { beat, context } = params;
     if (!beat?.image || beat.image.type !== imageType) return;
     if (beat.image?.type == "image" || beat.image?.type == "movie") {

--- a/src/utils/image_plugins/text_slide.ts
+++ b/src/utils/image_plugins/text_slide.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { renderMarkdownToImage } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
 import { resolveCombinedStyle } from "./bg_image_util.js";
@@ -26,7 +26,7 @@ const processTextSlide = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpMarkdown = (params: ImageProcessorParams) => {
+const dumpMarkdown = (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
   const slide = beat.image.slide;
@@ -36,7 +36,7 @@ const dumpMarkdown = (params: ImageProcessorParams) => {
   return `${titleString}${subtitleString}${bulletsString}`;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const markdown = dumpMarkdown(params);
   return await marked.parse(markdown ?? "");
 };

--- a/src/utils/image_plugins/utils.ts
+++ b/src/utils/image_plugins/utils.ts
@@ -1,9 +1,9 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatPathParams } from "../../types/index.js";
 import { getMarkdownStyle } from "../../data/markdownStyles.js";
 import { randomUUID } from "node:crypto";
 import nodeProcess from "node:process";
 
-export const parrotingImagePath = (params: ImageProcessorParams) => {
+export const parrotingImagePath = (params: BeatPathParams) => {
   return params.imagePath;
 };
 

--- a/src/utils/image_plugins/vision.ts
+++ b/src/utils/image_plugins/vision.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
 import { parrotingImagePath } from "./utils.js";
 import { htmlPlugin, templateNameTofunctionName } from "mulmocast-vision";
 import { resolve as resolvePath } from "path";
@@ -21,7 +21,7 @@ const processVision = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
-const dumpHtml = async (params: ImageProcessorParams) => {
+const dumpHtml = async (params: BeatRenderParams) => {
   const { beat, context } = params;
 
   const rootDir = context.fileDirs.nodeModuleRootPath ? resolvePath(context.fileDirs.nodeModuleRootPath, "mulmocast-vision") : undefined;

--- a/src/utils/image_plugins/voice_over.ts
+++ b/src/utils/image_plugins/voice_over.ts
@@ -1,4 +1,4 @@
-import { ImageProcessorParams } from "../../types/index.js";
+import { BeatPathParams, ImageProcessorParams } from "../../types/index.js";
 
 export const imageType = "voice_over";
 
@@ -8,6 +8,6 @@ export const processBeatReference = async (__: ImageProcessorParams) => {
 };
 
 export const process = processBeatReference;
-export const path = (__: ImageProcessorParams) => {
+export const path = (__: BeatPathParams) => {
   return undefined;
 };


### PR DESCRIPTION
## Summary

`ImageProcessorParams` は**4つの別々の操作に共有された1つの型**で、`markdown()` / `html()` / `path()` が `process()` の要求を丸ごと相続していました。それぞれが読むものだけを宣言するようにします。

**公開 API は変わりません**（後述の実測あり）。**挙動も変わりません**（画像 24 枚が md5 一致、mutation で検出力も確認済み）。

`Refs #1551`

## Items to Confirm / Review

### 1. 何が実態だったか（全実装を読んだ結果）

| 操作 | 実際に読むフィールド |
|---|---|
| `process()` | beat, context, imagePath, canvasSize, imageRefs, movieRefs, beatDuration — **全部使う** |
| `path()` | beat, context, imagePath（`pathSource` が3つとも使う） |
| `markdown()` / `html()` | **beat** ＋ mermaid / movie / vision / slide は **context**、slide は **imageRefs** も |

```ts
export type BeatRenderParams = Pick<ImageProcessorParams, "beat" | "context" | "imageRefs">;
export type BeatPathParams   = Pick<ImageProcessorParams, "beat" | "context" | "imagePath">;
```

**`ImageProcessorParams` 自体は無変更です。** `process()` の記述として正しく、かつ公開型なので触っていません。

### 2. 公開 API への影響: ありません（実測）

| 確認 | 結果 |
|---|---|
| `import type { ImageProcessorParams } from "mulmocast"` | **解決する**（公開型）→ **無変更なので影響なし** |
| `import { findImagePlugin } from "mulmocast"` | `TS2305: has no exported member` → **plugin テーブルは非公開** |
| `import type { BeatRenderParams } from "mulmocast"`（現行 npm 版） | `TS2305` → **この PR で新しく公開型が2つ増えます**（`type.ts` 全体が re-export されるため）。additive で既存を壊しませんが、「外からは何も見えない」ではないので明記します |
| `~/ss/llm` 全リポで `ImageProcessorParams` を grep | mulmocast-cli 自身の3ファイルのみ |
| mulmocast-app が `mulmocast` から import するもの | `getFileObject` / `initializeContextFromFiles` / `MulmoScript` / `mulmoScriptSchema` / `MulmoStudioContext` / `mulmoViewerBundle` / `puppeteerCrawlerAgent` / `readTemplatePrompt` / `setGraphAILogger` / `validateSchemaAgent` — **plugin 系ゼロ** |

引数型を狭めて壊れるのは「外部が plugin を**実装**している」場合ですが、テーブル型も `findImagePlugin` も export されていないため、その手段がありません。呼び出し側（広いオブジェクトを渡す）は構造的部分型で通ります。

> **訂正（cross-review round 1）**: 当初この欄に「外からは見えません」と書いていましたが、`BeatRenderParams` / `BeatPathParams` は `src/types/type.ts` にあり `index.common.ts` が `type.ts` を丸ごと re-export するので、**公開型として増えます**。壊れる変更ではありませんが、書き方が不正確でした。現行 npm 版に対して `import type { BeatRenderParams } from "mulmocast"` が `TS2305` になることで確認しています。

### 3. `strictFunctionTypes` により実装側も追従が必要でした

テーブルが arrow-property 記法なので反変です。`(p: ImageProcessorParams) => ...` を `(p: BeatRenderParams) => ...` に代入できないため、各 plugin の実装シグネチャも変えています。**これは副作用ではなく本題**で、各実装が必要なものを宣言する形になりました。

`slide.ts` の `resolveSlide` が `imageRefs` を読んでいたのは、コンパイラに教わりました（私の事前調査は見落としていました）。`imageRefs` は optional なので呼び出し側は変わりません。

### 4. 呼び出し側が「読まれないもの」を作るのをやめました

```diff
-const markdown = plugin.markdown ? plugin.markdown({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
-const html = plugin.html ? await plugin.html({ beat, context, imagePath, ...htmlStyle(context, beat) }) : undefined;
+const markdown = plugin.markdown ? plugin.markdown({ beat, context }) : undefined;
+const html = plugin.html ? await plugin.html({ beat, context }) : undefined;
```

`htmlStyle()` が1ビートあたり3回呼ばれていたのが1回になります（`process` 用の1回のみ）。純粋関数なので挙動は変わりません。

## 検証 — 「挙動が同じ」は読まずに走らせて確かめました

`mulmo images` を4つの script で変更前後に流し、生成 PNG の md5 を比較:

| script | beat 種別 | 枚数 | 結果 |
|---|---|---:|---|
| `test_order.json` | markdown ×9 | 9 | 🟢 一致 |
| `test_layout.json` | textSlide ×3, markdown, chart ×2, mermaid ×2 | 8 | 🟢 一致 |
| `test_ir_visualizations.json` | chart ×4, slide | 5 | 🟢 一致 |
| `test_beats.json` | textSlide ×2, beat ×4 | 2 | 🟢 一致 |

**この比較自体が差を検出できることを先に確認しています** — `textSlide` の見出しを `#` → `##` に変える mutation で **8枚中3枚が変化**しました。検出できない比較の「一致」は無意味なので。

（最初に流した mutation 確認はシェルのエスケープで anchor が外れ、実際には適用されないまま「検出できた」と出ていました。ファイル経由で書き直して取り直しています。）

その他: `tsc -p tsconfig.json` 0件 / `lint` 0 errors / `build` green / **全テスト 1166 pass, 0 fail**。

## この PR に含めていないこと

`#1554` で入れたテスト側の `imageProcessorParams()` の穴埋めは**まだ剥がしていません**。型が狭まっても `context` は必須のまま（mermaid / movie / vision / slide が読むため）なので、テストは `{ beat, context }` を渡す必要があります。埋める項目は5個から2個に減るので、別 PR で整理できます。

## User Prompt

> ImageProcessorParamsはコードで詳しく教えて
>
> Pick使った場合って、外向けのapiで副作用ある？具体的には ~/ss/llm/mulmocast-app/src/main/mulmo/ あたりで使っているもの。
>
> ok 提案順で。

Refs #1551
