### PR TITLE
test: make the method and agent fixtures shapes the app can produce

### DIFF
--- a/test/actions/test_image_preprocess_agent_plugin.ts
+++ b/test/actions/test_image_preprocess_agent_plugin.ts
@@ -38,7 +38,7 @@ test("imagePreprocessAgent - movie plugin", async () => {
     movieFile: resolvedMoviePath,
     beatDuration: undefined,
     markdown: undefined,
-    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: {}, keyName: "REPLICATE_API_TOKEN" },
+    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: { provider: "replicate" }, keyName: "REPLICATE_API_TOKEN" },
     imagePath: "/test/images/test_studio/1p.png",
     html:
       "\n" +
@@ -90,7 +90,7 @@ test("imagePreprocessAgent - with image plugin (textSlide)", async () => {
     },
     movieFile: undefined,
     beatDuration: undefined,
-    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: {}, keyName: "REPLICATE_API_TOKEN" },
+    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: { provider: "replicate" }, keyName: "REPLICATE_API_TOKEN" },
     markdown: "# 3.0 second with no Audio\n",
     html: "<h1>3.0 second with no Audio</h1>\n",
     imagePath: "/test/images/test_studio/1p.png",
@@ -125,7 +125,7 @@ test("imagePreprocessAgent - with image plugin (markdown)", async () => {
     },
     movieFile: undefined,
     beatDuration: undefined,
-    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: {}, keyName: "REPLICATE_API_TOKEN" },
+    movieAgentInfo: { agent: "movieReplicateAgent", movieParams: { provider: "replicate" }, keyName: "REPLICATE_API_TOKEN" },
     html: "<h2>Chapter 2</h2>\n<ul>\n<li>Hello</li>\n<li>World</li>\n</ul>\n",
     markdown: "## Chapter 2\n- Hello\n- World",
     imagePath: "/test/images/test_studio/1p.png",
