### PR TITLE
test: close out the last of the test/ type errors

### DIFF
--- a/test/agents/run_crawler.ts
+++ b/test/agents/run_crawler.ts
@@ -3,9 +3,14 @@ import { GraphAILogger } from "graphai";
 import puppeteerCrawlerAgentInfo from "../../src/agents/puppeteer_crawler_agent.js";
 
 import test from "node:test";
+import { agentCallContext } from "../fixtures.js";
 
 test("puppeteerCrawlerAgent", async () => {
-  const result = await puppeteerCrawlerAgentInfo.agent({ namedInputs: { url: "https://www3.nhk.or.jp/news/html/20250829/k10014907131000.html" } });
+  const result = await puppeteerCrawlerAgentInfo.agent({
+    ...agentCallContext,
+    params: {},
+    namedInputs: { url: "https://www3.nhk.or.jp/news/html/20250829/k10014907131000.html" },
+  });
 
   GraphAILogger.info(result);
 });

--- a/test/agents/test_image_genai_agent.ts
+++ b/test/agents/test_image_genai_agent.ts
@@ -1,19 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import type { GraphAI } from "graphai";
 import { imageGenAIAgent, buildDeprecatedGoogleImageModelMessage } from "../../src/agents/image_genai_agent.js";
+import { agentCallContext } from "../fixtures.js";
 
-const baseParams = {
-  config: { apiKey: "fake-key-not-used" },
-  filterParams: {},
-  debugInfo: {
-    verbose: false,
-    nodeId: "",
-    state: "",
-    retry: 0,
-    subGraphs: new Map<string, GraphAI>(),
-  },
-};
+const baseParams = { ...agentCallContext, config: { apiKey: "fake-key-not-used" } };
 
 const canvasSize = { width: 1024, height: 1024 };
 

--- a/test/agents/test_image_openai_agent.ts
+++ b/test/agents/test_image_openai_agent.ts
@@ -1,19 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import type { GraphAI } from "graphai";
 import { imageOpenaiAgent, buildDeprecatedModelMessage } from "../../src/agents/image_openai_agent.js";
+import { agentCallContext } from "../fixtures.js";
 
-const baseParams = {
-  config: { apiKey: "fake-key-not-used" },
-  filterParams: {},
-  debugInfo: {
-    verbose: false,
-    nodeId: "",
-    state: "",
-    retry: 0,
-    subGraphs: new Map<string, GraphAI>(),
-  },
-};
+const baseParams = { ...agentCallContext, config: { apiKey: "fake-key-not-used" } };
 
 const canvasSize = { width: 1024, height: 1024 };
 

--- a/test/agents/test_movie_replicate_agent.ts
+++ b/test/agents/test_movie_replicate_agent.ts
@@ -1,19 +1,9 @@
 import test from "node:test";
 import assert from "node:assert";
-import type { GraphAI } from "graphai";
 import { movieReplicateAgent } from "../../src/agents/movie_replicate_agent.js";
+import { agentCallContext } from "../fixtures.js";
 
-const baseParams = {
-  config: { apiKey: "fake-key-not-used" },
-  filterParams: {},
-  debugInfo: {
-    verbose: false,
-    nodeId: "",
-    state: "",
-    retry: 0,
-    subGraphs: new Map<string, GraphAI>(),
-  },
-};
+const baseParams = { ...agentCallContext, config: { apiKey: "fake-key-not-used" } };
 
 const canvasSize = { width: 1024, height: 1024 };
 

--- a/test/agents/test_validate_schema_agent.ts
+++ b/test/agents/test_validate_schema_agent.ts
@@ -1,8 +1,8 @@
 import validateSchemaAgent from "../../src/agents/validate_schema_agent.js";
 import test from "node:test";
 import assert from "node:assert";
-import type { GraphAI } from "graphai";
 import { mulmoScriptSchema } from "../../src/types/schema.js";
