### PR TITLE
refactor: let resolveCombinedStyle declare the two fields it reads

### DIFF
--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -49,12 +49,15 @@ const sizeToCSS = (size: string): string => {
   return size === "fill" ? "100% 100%" : size;
 };
 
+/** The background image comes from the script, the style from the beat; the paths and sizes `process()` needs are not read here. */
+type CombinedStyleParams = Pick<ImageProcessorParams, "context" | "textSlideStyle">;
+
 /**
  * Resolve combined style from background image and custom style.
  * Common pattern used by markdown, textSlide, mermaid plugins.
  */
 export const resolveCombinedStyle = async (
-  params: ImageProcessorParams,
+  params: CombinedStyleParams,
   beatBackgroundImage: BackgroundImage | undefined,
   beatStyle: string | undefined,
 ): Promise<string> => {

--- a/test/image_plugins/test_bg_image_util.ts
+++ b/test/image_plugins/test_bg_image_util.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 import { resolveCombinedStyle } from "../../src/utils/image_plugins/bg_image_util.js";
+import { createMockContext } from "../actions/utils.js";
 
 /**
  * resolveCombinedStyle is the only producer of the CSS that chart, mermaid, markdown and
@@ -13,7 +14,7 @@ import { resolveCombinedStyle } from "../../src/utils/image_plugins/bg_image_uti
  */
 
 const paramsWith = (textSlideStyle: string) => ({
-  context: { studio: { script: {} } },
+  context: createMockContext(),
   textSlideStyle,
 });
 


### PR DESCRIPTION
## Summary

`#1551` の残り45件のうち、**実装側の型が実態より広い**ケース（3件）です。`#1555` と同じ構図。

`resolveCombinedStyle(params, …)` は `ImageProcessorParams` 全体を要求しますが、**読むのは `context` と `textSlideStyle` の2つだけ**です（`const { context, textSlideStyle } = params;` がこの関数の全て）。要求だけが広いので、テストは `beat` / `imagePath` / `canvasSize` を「読まれないと知りつつ」埋めるしかなく、`test_bg_image_util.ts` はそれを避けて `context: { studio: { script: {} } }` という **`MulmoStudioContext` ではないもの**を渡していました。

- `Pick<ImageProcessorParams, "context" | "textSlideStyle">` に絞る（`BeatRenderParams` / `BeatPathParams` と同じやり方）
- テストは共有の `createMockContext()` を使う形に

呼び出し元4つ（markdown / text_slide / chart / mermaid）はいずれも full な `ImageProcessorParams` を渡しているので、構造的部分型でそのまま通ります。`bg_image_util` は package から export されていないため外部影響はありません。

型注釈のみの変更で、実行時の挙動は変わりません（`params` の分解も本体も無変更）。

`typecheck:test`: **45 → 42**

## Items to Confirm / Review

- **`CombinedStyleParams` を `type.ts` ではなくこのファイルに置きました。** `BeatRenderParams` / `BeatPathParams` は複数ファイルの plugin が実装する「インターフェイス」なので `type.ts` にありますが、これは1ファイル内のヘルパー1本の引数なので、読む関数の隣に置く方が理由が見える、という判断です。`type.ts` に集めたい場合は言ってください
- **テストの入力が実際に変わっています。** `{ studio: { script: {} } }` → `createMockContext()` なので、`context.studio.script.imageParams?.backgroundImage` の評価対象が変わりました。モックの `imageParams` に `backgroundImage` は無いので結果は同じ（= 背景CSSは空文字）で、3本のテストは出力を `strictEqual` で固定しているため、変わっていれば落ちます

## 検証

- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `npx tsc --noEmit -p tsconfig.test.json` — 45 → 42
- `yarn ci_test` 相当（全1166本）— **pass 1162 / fail 0 / skip 4**

## User Prompt

> #1551 すすめて

（`#1551`「test/ の型エラー 279 件」バックログの継続。残り45件のうち、実装側の型を実態に合わせる分をこの PR で。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type clarity for background image style processing without changing behavior.

* **Tests**
  * Updated background image utility tests to use a shared mock context helper.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->