@@ -145,7 +145,7 @@ const chartPluginExpected = {
   movieFile: undefined,
   beatDuration: undefined,
   markdown: undefined,
-  movieAgentInfo: { agent: "movieReplicateAgent", movieParams: {}, keyName: "REPLICATE_API_TOKEN" },
+  movieAgentInfo: { agent: "movieReplicateAgent", movieParams: { provider: "replicate" }, keyName: "REPLICATE_API_TOKEN" },
   imagePath: "/test/images/test_studio/1p.png",
   referenceImageForMovie: "/test/images/test_studio/1p.png",
   html:
@@ -251,7 +251,7 @@ const mermaidPluginExpected = {
   },
   movieFile: undefined,
   beatDuration: undefined,
-  movieAgentInfo: { agent: "movieReplicateAgent", movieParams: {}, keyName: "REPLICATE_API_TOKEN" },
+  movieAgentInfo: { agent: "movieReplicateAgent", movieParams: { provider: "replicate" }, keyName: "REPLICATE_API_TOKEN" },
   markdown:
     "```mermaid\n" +
     "graph LR\n" +

--- a/test/actions/utils.ts
+++ b/test/actions/utils.ts
@@ -1,6 +1,14 @@
 import { type MulmoStudioContext, type MulmoBeat } from "../../src/types/index.js";
-// Helper function to create mock context
+import { mulmoScriptSchema, mulmoPresentationStyleSchema } from "../../src/types/schema.js";
 
+/**
+ * A context shaped like the one the app builds.
+ *
+ * The script and the presentation style go through their schemas rather than being written
+ * out by hand: the defaults they fill are part of what every caller sees, and a literal that
+ * omits them is a state production cannot reach. This used to be a partial object that only
+ * satisfied `MulmoStudioContext` because nothing checked it.
+ */
 export const createMockContext = (): MulmoStudioContext => ({
   fileDirs: {
     mulmoFilePath: "/test/path/test.yaml",
@@ -9,47 +17,41 @@ export const createMockContext = (): MulmoStudioContext => ({
     outDirPath: "/test/output",
     imageDirPath: "/test/images",
     audioDirPath: "/test/audio",
+    isHttpPath: false,
+    fileOrUrl: "/test/path/test.yaml",
+    outputStudioFilePath: "/test/output/test_studio.json",
+    outputMultilingualFilePath: "/test/output/test_lang.json",
+    presentationStylePath: undefined,
+    fileName: "test",
+    grouped: false,
   },
   studio: {
     filename: "test_studio",
+    // The schema requires at least one beat, and the tests want to start from none and push
+    // their own — so it is parsed with a throwaway beat and emptied. Everything else the
+    // schema defaults is kept, which is what a real script carries.
     script: {
-      $mulmocast: {
-        version: "1.1",
-      },
-      title: "Test Script",
+      ...mulmoScriptSchema.parse({
+        $mulmocast: { version: "1.1" },
+        title: "Test Script",
+        beats: [{ text: "" }],
+        lang: "en",
+        canvasSize: { width: 1920, height: 1080 },
+      }),
       beats: [],
-      lang: "en",
-      canvasSize: { width: 1920, height: 1080 },
     },
     beats: [],
-    toJSON: () => "{}",
   },
   force: false,
-  presentationStyle: {
-    imageParams: {
-      provider: "openai",
-      model: "gpt-image-1",
-      style: "natural",
-      moderation: "auto",
-    },
-  },
+  lang: "en",
+  multiLingual: [],
+  presentationStyle: mulmoPresentationStyleSchema.parse({
+    $mulmocast: { version: "1.1" },
+    imageParams: { provider: "openai", model: "gpt-image-1", style: "natural", moderation: "auto" },
+  }),
   sessionState: {
-    inSession: {
-      audio: false,
-      image: false,
-      video: false,
-      multiLingual: false,
-      caption: false,
-      pdf: false,
-    },
-    inBeatSession: {
-      audio: {},
-      image: {},
-      movie: {},
-      multiLingual: {},
-      caption: {},
-      html: {},
-    },
+    inSession: { audio: false, image: false, video: false, multiLingual: false, caption: false, pdf: false, markdown: false, html: false, viewer: false },
+    inBeatSession: { audio: {}, image: {}, movie: {}, multiLingual: {}, caption: {}, html: {}, imageReference: {}, soundEffect: {}, lipSync: {} },
   },
 });
 

--- a/test/agents/run_crawler.ts
+++ b/test/agents/run_crawler.ts
@@ -1,6 +1,6 @@
 //  npx tsx ./test/agents/run_crawler.ts
 import { GraphAILogger } from "graphai";
-import puppeteerCrawlerAgentInfo from "../../src/agents/puppeteer_crawler_agent";
+import puppeteerCrawlerAgentInfo from "../../src/agents/puppeteer_crawler_agent.js";
 
 import test from "node:test";
 

--- a/test/agents/test_combine_audio_files.ts
+++ b/test/agents/test_combine_audio_files.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { audioParamsSchema } from "../../src/types/schema.js";
 import assert from "node:assert";
 
 import { createMockContext, createMockBeat } from "../actions/utils.js";
@@ -477,10 +478,10 @@ test("updateDurations with default padding", async () => {
 
   const mock = createMockContext();
   // Set up presentation style with default padding
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0, // Last beat gets no padding
-  };
+  });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -515,10 +516,10 @@ test("updateDurations with custom beat padding", async () => {
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -543,10 +544,10 @@ test("updateDurations padding with movie duration", async () => {
   const beat = createMockBeat({});
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0, // Last beat gets no closing padding
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -575,10 +576,10 @@ test("updateDurations padding with specified beat duration", async () => {
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0, // Last beat gets no closing padding
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -670,10 +671,10 @@ test("updateDurations multiple separate spill-over groups", async () => {
   ];
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0,
-  };
+  });
   mock.studio.script.beats.push(...beats);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -845,10 +846,10 @@ test("updateDurations complex mixed scenario", async () => {
   ];
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0,
-  };
+  });
   mock.studio.script.beats.push(...beats);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1027,7 +1028,7 @@ test("updateDurations spill-over continues over a silent moviePrompt beat", asyn
   const beat2 = createMockBeat({ text: "", moviePrompt: "draw the diagram" });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1047,7 +1048,7 @@ test("updateDurations spill-over ends at a moviePrompt beat with generateAudio",
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1067,7 +1068,7 @@ test("updateDurations spill-over ends at a moviePrompt beat with an always-audio
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1089,7 +1090,7 @@ test("updateDurations spill-over ends at an imported silent movie beat", async (
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1112,7 +1113,7 @@ test("updateDurations spill-over ends at an animated html_tailwind beat with exp
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -1138,7 +1139,7 @@ test("updateDurations silent movie beat still heads a voice-over group after nar
   });
 
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = { padding: 0, closingPadding: 0 };
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({ padding: 0, closingPadding: 0 });
   mock.studio.script.beats.push(beat1, beat2, beat3);
   mock.studio = createStudioData(mock.studio.script, "test");
 

--- a/test/agents/test_combine_audio_files2.ts
+++ b/test/agents/test_combine_audio_files2.ts
@@ -1,4 +1,5 @@
 import test from "node:test";
+import { audioParamsSchema } from "../../src/types/schema.js";
 import assert from "node:assert";
 
 import { createMockContext, createMockBeat } from "../actions/utils.js";
@@ -21,10 +22,10 @@ test("getPadding with custom beat padding", () => {
     },
   });
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -35,10 +36,10 @@ test("getPadding with custom beat padding", () => {
 test("getPadding for last beat", () => {
   const beat = createMockBeat({});
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -50,10 +51,10 @@ test("getPadding for second-to-last beat (closing gap)", () => {
   const beat1 = createMockBeat({});
   const beat2 = createMockBeat({});
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.5,
-  };
+  });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -66,10 +67,10 @@ test("getPadding for regular beat", () => {
   const beat2 = createMockBeat({});
   const beat3 = createMockBeat({});
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.0,
-  };
+  });
   mock.studio.script.beats.push(beat1, beat2, beat3);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -318,10 +319,10 @@ test("spilledOverAudio with insufficient audio", () => {
 test("noSpilledOverAudio with audio only", () => {
   const beat = createMockBeat({});
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -338,10 +339,10 @@ test("noSpilledOverAudio with movie and audio", () => {
   const beat1 = createMockBeat({});
   const beat2 = createMockBeat({});
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 1.0,
-  };
+  });
   mock.studio.script.beats.push(beat1, beat2);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -362,10 +363,10 @@ test("noSpilledOverAudio with movie and audio", () => {
 test("noSpilledOverAudio with specified beat duration", () => {
   const beat = createMockBeat({ duration: 45 });
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 
@@ -387,10 +388,10 @@ test("noSpilledOverAudio with custom beat padding", () => {
     },
   });
   const mock = createMockContext();
-  mock.presentationStyle.audioParams = {
+  mock.presentationStyle.audioParams = audioParamsSchema.parse({
     padding: 2.0,
     closingPadding: 0.0,
-  };
+  });
   mock.studio.script.beats.push(beat);
   mock.studio = createStudioData(mock.studio.script, "test");
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,5 @@
-import type { ImageProcessorParams, MulmoBeat, MulmoStudioContext } from "../src/types/index.js";
+import type { ImageProcessorParams, MulmoBeat, MulmoPresentationStyle, MulmoStudioContext } from "../src/types/index.js";
+import { mulmoPresentationStyleSchema } from "../src/types/schema.js";
 import type { SlideTheme } from "@mulmocast/deck";
 import { createMockContext } from "./actions/utils.js";
 
@@ -46,3 +47,14 @@ export const contextWithSlideTheme = (theme?: SlideTheme): MulmoStudioContext =>
   const context = createMockContext();
   return theme ? { ...context, presentationStyle: { ...context.presentationStyle, slideParams: { theme } } } : context;
 };
+
+/**
+ * A `MulmoPresentationStyle` from a partial one.
+ *
+ * `$mulmocast` is the only field the schema cannot default; everything else it fills exactly
+ * as it would for a real script. The fixtures this replaces were partial literals that only
+ * compiled where the parameter was cast, and they left the defaulted fields undefined —
+ * which is not a state production can produce.
+ */
+export const presentationStyleFixture = (partial: Record<string, unknown> = {}): MulmoPresentationStyle =>
+  mulmoPresentationStyleSchema.parse({ $mulmocast: { version: "1.1" }, ...partial });

--- a/test/methods/test_presentation_style.ts
+++ b/test/methods/test_presentation_style.ts
@@ -1,11 +1,13 @@
 import test from "node:test";
+import type { MulmoBeat } from "../../src/types/index.js";
+import { presentationStyleFixture } from "../fixtures.js";
 import assert from "node:assert";
 
 import { MulmoPresentationStyleMethods } from "../../src/methods/mulmo_presentation_style.js";
 import { createMockContext, createMockBeat } from "../actions/utils.js";
 
 test("defaultSpeaker isDefault", async () => {
-  const presentationStyle = {
+  const presentationStyle = presentationStyleFixture({
     speechParams: {
       provider: "openai",
       speakers: {
@@ -18,13 +20,13 @@ test("defaultSpeaker isDefault", async () => {
         },
       },
     },
-  };
+  });
   const result = MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   assert.equal(result, "Presenter");
 });
 
 test("defaultSpeaker no isDefault", async () => {
-  const presentationStyle = {
+  const presentationStyle = presentationStyleFixture({
     speechParams: {
       provider: "openai",
       speakers: {
@@ -36,13 +38,13 @@ test("defaultSpeaker no isDefault", async () => {
         },
       },
     },
-  };
+  });
   const result = MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   assert.equal(result, "Presenter");
 });
 
 test("defaultSpeaker no isDefault two speaker", async () => {
-  const presentationStyle = {
+  const presentationStyle = presentationStyleFixture({
     speechParams: {
       provider: "openai",
       speakers: {
@@ -60,13 +62,13 @@ test("defaultSpeaker no isDefault two speaker", async () => {
         },
       },
     },
-  };
+  });
   const result = MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   assert.equal(result, "Presenter1");
 });
 
 test("defaultSpeaker isDefault two speaker", async () => {
-  const presentationStyle = {
+  const presentationStyle = presentationStyleFixture({
     speechParams: {
       provider: "openai",
       speakers: {
@@ -86,18 +88,18 @@ test("defaultSpeaker isDefault two speaker", async () => {
         },
       },
     },
-  };
+  });
   const result = MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   assert.equal(result, "Presenter1");
 });
 
 test("defaultSpeaker error no speaker", async () => {
-  const presentationStyle = {
+  const presentationStyle = presentationStyleFixture({
     speechParams: {
       provider: "openai",
       speakers: {},
     },
-  };
+  });
   await assert.rejects(async () => {
     MulmoPresentationStyleMethods.getDefaultSpeaker(presentationStyle);
   });
@@ -108,6 +110,11 @@ test("defaultSpeaker error no speaker", async () => {
 // The priority surfaced here is the single source of truth that both
 // the renderer (`slide.ts`) and the editor (`@mulmocast/deck-web`)
 // will read from, so the tests below pin the contract loudly.
+
+// The label doubles as every colour so an assertion can name which theme won. It must be a
+// colour the schema accepts (six hex digits), or the fixture is one no script could carry.
+const PRESENTATION_THEME = "9E5EDA"; // distinguishable sentinels that are also valid colours
+const BEAT_THEME = "8EA7CD";
 
 const fakeTheme = (label: string) => ({
   colors: {
@@ -129,22 +136,22 @@ const fakeTheme = (label: string) => ({
 });
 
 test("getResolvedSlideTheme: per-beat theme wins over presentation-level", () => {
-  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
-  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" }, theme: fakeTheme("BEAT") } };
+  const presentationStyle = presentationStyleFixture({ slideParams: { theme: fakeTheme(PRESENTATION_THEME) } });
+  const beat: MulmoBeat = { text: "", image: { type: "slide", slide: { layout: "title", title: "x" }, theme: fakeTheme(BEAT_THEME) } };
   const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
-  assert.equal(result.colors.bg, "BEAT");
+  assert.equal(result.colors.bg, BEAT_THEME);
 });
 
 test("getResolvedSlideTheme: presentation-level theme used when beat lacks one", () => {
-  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
-  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" } } };
+  const presentationStyle = presentationStyleFixture({ slideParams: { theme: fakeTheme(PRESENTATION_THEME) } });
+  const beat: MulmoBeat = { text: "", image: { type: "slide", slide: { layout: "title", title: "x" } } };
   const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
-  assert.equal(result.colors.bg, "PRES");
+  assert.equal(result.colors.bg, PRESENTATION_THEME);
 });
 
 test("getResolvedSlideTheme: slideThemes.corporate fallback when neither is set", () => {
-  const presentationStyle = {};
-  const beat = { image: { type: "slide" as const, slide: { layout: "title" as const, title: "x" } } };
+  const presentationStyle = presentationStyleFixture({});
+  const beat: MulmoBeat = { text: "", image: { type: "slide", slide: { layout: "title", title: "x" } } };
   const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
   // corporate's bg is "F8FAFC"; we just assert the call returns a
   // theme-shaped object — checking the literal value would lock the
@@ -156,12 +163,12 @@ test("getResolvedSlideTheme: slideThemes.corporate fallback when neither is set"
 test("getResolvedSlideTheme: non-slide beat falls through to fallback (no throw)", () => {
   // Callers driving a deck preview from a mixed script need to be
   // able to hand any beat in without first checking its image.type.
-  const presentationStyle = { slideParams: { theme: fakeTheme("PRES") } };
-  const beat = { image: { type: "textSlide" as const, slide: { title: "x" } } };
+  const presentationStyle = presentationStyleFixture({ slideParams: { theme: fakeTheme(PRESENTATION_THEME) } });
+  const beat: MulmoBeat = { text: "", image: { type: "textSlide", slide: { title: "x" } } };
   const result = MulmoPresentationStyleMethods.getResolvedSlideTheme(presentationStyle, beat);
   // Falls through to the presentation-level theme since beat.image.theme
   // doesn't apply (different image kind), instead of throwing.
-  assert.equal(result.colors.bg, "PRES");
+  assert.equal(result.colors.bg, PRESENTATION_THEME);
 });
 
 // generatedMovieHasAudio: resolves provider/model (including defaults) and the

--- a/test/methods/test_presentation_style_movie.ts
+++ b/test/methods/test_presentation_style_movie.ts
@@ -3,7 +3,7 @@ import assert from "node:assert";
 
 import { MulmoPresentationStyleMethods } from "../../src/methods/mulmo_presentation_style.js";
 import { createMockContext } from "../actions/utils.js";
-import { MulmoStudioContext, MulmoBeat, MulmoPresentationStyle } from "../../src/types/index.js";
+import { MulmoStudioContext, MulmoBeat, MulmoPresentationStyle, MulmoTransition } from "../../src/types/index.js";
 
 const FLOAT_TOLERANCE = 1e-9;
 const approxEqual = (actual: number, expected: number): boolean => Math.abs(actual - expected) < FLOAT_TOLERANCE;
@@ -14,8 +14,8 @@ const frameCheckContext = (beats: Partial<MulmoBeat>[], presentationStyle: Parti
     presentationStyle,
   }) as unknown as MulmoStudioContext;
 
-const transition = (type: string) => ({ movieParams: { transition: { type, duration: 1.0 } } });
-const voiceOver = { image: { type: "voice_over" } };
+const transition = (type: MulmoTransition["type"]) => ({ movieParams: { transition: { type, duration: 1.0 } } });
+const voiceOver: Partial<MulmoBeat> = { image: { type: "voice_over" } };
 
 // --- getNeedFirstFrame ---
 
@@ -121,26 +121,26 @@ test("test getNeedLastFrame on an empty script", async () => {
 
 test("test getFillOption with defaults only", async () => {
   const context = frameCheckContext([]);
-  const result = MulmoPresentationStyleMethods.getFillOption(context, { speaker: "A" });
+  const result = MulmoPresentationStyleMethods.getFillOption(context, { speaker: "A", text: "" });
   assert.equal(result.style, "aspectFit");
 });
 
 test("test getFillOption with global setting", async () => {
   const context = frameCheckContext([], { movieParams: { fillOption: { style: "aspectFill" } } });
-  const result = MulmoPresentationStyleMethods.getFillOption(context, { speaker: "A" });
+  const result = MulmoPresentationStyleMethods.getFillOption(context, { speaker: "A", text: "" });
   assert.equal(result.style, "aspectFill");
 });
 
 test("test getFillOption with beat override", async () => {
   const context = frameCheckContext([], { movieParams: { fillOption: { style: "aspectFill" } } });
-  const beat: MulmoBeat = { speaker: "A", movieParams: { fillOption: { style: "aspectFit" } } };
+  const beat: MulmoBeat = { speaker: "A", text: "", movieParams: { fillOption: { style: "aspectFit" } } };
   const result = MulmoPresentationStyleMethods.getFillOption(context, beat);
   assert.equal(result.style, "aspectFit");
 });
 
 test("test getFillOption with beat override and no global setting", async () => {
   const context = frameCheckContext([]);
-  const beat: MulmoBeat = { speaker: "A", movieParams: { fillOption: { style: "aspectFill" } } };
+  const beat: MulmoBeat = { speaker: "A", text: "", movieParams: { fillOption: { style: "aspectFill" } } };
   const result = MulmoPresentationStyleMethods.getFillOption(context, beat);
   assert.equal(result.style, "aspectFill");
 });
@@ -163,7 +163,7 @@ const createContextWithAudioParams = (audioParamsOverrides: Record<string, unkno
 };
 
 const beatWithText: MulmoBeat = { speaker: "Presenter", text: "Hello" };
-const beatWithoutText: MulmoBeat = { speaker: "Presenter" };
+const beatWithoutText: MulmoBeat = { speaker: "Presenter", text: "" };
 
 test("getMovieVolume: no ducking, no movieVolume - returns 1.0", () => {
   const context = createContextWithAudioParams();


### PR DESCRIPTION
## Summary

`#1551` の続き。`test/` の型エラー **100 → 45**。全体テスト **1166 / 0 fail**。

`Refs #1551`

## Items to Confirm / Review

### 1. 共有モック `createMockContext` が `MulmoStudioContext` ではありませんでした

`test/actions/utils.ts` の宣言は `: MulmoStudioContext` ですが、実際には:

- `fileDirs` に `FileObject` の**7項目が欠落**（`isHttpPath` / `fileOrUrl` / `outputStudioFilePath` …）
- `studio.script` と `presentationStyle` が部分的なリテラル
- `lang` と `multiLingual` が**丸ごと無い**
- 型に存在しない `toJSON` が付いていた

`test/` が型検査外だったので通っていました。script と presentationStyle は**スキーマに通す**ようにしたので、実際の呼び出し側が見るデフォルトが揃います。**20ファイルが使う**ので、全体テストで確認しています。

### 2. それが golden を1つ持ち上げていました（ここは見てほしい）

`test_image_preprocess_agent_plugin.ts` は `movieParams: {}` を期待していましたが、`mulmoPresentationStyleSchema` は

```ts
movieParams: mulmoMovieParamsSchema.optional().default({ provider: defaultProviders.text2movie }),
```

と宣言しています。つまり**実在する context は必ず provider を持ちます**。`{}` はモックの不完全さを写していただけでした。

**期待値を「新しい出力」に合わせたのではなく、スキーマの宣言を根拠に直しています。** ここを取り違えると golden の追認になるので、明示しておきます。

### 3. fixture がスキーマと食い違っていたもの

| 件数 | 内容 |
|---:|---|
| 21 | `transition(type: string)` が literal union より広い → `MulmoTransition["type"]` に |
| 20 | 部分的な `audioParams` 代入 → `audioParamsSchema.parse` 経由（`introPadding` / `outroPadding` が埋まる。**52テストとも通る**ので、そこは結果に効いていません） |
| 9 | 部分的な `presentationStyle` → `presentationStyleFixture`（parse） |
| 5 | `text` 欠落 |

### 4. parse に変えたら theme が弾かれました — テスト側が不正でした

`presentationStyleFixture` に通すと `getResolvedSlideTheme` の3本が `ZodError` で落ちました。原因は theme の色が**リテラル文字列 `"PRES"` / `"BEAT"`** で、スキーマは `/^[0-9A-Fa-f]{6}$/` を要求すること。cast が検証を迂回していたので通っていました。

「label をそのまま全色に使い、assertion でどちらの theme が勝ったか判定する」という**仕掛けは有用なので残し**、16進として妥当な sentinel（`9E5EDA` / `8EA7CD`）に変えています。

### 5. 私が間違えて戻した2件（記録として）

- `mulmoScriptSchema.parse({ beats: [] })` は**投げます**（スキーマは1つ以上を要求）。捨てビートで parse して空にする形にしました
- `movieParams: {}` を `test/` 全体に一括置換して **30テストを壊しました**。`test_image_preprocess_agent.ts` は **`utils2.ts` の別モック**を使っており、そちらはまだ部分的なので `{}` が正しい。クラス修正のつもりで、クラスの範囲を確認していませんでした

## 検証

- `test/` 型エラー: **100 → 45**
- **全体テスト: 1166 tests / 0 fail**
- `lint` / `build`: green
- 新規 cast: **なし**

## 残り45件と、安全に進めなかったもの

`utils2.ts` の2つ目のモックも同じく部分的（6件）ですが、**直すと `test_image_preprocess_agent.ts` の golden が同様に動きます**。1つ目と同じ手順で扱えますが、別 PR にすべき規模です。

`test_bg_image_util.ts` の3件は `resolveCombinedStyle` が `context` と `textSlideStyle` しか読まないのに `ImageProcessorParams` を要求する件で、`#1555` と同じ実装側の話です。

## User Prompt

> cli #1551 のこりも安全にできるものはどんどんすすめる

Refs #1551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated image preprocessing expectations to reflect the Replicate provider.
  * Improved test fixtures and validation for presentation styles, audio settings, scripts, and session data.
  * Expanded presentation-style coverage for theme precedence, default speakers, transitions, and movie volume behavior.
  * Updated crawler imports and aligned movie, audio, and presentation tests with current schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->