### PR TITLE
test: build the action-test contexts the way the app builds them

### DIFF
--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -55,7 +55,7 @@ const mulmoCredit = (speaker: string, isPortrait: boolean) => {
   };
 };
 
-const initSessionState = () => {
+export const initSessionState = () => {
   return {
     inSession: {
       audio: false,

--- a/test/actions/run_audio.ts
+++ b/test/actions/run_audio.ts
@@ -2,7 +2,8 @@ import test from "node:test";
 // import assert from "node:assert";
 
 import { getFileObject } from "../../src/cli/helpers.js";
-import { createStudioData } from "../../src/utils/context.js";
+import { createStudioData, initSessionState } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
 import { generateBeatAudio } from "../../src/actions/audio.js";
 
 import path from "path";
@@ -10,7 +11,7 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const testMulmoScript = {
+const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
     version: "1.0",
     credit: "closing",
@@ -101,7 +102,7 @@ const testMulmoScript = {
       },
     },
   ],
-};
+});
 
 const getContext = () => {
   const fileDirs = getFileObject({ file: "hello.yaml" });
@@ -132,24 +133,7 @@ const getContext = () => {
         },
       },
     ],
-    sessionState: {
-      inSession: {
-        audio: false,
-        image: false,
-        video: false,
-        multiLingual: false,
-        caption: false,
-        pdf: false,
-      },
-      inBeatSession: {
-        audio: {},
-        image: {},
-        movie: {},
-        multiLingual: {},
-        caption: {},
-        html: {},
-      },
-    },
+    sessionState: initSessionState(),
     presentationStyle: studio.script,
   };
   return context;
@@ -158,11 +142,6 @@ const getContext = () => {
 test("test beat images", async () => {
   // const fileDirs = getFileObject({ file: "hello.yaml", basedir: __dirname });
   const context = getContext();
-  await generateBeatAudio(0, context, {
-    settings: {
-      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
-    },
-    langs: ["fr", "de"],
-  });
+  await generateBeatAudio(0, context, { langs: ["fr", "de"] });
   // console.log(listLocalizedAudioPaths(context, "de"));
 });

--- a/test/actions/run_translate.ts
+++ b/test/actions/run_translate.ts
@@ -2,7 +2,9 @@ import test from "node:test";
 // import assert from "node:assert";
 
 import { getFileObject } from "../../src/cli/helpers.js";
-import { createStudioData, getMultiLingual } from "../../src/utils/context.js";
+import { createStudioData, getMultiLingual, initSessionState } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
+import { multiLingualObjectToArray } from "../../src/utils/utils.js";
 import { translateBeat, translate } from "../../src/actions/translate.js";
 
 import path from "path";
@@ -10,7 +12,7 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const testMulmoScript = {
+const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
     version: "1.0",
     credit: "closing",
@@ -100,7 +102,7 @@ const testMulmoScript = {
       },
     },
   ],
