### PR TITLE
test: use the narrowed plugin types the image plugin tests were always assuming

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,4 @@
-import type { ImageProcessorParams, MulmoBeat } from "../src/types/index.js";
+import type { ImageProcessorParams, MulmoBeat, MulmoStudioContext } from "../src/types/index.js";
 import { createMockContext } from "./actions/utils.js";
 
 /**
@@ -20,3 +20,15 @@ export const imageProcessorParams = (params: Partial<ImageProcessorParams> & { b
   canvasSize: { width: 1280, height: 720 },
   ...params,
 });
+
+/**
+ * The mock context with a specific `mulmoFileDirPath`.
+ *
+ * Source-backed plugins resolve a relative path against that one field, so the tests used to
+ * build `{ fileDirs: { mulmoFileDirPath } }` and nothing else — which is not a
+ * `MulmoStudioContext`. The rest of the mock is inert for these plugins.
+ */
+export const contextWithDir = (mulmoFileDirPath: string): MulmoStudioContext => {
+  const context = createMockContext();
+  return { ...context, fileDirs: { ...context.fileDirs, mulmoFileDirPath } };
+};

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,5 @@
 import type { ImageProcessorParams, MulmoBeat, MulmoStudioContext } from "../src/types/index.js";
+import type { SlideTheme } from "@mulmocast/deck";
 import { createMockContext } from "./actions/utils.js";
 
 /**
@@ -31,4 +32,17 @@ export const imageProcessorParams = (params: Partial<ImageProcessorParams> & { b
 export const contextWithDir = (mulmoFileDirPath: string): MulmoStudioContext => {
   const context = createMockContext();
   return { ...context, fileDirs: { ...context.fileDirs, mulmoFileDirPath } };
+};
+
+/**
+ * The mock context with a slide theme, or without one.
+ *
+ * The mock's `presentationStyle` carries only `imageParams`, so it is already the
+ * "no slide theme configured" case the fallback tests want; passing a theme adds the one
+ * field those tests vary. The literals these replaced were not `MulmoStudioContext` at all
+ * and only compiled behind an `as`.
+ */
+export const contextWithSlideTheme = (theme?: SlideTheme): MulmoStudioContext => {
+  const context = createMockContext();
+  return theme ? { ...context, presentationStyle: { ...context.presentationStyle, slideParams: { theme } } } : context;
 };

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { createMockContext } from "../actions/utils.js";
 import type { MulmoBeat } from "../../src/types/index.js";
 import assert from "node:assert";
 import { chartHtml, escapedChartTemplateValues, resolveChartPlugins, stringifyChartData } from "../../src/utils/image_plugins/chart_html.js";
