### PR TITLE
fix: point yarn test at the CLI entry the actions moved behind

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ yarn ci_test                 # Run Node.js native test runner
 ### Core CLI Commands
 ```bash
 yarn cli                     # Run the CLI directly with npx tsx
-yarn test                    # Run end-to-end test (generates test files)
+yarn test                    # Run end-to-end test (generates test files; needs TTS/image API keys)
 
 # Content generation shortcuts
 yarn audio <script>          # Generate audio from MulmoScript

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "images": "npx tsx ./src/cli/bin.ts images",
     "preprocess": "npx tsx ./src/cli/bin.ts preprocess",
     "pdf": "npx tsx ./src/cli/bin.ts pdf",
-    "test": "rm -f scratchpad/test*.* && npx tsx ./src/audio.ts scripts/test/test.json && npx tsx ./src/images.ts scripts/test/test.json && npx tsx ./src/movie.ts scripts/test/test.json",
+    "test": "rm -f scratchpad/test*.* && npx tsx ./src/cli/bin.ts audio scripts/test/test.json && npx tsx ./src/cli/bin.ts images scripts/test/test.json && npx tsx ./src/cli/bin.ts movie scripts/test/test.json",
     "ci_test": "cross-env NODE_ENV=test tsx --test --experimental-test-coverage ./test/*/test_*.ts",
     "lint": "eslint src test assets/html/js",
     "build": "tsc",


### PR DESCRIPTION
## Summary

**`yarn test` は 2025-05-02 から壊れていました。** `c5e6dd6b "move audio to actions"` が `src/audio.ts` / `src/images.ts` / `src/movie.ts` を `src/actions/` へ移し、`gen` script は直したのに `test` は取り残されていました。

差分は **package.json 1行 + CLAUDE.md 1行**です。

## Items to Confirm / Review

### 1. パスを `src/actions/` に付け替えるだけでは直りません

移動先は**モジュールであってエントリではありません**（`process.argv` も `main()` も持たない）。現在のエントリは `src/cli/bin.ts` で、アクションはサブコマンドです — `c5e6dd6b` が `gen` に対して行ったのと同じ形にしました:

```diff
-npx tsx ./src/audio.ts scripts/test/test.json
+npx tsx ./src/cli/bin.ts audio scripts/test/test.json
```

### 2. 修正前後を実際に走らせて確認しています

| | 結果 |
|---|---|
| 修正前 | `ERR_MODULE_NOT_FOUND`（何もせず死ぬ） |
| 修正後 | 3つとも provider まで到達し、`apiKeyMissing` と必要な環境変数名を報告 |

鍵が無い状態での `apiKeyMissing` は**正しい挙動**です（exit 1 で落ちます）。

> 途中、「鍵が無くても exit 0 になる」と誤読しかけました。`cmd | grep | tail; echo $?` が `tail` の終了値を見ていただけで、リダイレクトして測り直すと **exit 1** です。欠陥ではありません。

### 3. API キーが要ることがどこにも書かれていませんでした

`CLAUDE.md:23` は `yarn test` を "Run end-to-end test (generates test files)" とだけ説明していました。実際には TTS / 画像生成の鍵が要るので、そう書き足しました。

**この script の意図は e2e smoke で正しい**（CLAUDE.md がそう定義している）ので、`ci_test`（鍵不要のユニットテスト）に付け替える案は取りませんでした。CI が使うのは `ci_test` のままです。

### 4. 同じ取り残しが他に無いか掃きました

`package.json` の全 script について、参照している `src/` `scripts/` `test/` `assets/` `batch/` 配下のパスが実在するか機械的に検査しました。**壊れているのは `test` 1本だけ**です。

（最初の検査は正規表現の交替順が `js|json` だったため `scripts/test/test.json` を `.js` と誤判定し、偽陽性を6件出しました。`json|js` に直して取り直しています。）

## 検証

`lint` / `build`: green。テストコードには触れていません。

## User Prompt

> yarn testなおして。

Closes nothing — issue は立てていません（1行の修正のため）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that end-to-end tests require text-to-speech and image API keys.

* **Bug Fixes**
  * Updated the test workflow to run audio, image, and movie generation through the standard command-line interface, improving test execution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->