+import { agentCallContext } from "../fixtures.js";
 
 const validMulmoScriptJson = JSON.stringify({
   $mulmocast: {
@@ -63,17 +63,7 @@ const invalidMulmoScriptJson = JSON.stringify({
   beats: [],
 });
 
-const baseParams = {
-  params: {},
-  debugInfo: {
-    verbose: false,
-    nodeId: "",
-    state: "",
-    retry: 0,
-    subGraphs: new Map<string, GraphAI>(),
-  },
-  filterParams: {},
-};
+const baseParams = { ...agentCallContext, params: {} };
 
 test("validateSchemaAgent with valid MulmoScript", async () => {
   const result = await validateSchemaAgent.agent({

--- a/test/beat_html/test_html_tailwind.ts
+++ b/test/beat_html/test_html_tailwind.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert";
 import { htmlTailwindToHtml } from "../../src/utils/beat_html/html_tailwind.js";
+import { imageProcessorParams } from "../fixtures.js";
+import { htmlTailwindMarkup } from "../../src/utils/image_plugins/html_tailwind_markup.js";
 import { requireImagePlugin } from "../image_plugins/utils.js";
 import { mulmoHtmlTailwindMediaSchema } from "../../src/types/schema.js";
 
@@ -54,9 +56,10 @@ test("and refused again at render time, for a caller that did not parse", () => 
 // path the pipeline reaches — but the guard decides what happens when someone bypasses it,
 // and before this PR `[null]` threw and `["str"]` rendered garbage from a string.
 test("elements that are not an array of objects fall back to html", () => {
-  const unparsed = (elements: unknown) => htmlTailwindToHtml({ type: "html_tailwind", elements, html: "<div>fallback</div>" });
+  // The guard is in htmlTailwindMarkup, whose parameter already declares `elements` as unknown.
+  const unparsed = (elements: unknown) => htmlTailwindMarkup({ elements, html: "<div>fallback</div>" });
   ["not-an-array", 7, {}, null, [null], ["str"], [undefined]].forEach((elements) => {
-    assert.strictEqual(unparsed(elements)?.html, "<div>fallback</div>", `${JSON.stringify(elements)} must fall back`);
+    assert.strictEqual(unparsed(elements), "<div>fallback</div>", `${JSON.stringify(elements)} must fall back`);
   });
 });
 
@@ -65,6 +68,6 @@ test("the fragment is the same markup the document dump produces", async () => {
   const plugin = requireImagePlugin("html_tailwind");
   for (const over of [{ html: "<div>a</div>" }, { html: ["a", "b"] }, { elements: [{ id: "p", text: "x" }] }]) {
     const image = media(over);
-    assert.strictEqual(htmlTailwindToHtml(image)!.html, await plugin.html!({ beat: { image } }), JSON.stringify(over));
+    assert.strictEqual(htmlTailwindToHtml(image)!.html, await plugin.html!(imageProcessorParams({ beat: { text: "", image } })), JSON.stringify(over));
   }
 });

--- a/test/beat_html/test_index.ts
+++ b/test/beat_html/test_index.ts
@@ -1,20 +1,21 @@
 import test from "node:test";
 import assert from "node:assert";
 import { beatToHtml } from "../../src/utils/beat_html/index.js";
+import type { MulmoBeat } from "../../src/types/index.js";
 
 // The contract tells callers to pass something derived from the beat's index — `beat-3`,
 // not `3`, since an id must not start with a digit — or a sanitized id. A beat's own `id`
 // comes from the script and is unrestricted, so the boundary refuses rather than guessing a
 // repair — a guess can collapse two beats onto one element id, which is the bug idPrefix exists to prevent.
 test("beatToHtml refuses an idPrefix outside the permitted set", () => {
-  const beat = { image: { type: "markdown", markdown: "# T" } };
+  const beat: MulmoBeat = { text: "", image: { type: "markdown", markdown: "# T" } };
   ['" onload="pwn()" x=', "beat 1", "第1章", "", "0", "3"].forEach((idPrefix) => {
     assert.throws(() => beatToHtml(beat, { idPrefix }), /element id must match/, `${JSON.stringify(idPrefix)} must be rejected`);
   });
 });
 
 test("beatToHtml accepts the shapes the contract recommends", () => {
-  const beat = { image: { type: "markdown", markdown: "# T" } };
+  const beat: MulmoBeat = { text: "", image: { type: "markdown", markdown: "# T" } };
   ["beat-0", "beat-3", "beat_3", "b3"].forEach((idPrefix) => {
     assert.ok(beatToHtml(beat, { idPrefix }), `${idPrefix} must be accepted`);
   });

--- a/test/beat_html/test_media.ts
+++ b/test/beat_html/test_media.ts
@@ -26,7 +26,7 @@ test("a path is emitted for the host to resolve, a base64 source renders nothing
 });
 
 test("neither needs a runtime from the host", () => {
-  assert.strictEqual(imageToHtml(image(URL_SRC), "").requires, undefined);
+  assert.strictEqual(imageToHtml(image(URL_SRC), "")!.requires, undefined);
   assert.strictEqual(movieToHtml(movie({ kind: "url", url: "https://e.com/a.mp4" }))!.requires, undefined);
 });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,3 +1,4 @@
+import type { GraphAI } from "graphai";
 import type { ImageProcessorParams, MulmoBeat, MulmoPresentationStyle, MulmoStudioContext } from "../src/types/index.js";
 import { mulmoPresentationStyleSchema } from "../src/types/schema.js";
 import type { SlideTheme } from "@mulmocast/deck";
@@ -58,3 +59,20 @@ export const contextWithSlideTheme = (theme?: SlideTheme): MulmoStudioContext =>
  */
 export const presentationStyleFixture = (partial: Record<string, unknown> = {}): MulmoPresentationStyle =>
   mulmoPresentationStyleSchema.parse({ $mulmocast: { version: "1.1" }, ...partial });
+
+/**
+ * The GraphAI plumbing an `AgentFunctionContext` carries and no mulmo agent reads.
+ *
+ * The graph fills it in at runtime, so a test that calls an agent function directly has to
+ * supply it. Each caller adds its own `config` / `params`, which are the parts a test varies.
+ */
+export const agentCallContext = {
+  filterParams: {},
+  debugInfo: {
+    verbose: false,
+    nodeId: "",
+    state: "",
+    retry: 0,
+    subGraphs: new Map<string, GraphAI>(),
+  },
+};

--- a/test/methods/test_studio_context_duration.ts
+++ b/test/methods/test_studio_context_duration.ts
@@ -88,7 +88,7 @@ test("test isMovieBeat recognizes every movie source", async () => {
   const context = movieBeatContext();
   assert.equal(MulmoStudioContextMethods.isMovieBeat(context, { lipSyncFile: "a.mp4" }, shot("A")), true);
   assert.equal(MulmoStudioContextMethods.isMovieBeat(context, { movieFile: "a.mp4" }, shot("A")), true);
-  assert.equal(MulmoStudioContextMethods.isMovieBeat(context, {}, { image: { type: "movie", source: { kind: "path", path: "a.mp4" } } }), true);
+  assert.equal(MulmoStudioContextMethods.isMovieBeat(context, {}, { text: "", image: { type: "movie", source: { kind: "path", path: "a.mp4" } } }), true);
 });
 
 test("test isMovieBeat treats a still beat as a still", async () => {

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -3,6 +3,7 @@ import assert from "node:assert";
 
 import { getFileObject } from "../../src/cli/helpers.js";
 import { createStudioData } from "../../src/utils/context.js";
+import { MulmoScriptMethods } from "../../src/methods/index.js";
 import { MulmoStudioContextMethods } from "../../src/methods/mulmo_studio_context.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
 
@@ -85,14 +86,14 @@ test("test getImageProjectDirPath without grouped", async () => {
 
 test("test createStudioData", async () => {
   const studio = createStudioData(
-    {
+    MulmoScriptMethods.validate({
       $mulmocast: {
         version: "1.1",
         credit: "closing",
       },
       lang: "en",
       beats: [{ text: "hello" }],
-    },
+    }),
     "",
   );
   // console.log(JSON.stringify(ret));
@@ -141,7 +142,7 @@ test("test createStudioData", async () => {
 
 test("test createStudioData", async () => {
   const studio = createStudioData(
-    {
+    MulmoScriptMethods.validate({
       $mulmocast: {
         version: "1.1",
         credit: "closing",
@@ -149,7 +150,7 @@ test("test createStudioData", async () => {
       lang: "en",
       speechParams: { speakers: { Test: { displayName: { en: "Test" }, voiceId: "shimmer", provider: "openai" } } },
       beats: [{ text: "hello" }],
-    },
+    }),
     "",
   );
   // console.log(JSON.stringify(ret));

--- a/test/utils/test_generate_audio.ts
+++ b/test/utils/test_generate_audio.ts
@@ -6,6 +6,7 @@ import { currentMulmoScriptVersion } from "../../src/types/const.js";
 import { movieGenAIAgent } from "../../src/agents/movie_genai_agent.js";
 import { movieReplicateAgent } from "../../src/agents/movie_replicate_agent.js";
 import { apiErrorType, hasCause, imageAction, unsupportedModelTarget } from "../../src/utils/error_cause.js";
+import { agentCallContext } from "../fixtures.js";
 
 // Test: generateAudio schema validation
 test("generateAudio: true is valid in movieParams", () => {
@@ -52,7 +53,7 @@ test("generateAudio: string is invalid", () => {
 });
 
 // Test: provider2agent audio metadata (table-driven)
-const replicateAudioTests: { model: string; mode: string; param?: string }[] = [
+const replicateAudioTests: { model: `${string}/${string}`; mode: string; param?: string }[] = [
   { model: "kwaivgi/kling-v3-video", mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
   { model: "kwaivgi/kling-v3-omni-video", mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
   { model: "google/veo-3", mode: AUDIO_MODE_OPTIONAL, param: "generate_audio" },
@@ -92,6 +93,7 @@ test("movieGenAIAgent rejects generateAudio=true for never-audio model", async (
   await assert.rejects(
     () =>
       movieGenAIAgent({
+        ...agentCallContext,
         namedInputs: {
           prompt: "A calm ocean at sunset",
           movieFile: "output/test/test_genai_audio.mp4",
@@ -121,6 +123,7 @@ test("movieReplicateAgent rejects generateAudio=true for never-audio model", asy
   await assert.rejects(
     () =>
       movieReplicateAgent({
+        ...agentCallContext,
         namedInputs: {
           prompt: "A calm ocean at sunset",
           movieFile: "output/test/test_replicate_audio.mp4",

--- a/test/utils/test_localized_text.ts
+++ b/test/utils/test_localized_text.ts
@@ -9,16 +9,16 @@ test("test localizedText 1", async () => {
 });
 
 test("test localizedText 2", async () => {
-  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー" } } });
+  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー", lang: "ja", cacheKey: "" } } });
   assert.equal(result, "hello");
 });
 
 test("test localizedText 3", async () => {
-  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー" } } }, "ja");
+  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー", lang: "ja", cacheKey: "" } } }, "ja");
   assert.equal(result, "ハロー");
 });
 
 test("test localizedText 4", async () => {
-  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー" } } }, "ja", "ja");
+  const result = localizedText({ text: "hello" }, { multiLingualTexts: { ja: { text: "ハロー", lang: "ja", cacheKey: "" } } }, "ja", "ja");
   assert.equal(result, "hello");
 });

--- a/test/utils/test_prompt.ts
+++ b/test/utils/test_prompt.ts
@@ -4,7 +4,7 @@ import assert from "node:assert";
 import { imagePrompt } from "../../src/utils/prompt.js";
 
 test("test imagePrompt", async () => {
-  const res = imagePrompt({ imagePrompt: "Blue sky in Hawaii" });
+  const res = imagePrompt({ text: "", imagePrompt: "Blue sky in Hawaii" });
   assert.equal(res, "Blue sky in Hawaii\n");
 
   const res2 = imagePrompt({ text: "Blue sky in Hawaii" });

--- a/test/utils/test_validate_styles.ts
+++ b/test/utils/test_validate_styles.ts
@@ -18,7 +18,7 @@ test("test presentation styles", async () => {
       const jsonData = JSON.parse(content);
       mulmoPresentationStyleSchema.parse(jsonData);
     } catch (error) {
-      assert.fail("Invalid style file: " + file + " " + error.message);
+      assert.fail("Invalid style file: " + file + " " + (error instanceof Error ? error.message : String(error)));
     }
   });
 });

--- a/test/zod/test_markdown_schema.ts
+++ b/test/zod/test_markdown_schema.ts
@@ -668,7 +668,9 @@ test("mulmoMarkdownMediaSchema: valid with full layout options", () => {
     style: "presentation",
   });
   assert(data.success);
-  assert.strictEqual(data.data?.markdown.header, "Presentation Title");
+  const { markdown } = data.data;
+  assert.ok(typeof markdown === "object" && !Array.isArray(markdown), "the layout-object form, not a bare string");
+  assert.strictEqual(markdown.header, "Presentation Title");
 });
 
 test("mulmoMarkdownMediaSchema: valid 2x2 with header and sidebar-left", () => {


### PR DESCRIPTION
## Summary

`#1551` の**残り全部**（`test/actions` 以外の18件）です。これで `#1559` `#1560` `#1561` と合わせて **279 → 0** になります。

内訳と、それぞれの根拠:

| 件数 | 直したもの | 根拠 |
|---:|---|---|
| 3 | `localizedText` の `multiLingualTexts` に `lang` / `cacheKey` が無い | スキーマの必須項目。`localizedText` は `.text` しか読まないので挙動は不変 |
| 3 | `text` の無い beat（`imagePrompt` / `beatToHtml` / `isMovieBeat`） | 3つとも `beat.text` を読まないことを確認した上で `text: ""` |
| 2 | `test_cli` が部分的な script を `createStudioData` に渡している | `createStudioData` は内部で `validate()` するので渡すのは生スクリプト。`#1561` と同じく `MulmoScriptMethods.validate()` を先に通す形に。goldens は無変更 |
| 4 | agent を直接呼ぶときの `debugInfo` / `filterParams` 欠落 | 下記 |
| 1 | replicate モデル表が `model: string` | `modelParams` のキーは `owner/name`。その template literal 型にすると index エラーが消える |
| 1 | `unknown` な error から `.message` | `error instanceof Error` で絞る |
| 1 | markdown レイアウトの union に `.header` | `typeof === "object" && !Array.isArray` で絞ってから読む |
| 1 | `imageToHtml(...).requires` | 前後の行と同じく non-null |
| 2 | `htmlTailwindToHtml` に非配列を渡している | 下記 |

**agent 呼び出しの GraphAI 配管（`debugInfo` / `filterParams`）**

`AgentFunctionContext` が要求し、mulmo のどの agent も読まないもので、**4つのテストファイルに同一のリテラルがコピーされていました**。これを `test/fixtures.ts` の `agentCallContext` に出して、今回必要になった2ファイル（`test_generate_audio` / `run_crawler`）が5個目・6個目のコピーにならないようにしています。`config` / `params` はテストごとに意味が違うので各ファイルに残しています。

**「zod を通らなかった呼び出し元」のテストの置き場所**

`elements that are not an array of objects fall back to html` は `"not-an-array"` / `7` / `null` を `htmlTailwindToHtml` に渡していましたが、この関数の引数は**パース済みのスキーマ型**です。ガード本体は `htmlTailwindMarkup` にあり、**そちらの引数は既に `elements?: unknown` と宣言している**ので、敵性入力はそちらへ移しました。`as` を足さずに済み、テストの意図（ガードは何をするか）はそのままです。

`typecheck:test`: **45 → 27**（このブランチ単体。残り27件は `#1559` の3件・`#1560` の6件・`#1561` の18件で、**4本すべてが入ると 0**）

## Items to Confirm / Review

- **`agentCallContext` のために既存の4ファイル（型エラーが無いファイル）も触っています。** 値は4箇所とも同一なので挙動は変わりませんが、「エラーの無いファイルを触るな」という方針であれば分けます
- **`htmlTailwindToHtml` → `htmlTailwindMarkup` への付け替えで、`html === "" ? undefined : { html }` のラップ部分はこの7ケースについては通らなくなります。** ラップ自体は同ファイルの他のテストが通しています
- **`text: ""` を足した3箇所**は、いずれも対象の関数が `beat.text` を読まないことを実装で確認しています（`imagePrompt` は `beat.imagePrompt || …` の `||` で短絡、`beatToHtml` / `isMovieBeat` は `image` しか見ません）
- **4本の順番**: `#1559` → `#1560` → `#1561` → 本 PR の順で作りましたが、**触るファイルが重ならないので順不同で merge できます**

## 次にやること（この PR の範囲外）

- 4本が入ったら `#1552` の warn job をブロッキングに切り替えるか、`typecheck:test` を `lint_test` に統合する（`#1551` の最後の項目）
- `test/actions/test_create_video.ts` の `as MulmoStudioContext`、`test/utils/test_cli.ts` の `as unknown as MulmoStudioContext` など、**残っている cast の回収**。`#1557` と同じで整形ではなく調査になるので別 PR

## 検証

- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `npx tsc --noEmit -p tsconfig.test.json` — 45 → 27（本ブランチ単体）
- 全テスト（1166本）— **pass 1162 / fail 0 / skip 4**（変更前と同一）

## User Prompt

> #1551 すすめて

（`#1551`「test/ の型エラー 279 件」バックログの継続。`#1559` `#1560` `#1561` に続く4本目で、これで残り0件。）