@@ -106,7 +107,7 @@ test("prototype member names resolve to no plugin", () => {
 });
 
 test("the plugin passes the beat straight through to the renderer", async () => {
-  const html = await chartPluginHtml()({ beat: { text: "", image: { type: "chart", title: "Revenue", chartData: CHART_DATA } } });
+  const html = await chartPluginHtml()({ beat: { text: "", image: { type: "chart", title: "Revenue", chartData: CHART_DATA } }, context: createMockContext() });
   assert.ok(html, "a chart beat must produce html");
 
   const id = html.match(/<canvas id="([^"]*)">/)?.[1];
@@ -124,7 +125,7 @@ test("chart data is serialized before the title is read", async () => {
   cyclic.self = cyclic;
   const read: string[] = [];
   const image = {
-    type: "chart",
+    type: "chart" as const,
     chartData: cyclic,
     get title(): string {
       read.push("title");
@@ -132,7 +133,7 @@ test("chart data is serialized before the title is read", async () => {
     },
   };
 
-  await assert.rejects(() => Promise.resolve(html({ beat: { text: "", image } })), /circular structure/);
+  await assert.rejects(() => Promise.resolve(html({ beat: { text: "", image }, context: createMockContext() })), /circular structure/);
   assert.deepStrictEqual(read, [], "the title must not be read once serialization has thrown");
 });
 
@@ -142,9 +143,9 @@ test("stringifyChartData pretty-prints with two spaces", () => {
 
 test("the plugin declines beats that are not charts", async () => {
   const html = chartPluginHtml();
-  assert.strictEqual(await html({ beat: { text: "" } }), undefined);
-  assert.strictEqual(await html({ beat: { text: "", image: undefined } }), undefined);
-  assert.strictEqual(await html({ beat: { text: "", image: { type: "markdown", markdown: "x" } } }), undefined);
+  assert.strictEqual(await html({ beat: { text: "" }, context: createMockContext() }), undefined);
+  assert.strictEqual(await html({ beat: { text: "", image: undefined }, context: createMockContext() }), undefined);
+  assert.strictEqual(await html({ beat: { text: "", image: { type: "markdown", markdown: "x" } }, context: createMockContext() }), undefined);
 });
 
 // generateUniqueId returns the literal "id" under NODE_ENV=test, which is what CI sets, so
@@ -155,7 +156,7 @@ test("each call gets its own chart-prefixed id", async () => {
   delete process.env.NODE_ENV;
   try {
     const beat: MulmoBeat = { text: "", image: { type: "chart", title: "t", chartData: {} } };
-    const ids = await Promise.all([0, 1, 2].map(async () => (await html({ beat }))?.match(/<canvas id="([^"]*)">/)?.[1]));
+    const ids = await Promise.all([0, 1, 2].map(async () => (await html({ beat, context: createMockContext() }))?.match(/<canvas id="([^"]*)">/)?.[1]));
     ids.forEach((id) => assert.match(id ?? "", /^chart-[0-9a-f]{8}$/));
     assert.strictEqual(new Set(ids).size, 3, `ids must be unique, got ${JSON.stringify(ids)}`);
   } finally {

--- a/test/image_plugins/test_chart_html.ts
+++ b/test/image_plugins/test_chart_html.ts
@@ -124,16 +124,21 @@ test("chart data is serialized before the title is read", async () => {
   const cyclic: Record<string, unknown> = { type: "bar" };
   cyclic.self = cyclic;
   const read: string[] = [];
-  const image = {
-    type: "chart" as const,
-    chartData: cyclic,
-    get title(): string {
-      read.push("title");
-      return "T";
+  // Annotated rather than asserted: the annotation is what narrows `type` to the literal,
+  // and it also checks the getter against the shape the schema declares.
+  const beat: MulmoBeat = {
+    text: "",
+    image: {
+      type: "chart",
+      chartData: cyclic,
+      get title(): string {
+        read.push("title");
+        return "T";
+      },
     },
   };
 
-  await assert.rejects(() => Promise.resolve(html({ beat: { text: "", image }, context: createMockContext() })), /circular structure/);
+  await assert.rejects(() => Promise.resolve(html({ beat, context: createMockContext() })), /circular structure/);
   assert.deepStrictEqual(read, [], "the title must not be read once serialization has thrown");
 });
 

--- a/test/image_plugins/test_html_animation.ts
+++ b/test/image_plugins/test_html_animation.ts
@@ -1,11 +1,12 @@
 import test from "node:test";
-import type { MulmoBeat } from "../../src/types/index.js";
+import { createMockContext } from "../actions/utils.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 import assert from "node:assert";
 import { requireHtmlPlugin } from "./utils.js";
 import { mulmoHtmlTailwindMediaSchema, htmlTailwindAnimationSchema } from "../../src/types/schema.js";
 import { normalizeEvenDimensions } from "../../src/utils/ffmpeg_utils.js";
 import { MulmoBeatMethods } from "../../src/methods/index.js";
-import type { ImageProcessorParams, MulmoBeat } from "../../src/types/index.js";
+import type { MulmoBeat } from "../../src/types/index.js";
 
 // === Schema tests ===
 
@@ -80,7 +81,8 @@ test("html_tailwind plugin - static beat returns correct path", () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/0p.png",
     beat: {
       text: "",
@@ -100,7 +102,8 @@ test("html_tailwind plugin - animated beat returns correct path (parrotingImageP
   assert(plugin, "html_tailwind plugin should exist");
 
   // When animated, imagePluginAgent passes the .mp4 path as imagePath
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/0p_animated.mp4",
     beat: {
       text: "",
@@ -121,7 +124,8 @@ test("html_tailwind plugin - html dump works for static beat", async () => {
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/0p.png",
     beat: {
       text: "",
@@ -141,7 +145,8 @@ test("html_tailwind plugin - html dump works for animated beat", async () => {
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/0p_animated.mp4",
     beat: {
       text: "",
@@ -177,7 +182,8 @@ test("html_tailwind plugin - animation: false treated as static", () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/0p.png",
     beat: {
       text: "",

--- a/test/image_plugins/test_html_animation.ts
+++ b/test/image_plugins/test_html_animation.ts
@@ -178,25 +178,21 @@ test("mulmoHtmlTailwindMediaSchema - animation: false is rejected by schema", ()
   assert(!result.success, "should reject animation: false");
 });
 
-test("html_tailwind plugin - animation: false treated as static", () => {
+// `path` is parrotingImagePath: it answers `imagePath` whatever the beat says, so it cannot
+// distinguish an animated beat from a static one. The previous version of this test claimed
+// it could — it passed just as well with `animation: true`, which is how it was found. The
+// png-vs-mp4 choice belongs to the caller, from isAnimatedHtmlTailwind.
+test("html_tailwind plugin - path returns the given path, animated or not", () => {
   const plugin = requireHtmlPlugin("html_tailwind");
-  assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: BeatPathParams = {
+  const params = (animation: true | undefined): BeatPathParams => ({
     context: createMockContext(),
     imagePath: "/test/path/0p.png",
-    beat: {
-      text: "",
-      image: {
-        type: "html_tailwind",
-        html: "<div>Hello</div>",
-        animation: false as unknown as true, // simulate unvalidated input
-      },
-    },
-  };
+    beat: { text: "", image: { type: "html_tailwind", html: "<div>Hello</div>", animation } },
+  });
 
-  const path = plugin.path(mockParams);
-  assert.strictEqual(path, "/test/path/0p.png", "should return png path for animation: false");
+  assert.strictEqual(plugin.path(params(undefined)), "/test/path/0p.png");
+  assert.strictEqual(plugin.path(params(true)), "/test/path/0p.png", "an animated beat gets the same answer");
 });
 
 // === isAnimatedHtmlTailwind tests ===
@@ -216,9 +212,12 @@ test("isAnimatedHtmlTailwind - false for undefined animation", () => {
   assert.strictEqual(MulmoBeatMethods.isAnimatedHtmlTailwind(beat), false);
 });
 
-test("isAnimatedHtmlTailwind - false for animation: false (unvalidated)", () => {
-  const beat: MulmoBeat = { text: "", image: { type: "html_tailwind" as const, html: "<div></div>", animation: false as unknown as true } };
-  assert.strictEqual(MulmoBeatMethods.isAnimatedHtmlTailwind(beat), false);
+// `animation: false` cannot exist on a parsed beat — the schema is `true | {fps, movie}` —
+// so the beat-level function cannot be handed one without forcing the type. The decision it
+// delegates to takes `unknown` precisely because the field arrives unvalidated, and that is
+// where this case belongs.
+test("isAnimationEnabled - false for an unvalidated animation: false", () => {
+  assert.strictEqual(MulmoBeatMethods.isAnimationEnabled(false), false);
 });
 
 test("isAnimatedHtmlTailwind - false for non-html_tailwind type", () => {

--- a/test/image_plugins/test_html_tailwind_plugin.ts
+++ b/test/image_plugins/test_html_tailwind_plugin.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
+import { createMockContext } from "../actions/utils.js";
 import assert from "node:assert";
 import { requireHtmlPlugin } from "./utils.js";
-import { ImageProcessorParams } from "../../src/types/index.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 
 test("html_tailwind plugin basic functionality", () => {
   const plugin = requireHtmlPlugin("html_tailwind");
@@ -13,7 +14,8 @@ test("html_tailwind plugin path function", () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/tailwind.png",
     beat: {
       text: "",
@@ -33,7 +35,8 @@ test("html_tailwind plugin html generation with string html", async () => {
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/tailwind.png",
     beat: {
       text: "",
@@ -53,7 +56,8 @@ test("html_tailwind plugin html generation with array html", async () => {
   assert(plugin, "html_tailwind plugin should exist");
   assert(plugin.html, "html_tailwind plugin should have html function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/tailwind.png",
     beat: {
       text: "",
@@ -88,7 +92,8 @@ test("html_tailwind plugin with complex tailwind classes", async () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/complex.png",
     beat: {
       text: "",
@@ -122,7 +127,8 @@ test("html_tailwind plugin with form elements", async () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/form.png",
     beat: {
       text: "",
@@ -164,7 +170,8 @@ test("html_tailwind plugin with grid layout", async () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/grid.png",
     beat: {
       text: "",
@@ -201,7 +208,8 @@ test("html_tailwind plugin with empty html string", async () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/empty.png",
     beat: {
       text: "",
@@ -220,7 +228,8 @@ test("html_tailwind plugin with empty html array", async () => {
   const plugin = requireHtmlPlugin("html_tailwind");
   assert(plugin, "html_tailwind plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/empty-array.png",
     beat: {
       text: "",

--- a/test/image_plugins/test_image_plugin.ts
+++ b/test/image_plugins/test_image_plugin.ts
@@ -1,5 +1,5 @@
 import { requireImagePlugin } from "./utils.js";
-import { imageProcessorParams } from "../fixtures.js";
+import { imageProcessorParams, contextWithDir } from "../fixtures.js";
 import { resolve } from "node:path";
 
 import test from "node:test";
@@ -9,7 +9,7 @@ test("test imagePlugin mermaid", async () => {
   const plugin = requireImagePlugin("mermaid");
   assert.equal(plugin.imageType, "mermaid");
 
-  const path = plugin.path(imageProcessorParams({ imagePath: "expectImagePath" }));
+  const path = plugin.path(imageProcessorParams({ beat: { text: "" }, imagePath: "expectImagePath" }));
   assert.equal(path, "expectImagePath");
 });
 
@@ -28,7 +28,6 @@ test("test imagePlugin image url", async () => {
         },
       },
     }),
-    {},
   );
   assert.equal(path, "expectImagePath");
 });
@@ -47,7 +46,7 @@ test("test imagePlugin image path", async () => {
           source: { kind: "path", path: "expectImagePath" },
         },
       },
-      context: { fileDirs: { mulmoFileDirPath: "/bin" } },
+      context: contextWithDir("/bin"),
     }),
   );
   assert.equal(path, resolve("/bin", "expectImagePath"));
@@ -57,6 +56,6 @@ test("test imagePlugin beat", async () => {
   const plugin = requireImagePlugin("beat");
   assert.equal(plugin.imageType, "beat");
 
-  const path = plugin.path(imageProcessorParams({ type: "beat", imagePath: "expectImagePath" }));
+  const path = plugin.path(imageProcessorParams({ beat: { text: "", image: { type: "beat" } }, imagePath: "expectImagePath" }));
   assert.strictEqual(path, undefined);
 });

--- a/test/image_plugins/test_image_plugin_html.ts
+++ b/test/image_plugins/test_image_plugin_html.ts
@@ -48,7 +48,7 @@ test("test imagePlugin html_tailwind - html method with wrong type", async () =>
     text: "",
     image: {
       type: "markdown",
-      html: "<div>Test</div>",
+      markdown: "# Test",
     },
   };
 

--- a/test/image_plugins/test_mermaid_plugin.ts
+++ b/test/image_plugins/test_mermaid_plugin.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
+import { createMockContext } from "../actions/utils.js";
 import assert from "node:assert";
 import { requireRenderingPlugin } from "./utils.js";
-import { ImageProcessorParams } from "../../src/types/index.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 import { escapedMermaidTemplateValues, mermaidHtml } from "../../src/utils/image_plugins/mermaid_html.js";
 
 test("mermaid plugin basic functionality", () => {
@@ -14,9 +15,11 @@ test("mermaid plugin path function", () => {
   const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/diagram.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
         title: "Test Diagram",
@@ -37,9 +40,11 @@ test("mermaid plugin markdown generation with text code", () => {
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/diagram.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
         title: "Flow Chart",
@@ -60,11 +65,14 @@ test("mermaid plugin markdown generation with simple flowchart", () => {
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/flowchart.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "text",
           text: "flowchart LR\n    A --> B --> C",
@@ -82,11 +90,14 @@ test("mermaid plugin markdown generation with sequence diagram", () => {
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/sequence.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "text",
           text: "sequenceDiagram\n    Alice->>Bob: Hello Bob, how are you?\n    Bob-->>John: How about you John?\n    Bob--x Alice: I am good thanks!",
@@ -107,11 +118,14 @@ test("mermaid plugin markdown generation with class diagram", () => {
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/class.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "text",
           text: "classDiagram\n    Animal <|-- Duck\n    Animal <|-- Fish\n    Animal : +int age\n    Animal : +String gender",
@@ -129,12 +143,14 @@ test("mermaid plugin markdown generation with non-text code returns undefined", 
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/diagram.png",
     beat: {
       text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "path",
           path: "/path/to/diagram.mmd",
@@ -152,7 +168,8 @@ test("mermaid plugin markdown generation with wrong image type", () => {
   assert(plugin, "mermaid plugin should exist");
   assert(plugin.markdown, "mermaid plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -171,9 +188,11 @@ test("mermaid plugin with gantt chart", () => {
   const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/gantt.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
         title: "Project Timeline",
@@ -194,9 +213,11 @@ test("mermaid plugin with pie chart", () => {
   const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/pie.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
         title: "Distribution",
@@ -217,11 +238,14 @@ test("mermaid plugin with user journey", () => {
   const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/journey.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "text",
           text: "journey\n    title My working day\n    section Go to work\n      Make tea: 5: Me\n      Go upstairs: 3: Me\n      Do work: 1: Me, Cat",
@@ -239,11 +263,14 @@ test("mermaid plugin with empty code", () => {
   const plugin = requireRenderingPlugin("mermaid");
   assert(plugin, "mermaid plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/empty.png",
     beat: {
+      text: "",
       image: {
         type: "mermaid",
+        title: "Diagram",
         code: {
           kind: "text",
           text: "",

--- a/test/image_plugins/test_slide_plugin.ts
+++ b/test/image_plugins/test_slide_plugin.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
+import { contextWithSlideTheme } from "../fixtures.js";
+import { createMockContext } from "../actions/utils.js";
 import assert from "node:assert";
 import { requireHtmlPlugin } from "./utils.js";
-import { ImageProcessorParams } from "../../src/types/index.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 
 const validTheme = {
   colors: {
@@ -51,7 +53,8 @@ test("slide plugin path function", () => {
   const plugin = requireHtmlPlugin("slide");
   assert(plugin, "slide plugin should exist");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -61,7 +64,7 @@ test("slide plugin path function", () => {
         slide: { layout: "title", title: "Test" },
       },
     },
-  } as ImageProcessorParams;
+  };
 
   const path = plugin.path(mockParams);
   assert.strictEqual(path, "/test/path/image.png");
@@ -72,7 +75,7 @@ test("slide plugin html uses beat.image.theme when provided", async () => {
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -82,10 +85,8 @@ test("slide plugin html uses beat.image.theme when provided", async () => {
         slide: { layout: "title", title: "Hello World" },
       },
     },
-    context: {
-      presentationStyle: {},
-    },
-  } as ImageProcessorParams;
+    context: contextWithSlideTheme(),
+  };
 
   const html = await plugin.html(mockParams);
   assert(html, "HTML should be generated");
@@ -98,7 +99,7 @@ test("slide plugin html falls back to slideParams.theme when beat theme is missi
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -107,14 +108,8 @@ test("slide plugin html falls back to slideParams.theme when beat theme is missi
         slide: { layout: "title", title: "Fallback Test" },
       },
     },
-    context: {
-      presentationStyle: {
-        slideParams: {
-          theme: validTheme,
-        },
-      },
-    },
-  } as ImageProcessorParams;
+    context: contextWithSlideTheme(validTheme),
+  };
 
   const html = await plugin.html(mockParams);
   assert(html, "HTML should be generated");
@@ -127,7 +122,7 @@ test("slide plugin html uses beat theme over slideParams theme (override)", asyn
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -137,14 +132,8 @@ test("slide plugin html uses beat theme over slideParams theme (override)", asyn
         slide: { layout: "title", title: "Override Test" },
       },
     },
-    context: {
-      presentationStyle: {
-        slideParams: {
-          theme: validTheme,
-        },
-      },
-    },
-  } as ImageProcessorParams;
+    context: contextWithSlideTheme(validTheme),
+  };
 
   const html = await plugin.html(mockParams);
   assert(html, "HTML should be generated");
@@ -157,7 +146,7 @@ test("slide plugin html uses corporate theme as default when both themes are mis
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -166,10 +155,8 @@ test("slide plugin html uses corporate theme as default when both themes are mis
         slide: { layout: "title", title: "No Theme" },
       },
     },
-    context: {
-      presentationStyle: {},
-    },
-  } as ImageProcessorParams;
+    context: contextWithSlideTheme(),
+  };
 
   const html = await plugin.html(mockParams);
   assert(html, "HTML should be generated with default corporate theme");
@@ -181,7 +168,7 @@ test("slide plugin html returns undefined for non-slide beat", async () => {
   assert(plugin, "slide plugin should exist");
   assert(plugin.html, "slide plugin should have html function");
 
-  const mockParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -190,10 +177,8 @@ test("slide plugin html returns undefined for non-slide beat", async () => {
         slide: { title: "Not a slide" },
       },
     },
-    context: {
-      presentationStyle: {},
-    },
-  } as ImageProcessorParams;
+    context: contextWithSlideTheme(),
+  };
 
   const html = await plugin.html(mockParams);
   assert.strictEqual(html, undefined);

--- a/test/image_plugins/test_source_plugins.ts
+++ b/test/image_plugins/test_source_plugins.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
+import { contextWithDir } from "../fixtures.js";
+import { createMockContext } from "../actions/utils.js";
 import assert from "node:assert";
 import { resolve } from "node:path";
 import { requireImagePlugin } from "./utils.js";
-import { ImageProcessorParams } from "../../src/types/index.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 
 // Image plugin tests
 test("image plugin basic functionality", () => {
@@ -15,7 +17,8 @@ test("image plugin path with URL source", () => {
   const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -37,7 +40,7 @@ test("image plugin path with path source", () => {
   const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -49,11 +52,7 @@ test("image plugin path with path source", () => {
         },
       },
     },
-    context: {
-      fileDirs: {
-        mulmoFileDirPath: "/project",
-      },
-    },
+    context: contextWithDir("/project"),
   };
 
   const path = plugin.path(mockParams);
@@ -64,7 +63,7 @@ test("image plugin path with relative path source", () => {
   const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -76,11 +75,7 @@ test("image plugin path with relative path source", () => {
         },
       },
     },
-    context: {
-      fileDirs: {
-        mulmoFileDirPath: "/home/user/project",
-      },
-    },
+    context: contextWithDir("/home/user/project"),
   };
 
   const path = plugin.path(mockParams);
@@ -91,7 +86,8 @@ test("image plugin path with wrong image type", () => {
   const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -117,7 +113,8 @@ test("movie plugin path with URL source", () => {
   const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/movie.png",
     beat: {
       text: "",
@@ -140,7 +137,7 @@ test("movie plugin path with path source", () => {
   const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/movie.png",
     beat: {
       text: "",
@@ -152,11 +149,7 @@ test("movie plugin path with path source", () => {
         },
       },
     },
-    context: {
-      fileDirs: {
-        mulmoFileDirPath: "/project",
-      },
-    },
+    context: contextWithDir("/project"),
   };
 
   const path = plugin.path(mockParams);
@@ -167,7 +160,8 @@ test("movie plugin path extension fix", () => {
   const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/video.png",
     beat: {
       text: "",
@@ -190,7 +184,8 @@ test("movie plugin path with .mov already in imagePath", () => {
   const plugin = requireImagePlugin("movie");
   assert(plugin, "movie plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/video.mov",
     beat: {
       text: "",
@@ -213,7 +208,8 @@ test("source plugins with no image property", () => {
   const imagePlugin = requireImagePlugin("image");
   const moviePlugin = requireImagePlugin("movie");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/file.png",
     beat: { text: "" },
   };
@@ -228,7 +224,7 @@ test("source plugins with no image property", () => {
 test("source plugins with unknown source kind", () => {
   const imagePlugin = requireImagePlugin("image");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -241,11 +237,7 @@ test("source plugins with unknown source kind", () => {
         },
       },
     },
-    context: {
-      fileDirs: {
-        mulmoFileDirPath: "/project",
-      },
-    },
+    context: contextWithDir("/project"),
   };
 
   const path = imagePlugin?.path(mockParams);
@@ -256,7 +248,7 @@ test("image plugin with absolute path source", () => {
   const plugin = requireImagePlugin("image");
   assert(plugin, "image plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -268,11 +260,7 @@ test("image plugin with absolute path source", () => {
         },
       },
     },
-    context: {
-      fileDirs: {
-        mulmoFileDirPath: "/project",
-      },
-    },
+    context: contextWithDir("/project"),
   };
 
   const path = plugin.path(mockParams);

--- a/test/image_plugins/test_text_slide_plugin.ts
+++ b/test/image_plugins/test_text_slide_plugin.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
+import { createMockContext } from "../actions/utils.js";
 import assert from "node:assert";
 import { requireRenderingPlugin } from "./utils.js";
-import { ImageProcessorParams } from "../../src/types/index.js";
+import type { BeatPathParams } from "../../src/types/index.js";
 
 test("text_slide plugin basic functionality", () => {
   const plugin = requireRenderingPlugin("textSlide");
@@ -13,7 +14,8 @@ test("text_slide plugin path function", () => {
   const plugin = requireRenderingPlugin("textSlide");
   assert(plugin, "textSlide plugin should exist");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -35,7 +37,8 @@ test("text_slide plugin markdown generation with title only", () => {
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -57,7 +60,8 @@ test("text_slide plugin markdown generation with title and subtitle", () => {
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -80,7 +84,8 @@ test("text_slide plugin markdown generation with title, subtitle, and bullets", 
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
@@ -104,13 +109,17 @@ test("text_slide plugin markdown generation with bullets only", () => {
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
       image: {
         type: "textSlide",
         slide: {
+          // The schema requires a title; the renderer treats an empty one as absent
+          // (`slide.title ? ... : ""`), which is the branch this test covers.
+          title: "",
           bullets: ["Bullet A", "Bullet B"],
         },
       },
@@ -126,13 +135,16 @@ test("text_slide plugin markdown generation with empty slide", () => {
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.markdown, "textSlide plugin should have markdown function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",
       image: {
         type: "textSlide",
-        slide: {},
+        // Same as above: an empty title is how "no title" is expressed to a schema
+        // that requires the field.
+        slide: { title: "" },
       },
     },
   };
@@ -146,7 +158,8 @@ test("text_slide plugin html generation", async () => {
   assert(plugin, "textSlide plugin should exist");
   assert(plugin.html, "textSlide plugin should have html function");
 
-  const mockParams: ImageProcessorParams = {
+  const mockParams: BeatPathParams = {
+    context: createMockContext(),
     imagePath: "/test/path/image.png",
     beat: {
       text: "",


### PR DESCRIPTION
## Summary

`#1555` で狭めた型の**テスト側の回収**です。`test/` の型エラー **155 → 100**、`image_plugins` は **50 → 3**。

`Refs #1551`

## Items to Confirm / Review

### 1. どれも「fixture がスキーマと食い違っている」であって、コードの不具合ではありません

| 形 | 直し方 |
|---|---|
| `const mockParams: ImageProcessorParams` だが実際は `path()` / `markdown()` / `html()` にしか渡らない | `BeatPathParams` に。これは `BeatRenderParams` も満たすので、両方を呼ぶファイルも1つの注釈で済みます |
| beat に `text` が無い / mermaid beat に `title` が無い | どちらもスキーマ必須。`MulmoBeat` は `z.infer`（**出力型**）なので、手書き fixture は入力形で、書く必要があります |
| `context: { fileDirs: { mulmoFileDirPath } }` | `MulmoStudioContext` ではありません。`contextWithDir()` が既存モックのその1フィールドだけ差し替えます |
| 片方の `type` にもう片方のペイロード／`path()` に余計な第2引数 | 意図は保ったまま、**実在する形**に |

### 2. titleless の textSlide は `title: ""` にしています（ここは見てほしい）

`textSlide.slide.title` はスキーマ必須ですが、renderer は:

```ts
const titleString = slide.title ? `# ${slide.title}\n` : "";
```

と**タイトル無しを明示的に扱っています**。実タイトルを足せばコンパイルは通りますが、**このテストが見ている分岐が消えます**。空文字はスキーマを満たし、renderer からは「無し」に見えるので、両立させました。

スキーマと renderer のどちらが正しいかは仕様の話なので、そこは触っていません。

### 3. 自分のミスを2つ、途中で見つけて直しました

- 1回目のパスが **`MulmoBeat` の import を重複追加**していました
- 「この beat にもう `text` があるか」の判定が**入れ子のキーまで見ていた**ため、`image.code.text` を持つ mermaid beat をすべて skip していました（トップレベルのキーだけ見るよう修正）

どちらも型検査とテスト実行で出ました。

### 4. 残る `image_plugins` 3件は別 PR にします

`test_bg_image_util.ts` の3件は `resolveCombinedStyle(params, …)` が `ImageProcessorParams` を要求するせいですが、**この関数が読むのは `context` と `textSlideStyle` だけ**です。`#1555` と同じ「型が実態より広い」構図で、直すなら実装側なので、この PR（テストのみ）には混ぜません。

### 5. cast は9件すべて外しました（追加コミット `7be7dc83`）

「cast を使いたくない」との指摘を受けて、この PR が触るファイルから**既存分も含めて全廃**しました。**どれも何かを隠していました**:

| cast | 外して分かったこと |
|---|---|
| `type: "chart" as const`（この PR で私が入れた） | beat の型注釈で narrow されるので元々不要 |
| `} as ImageProcessorParams` ×6（`test_slide_plugin`、既存） | 隠れていた `context: { presentationStyle: {} }` は `MulmoStudioContext` ではありませんでした。`contextWithSlideTheme()` で構築 — 既存モックの `presentationStyle` は `imageParams` だけなので、**それ自体が「slide theme 無し」の fixture** です |
| `animation: false as unknown as true` ×2（`#1554` で**私が**入れた） | `animation` は `true \| {fps, movie}` なので `false` は parse 済み beat に存在しません。1件は `MulmoBeatMethods.isAnimationEnabled(false)`（`unknown` を取る）に移設 |

**そのうち1件は空のテストでした。** `path()` が `animation: false` のとき png パスを返す、と主張していましたが、`html_tailwind` の `path` は `parrotingImagePath` で **beat の中身に関係なく `imagePath` を返します**。fixture を `animation: true` に変えても通ることで判明しました。今は両方の値に対して「実際に保証されること」を主張しています。

## 検証

- `test/` 型エラー: **155 → 100**（`image_plugins` 50 → 3）
- `image_plugins` テスト: **172 pass / 0 fail**
- **全体テスト: 1166 tests / 0 fail**
- `lint` / `build`: green

## User Prompt

> cli #1551 や viewer #69もすすめる

Refs #1551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated image, chart, animation, Tailwind, Mermaid, source, and text-slide plugin tests to reflect the current rendering context and parameter formats.
  - Improved mock file-path handling and rendering context coverage.
  - Corrected test fixtures for markdown images and empty text slides without changing expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