-};
+});
 
 const getContext = () => {
   const fileDirs = getFileObject({ file: "hello.yaml" });
@@ -108,28 +110,12 @@ const getContext = () => {
   const studio = createStudioData(testMulmoScript, "hello");
   const multiLingual = getMultiLingual("", studio.beats);
   const context = {
-    multiLingual,
+    multiLingual: multiLingualObjectToArray(multiLingual, studio.beats),
     studio,
     fileDirs,
     force: false,
-    sessionState: {
-      inSession: {
-        audio: false,
-        image: false,
-        video: false,
-        multiLingual: false,
-        caption: false,
-        pdf: false,
-      },
-      inBeatSession: {
-        audio: {},
-        image: {},
-        movie: {},
-        multiLingual: {},
-        caption: {},
-        html: {},
-      },
-    },
+    lang: studio.script.lang,
+    sessionState: initSessionState(),
     presentationStyle: studio.script,
   };
   return context;
@@ -147,7 +133,7 @@ test("test beat translate", async () => {
 
 test("test beat translate - fresh translation", async () => {
   const context = getContext();
-  context.multiLingual["__index__1"].multiLingualTexts = {
+  context.multiLingual[1].multiLingualTexts = {
     fr: {
       lang: "fr",
       text: "## Original Language\nen\n## Language\nfr\n## Target\nCeci est un tableau au format markdown.",

--- a/test/actions/test_audio_mix.ts
+++ b/test/actions/test_audio_mix.ts
@@ -55,7 +55,7 @@ test("isExplicitMixMode: returns false when ducking is set but suppressSpeech is
 
 test("isExplicitMixMode: returns true when only beat-level movieVolume is set", () => {
   const context = createContextWithAudioParams();
-  context.studio.script.beats = [{ speaker: "Presenter", audioParams: { movieVolume: 0.5 } }];
+  context.studio.script.beats = [{ text: "", speaker: "Presenter", audioParams: { movieVolume: 0.5 } }];
   assert.strictEqual(isExplicitMixMode(context), true);
 });
 
@@ -108,7 +108,7 @@ test("mixAudiosFromMovieBeats: explicit mode - uses normalize=0 and alimiter", (
 
 test("mixAudiosFromMovieBeats: explicit mode - beat-level movieVolume triggers normalize=0", () => {
   const context = createContextWithAudioParams();
-  context.studio.script.beats = [{ speaker: "Presenter", audioParams: { movieVolume: 0.5 } }];
+  context.studio.script.beats = [{ text: "", speaker: "Presenter", audioParams: { movieVolume: 0.5 } }];
   const ffmpegContext = FfmpegContextInit();
   mixAudiosFromMovieBeats(ffmpegContext, "0:a", ["a1", "a2"], context);
 

--- a/test/actions/test_create_video.ts
+++ b/test/actions/test_create_video.ts
@@ -5,6 +5,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
 import { createVideo } from "../../src/actions/movie.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
 import type { MulmoStudioContext, MulmoScript } from "../../src/types/index.js";
 
 // Helper function to create a minimal context from a script
@@ -59,7 +60,7 @@ test("test createVideo with fsd_demo.json in testMode", async () => {
 
 test("test createVideo filterComplex structure", async () => {
   // Create a minimal script with 2 beats
-  const script: MulmoScript = {
+  const script = MulmoScriptMethods.validate({
     $mulmocast: { version: "1.1" },
     lang: "en",
     title: "Test Video",
@@ -81,7 +82,7 @@ test("test createVideo filterComplex structure", async () => {
         },
       },
     ],
-  };
+  });
 
   const context = createContextFromScript(script);
 

--- a/test/actions/test_images.ts
+++ b/test/actions/test_images.ts
@@ -3,7 +3,9 @@ import test from "node:test";
 import { GraphAILogger } from "graphai";
 
 import { getFileObject } from "../../src/cli/helpers.js";
-import { createStudioData } from "../../src/utils/context.js";
+import { createStudioData, initSessionState } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
+import { multiLingualObjectToArray } from "../../src/utils/utils.js";
 import { images, generateBeatImage } from "../../src/actions/images.js";
 import { addSessionProgressCallback } from "../../src/methods/mulmo_studio_context.js";
 
@@ -12,7 +14,7 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const testMulmoScript = {
+const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
     version: "1.0",
     credit: "closing",
@@ -102,7 +104,7 @@ const testMulmoScript = {
       },
     },
   ],
-};
+});
 
 const getContext = () => {
   const fileDirs = getFileObject({ file: "hello.yaml" });
@@ -111,24 +113,9 @@ const getContext = () => {
     studio,
     fileDirs,
     force: false,
-    sessionState: {
-      inSession: {
-        audio: false,
-        image: false,
-        video: false,
-        multiLingual: false,
-        caption: false,
-        pdf: false,
-      },
-      inBeatSession: {
-        audio: {},
-        image: {},
-        movie: {},
-        multiLingual: {},
-        caption: {},
-        html: {},
-      },
-    },
+    lang: studio.script.lang,
+    multiLingual: multiLingualObjectToArray(undefined, studio.script.beats),
+    sessionState: initSessionState(),
     presentationStyle: studio.script,
   };
   return context;

--- a/test/actions/test_images_error.ts
+++ b/test/actions/test_images_error.ts
@@ -3,7 +3,9 @@ import assert from "node:assert";
 import { GraphAILogger } from "graphai";
 
 import { getFileObject } from "../../src/cli/helpers.js";
-import { createStudioData } from "../../src/utils/context.js";
+import { createStudioData, initSessionState } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
+import { multiLingualObjectToArray } from "../../src/utils/utils.js";
 import { images } from "../../src/actions/images.js";
 import { addSessionProgressCallback } from "../../src/methods/mulmo_studio_context.js";
 
@@ -12,7 +14,7 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const testMulmoScript = {
+const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
     version: "1.1",
   },
@@ -63,7 +65,7 @@ const testMulmoScript = {
       },
     },
   ],
-};
+});
 
 const getContext = () => {
   const fileDirs = getFileObject({ file: "hello.yaml" });
@@ -72,24 +74,9 @@ const getContext = () => {
     studio,
     fileDirs,
     force: false,
-    sessionState: {
-      inSession: {
-        audio: false,
-        image: false,
-        video: false,
-        multiLingual: false,
-        caption: false,
-        pdf: false,
-      },
-      inBeatSession: {
-        audio: {},
-        image: {},
-        movie: {},
-        multiLingual: {},
-        caption: {},
-        html: {},
-      },
-    },
+    lang: studio.script.lang,
+    multiLingual: multiLingualObjectToArray(undefined, studio.script.beats),
+    sessionState: initSessionState(),
     presentationStyle: studio.script,
   };
   return context;

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -2,7 +2,8 @@ import test from "node:test";
 // import assert from "node:assert";
 
 import { getFileObject } from "../../src/cli/helpers.js";
-import { createStudioData } from "../../src/utils/context.js";
+import { createStudioData, initSessionState } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
 import { audio, images, movie } from "../../src/actions/index.js";
 
 import path from "path";
@@ -18,7 +19,7 @@ const audioData = {
   },
 };
 
-const mulmoScript = {
+const mulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
     version: "1.0",
     credit: "closing",
@@ -112,7 +113,7 @@ const mulmoScript = {
       },
     },
   ],
-};
+});
 
 test("test images and movie", async () => {
   // const fileDirs = getFileObject({ file: "hello.yaml", basedir: __dirname });
@@ -124,24 +125,7 @@ test("test images and movie", async () => {
     fileDirs,
     force: false,
     lang: "en",
-    sessionState: {
-      inSession: {
-        audio: false,
-        image: false,
-        video: false,
-        multiLingual: false,
-        caption: false,
-        pdf: false,
-      },
-      inBeatSession: {
-        audio: {},
-        image: {},
-        movie: {},
-        multiLingual: {},
-        caption: {},
-        html: {},
-      },
-    },
+    sessionState: initSessionState(),
     presentationStyle: studio.script,
     multiLingual: [...Array(studio.script.beats.length)].map(() => ({ multiLingualTexts: {} })),
   };

--- a/test/actions/test_viewer.ts
+++ b/test/actions/test_viewer.ts
@@ -6,6 +6,7 @@ import path from "path";
 
 import { viewer, viewerFilePath } from "../../src/actions/viewer.js";
 import { createStudioData } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
 
 // Minimal valid 1x1 transparent PNG (base64). Self-contained so the test does
@@ -19,7 +20,7 @@ const writeSamplePng = (dir: string, name: string): string => {
 };
 
 const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): MulmoStudioContext => {
-  const mulmoScript = {
+  const mulmoScript = MulmoScriptMethods.validate({
     $mulmocast: { version: "1.0", credit: "closing" },
     title: "Viewer Test Deck",
     description: "",
@@ -27,7 +28,7 @@ const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): M
       text: `Caption ${i + 1}`,
       image: { type: "textSlide" as const, slide: { title: `Slide ${i + 1}` } },
     })),
-  };
+  });
   const studio = createStudioData(mulmoScript, "viewer_test");
   // Inject pre-rendered image paths for each beat so the viewer can pick them up.
   beatImageFiles.forEach((file, i) => {
@@ -171,7 +172,7 @@ test("viewer prefers htmlImageFile over imageFile (matches pdf.ts / movie.ts)", 
 test("viewer escapes HTML in title and caption", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
   try {
-    const mulmoScript = {
+    const mulmoScript = MulmoScriptMethods.validate({
       $mulmocast: { version: "1.0", credit: "closing" },
       title: "<script>alert(1)</script>",
       description: "",
@@ -181,7 +182,7 @@ test("viewer escapes HTML in title and caption", async () => {
           image: { type: "textSlide" as const, slide: { title: "T" } },
         },
       ],
-    };
+    });
     const studio = createStudioData(mulmoScript, "viewer_test");
     studio.beats[0].imageFile = writeSamplePng(tmpDir, "sample.png");
     const context = {


### PR DESCRIPTION
## Summary

`#1551` の残りのうち、**`test/actions/*` が部分的な MulmoScript / MulmoStudioContext を組んでいる**分（16件）です。

やったことは3つで、いずれも「テストが本番と同じ作り方をする」形に寄せたものです。

**1. `sessionState` の手書きコピー（5ファイル）を `initSessionState()` に**

`src/utils/context.ts` の `initSessionState` を `export` しました（本番側の変更はこの1語だけ）。テスト側に6コピーあった `inSession` / `inBeatSession` のリテラルは、本番が `markdown` / `html` / `viewer` / `imageReference` / `soundEffect` / `lipSync` を足した時に**追随せず古いまま**になっていたもので、テスト用に9個目のコピーを作るのではなく本番の初期化関数を呼ぶようにしました。

**2. スクリプトのリテラルを `MulmoScriptMethods.validate()` 経由に**

`createStudioData(script, …)` の引数型は `MulmoScript`（= 検証済み）ですが、テストは `$mulmocast.version: "1.0"` の生スクリプトを渡していました。**`createStudioData` は中で `validate()` を呼ぶので、渡すのは生で正しい**（本番も生のファイル内容を渡します）。バージョンを 1.1 に書き換えて 1.0 の移行パスを消すのではなく、本番と同じ `validate()` をテスト側で先に通すことで、**1.0 → 1.1 の移行はそのまま通したまま**型が合うようにしました。`validate` は 1.1 に対して冪等なので、`createStudioData` 内の2回目の呼び出しで結果は変わりません。

**3. `lang` / `multiLingual` の欠落**

`MulmoStudioContext` の必須2フィールドです。本番と同じく `lang` は `studio.script.lang`、`multiLingual` は `multiLingualObjectToArray(…)` で作っています。

ついでに出てきた2件:

- `run_translate.ts` は `multiLingual` に **`getMultiLingual()` の返り値（Record）をそのまま**入れていました。`MulmoStudioContext.multiLingual` は配列で、本番は `multiLingualObjectToArray()` で変換してから入れます。`generateBeatAudio` / `translateBeat` は `context.multiLingual[index]` と**添字**で引くので、Record を渡していたこのファイルは実際には毎回 `undefined` を見ていたことになります。本番と同じ変換を通し、テスト内の `context.multiLingual["__index__1"]` は `context.multiLingual[1]` にしました
- `run_audio.ts` の `settings: { OPENAI_API_KEY: process.env.OPENAI_API_KEY }` は `string | undefined` で型が合いませんでした。`settings` の行き先は `settings2GraphAIConfig(settings, process.env)` だけで、`settings?.[key] ?? env?.[key]` と **`process.env` へフォールバックする**ので、この受け渡しは何も足していません。渡すのをやめました

`typecheck:test`: **45 → 27**（`#1559` / `#1560` と合わせると 18）

## Items to Confirm / Review

- **`initSessionState` の `export`（本番側の唯一の変更）**。テスト側に fixture を置く手もありますが、それは7個目のコピーになり、また同じように古くなります。本番の初期化関数を呼ぶ方が drift しません
- **`run_translate.ts` の Record → 配列は、型合わせではなく挙動の修正です。** `run_*.ts` は `ci_test` の glob（`test/*/test_*.ts`）に入っておらず API キーが要る手動スクリプトなので、**手元では実行して確認できていません**。ここだけは目で見てもらえると助かります
- **`test_audio_mix.ts` は `text: ""` を足しました。** `isExplicitMixMode` / `mixAudiosFromMovieBeats` はどちらも `beat.text` を読まないことを確認した上で、「audioParams しか持たない beat」というテストの意図を保つために空文字にしています（`createMockBeat` を使うと `"Test beat text"` が入り、意図がぼやけます）
- **`test_create_video.ts` の `as MulmoStudioContext` は残しています。** `createContextFromScript` は意図的に最小の context を組んでおり、`as` を外すのは `#1557` と同じ「調査」になります。goldens が `scale=w=…` を固定しているので、別 PR で扱う方が安全という判断です

## 検証

- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `npx tsc --noEmit -p tsconfig.test.json` — 45 → 27
- 全テスト（1166本）— **pass 1162 / fail 0 / skip 4**（変更前と同一）
- `test_images` / `test_images_error` / `test_movie` / `test_create_video` は個別にも実行（62本 pass）

## User Prompt

> #1551 すすめて

（`#1551`「test/ の型エラー 279 件」バックログの継続。`#1559` `#1560` に続く3本目。）
