### PR TITLE
test: name the script version through currentMulmoScriptVersion

### DIFF
--- a/test/actions/run_audio.ts
+++ b/test/actions/run_audio.ts
@@ -8,12 +8,13 @@ import { generateBeatAudio } from "../../src/actions/audio.js";
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
-    version: "1.0",
+    version: currentMulmoScriptVersion,
     credit: "closing",
   },
   title: "MASAI: A Modular Future for Software Engineering AI",

--- a/test/actions/run_translate.ts
+++ b/test/actions/run_translate.ts
@@ -9,12 +9,13 @@ import { translateBeat, translate } from "../../src/actions/translate.js";
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
-    version: "1.0",
+    version: currentMulmoScriptVersion,
     credit: "closing",
   },
   title: "MASAI: A Modular Future for Software Engineering AI",

--- a/test/actions/test_create_video.ts
+++ b/test/actions/test_create_video.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "url";
 import { createVideo } from "../../src/actions/movie.js";
 import { MulmoScriptMethods } from "../../src/methods/index.js";
 import type { MulmoStudioContext, MulmoScript } from "../../src/types/index.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 // Helper function to create a minimal context from a script
 const createContextFromScript = (script: MulmoScript): MulmoStudioContext => {
@@ -61,7 +62,7 @@ test("test createVideo with fsd_demo.json in testMode", async () => {
 test("test createVideo filterComplex structure", async () => {
   // Create a minimal script with 2 beats
   const script = MulmoScriptMethods.validate({
-    $mulmocast: { version: "1.1" },
+    $mulmocast: { version: currentMulmoScriptVersion },
     lang: "en",
     title: "Test Video",
     beats: [
@@ -1084,7 +1085,7 @@ test("test createVideo with test_video_filters.json", async () => {
 // used to reference an undefined filtergraph pad ([undefined_last]) and crash ffmpeg.
 const createVoiceOverTransitionScript = (transitionType: string): MulmoScript =>
   ({
-    $mulmocast: { version: "1.1" },
+    $mulmocast: { version: currentMulmoScriptVersion },
     lang: "en",
     title: "Voice over with transition",
     beats: [
@@ -1155,7 +1156,7 @@ test("test createVideo with voice_over beat before a slidein transition", async 
 // video ends up shorter than the audio and everything after the first voice_over drifts.
 test("test createVideo covers the voice_over group when the movie is shorter than its audio", async () => {
   const script = {
-    $mulmocast: { version: "1.1" },
+    $mulmocast: { version: currentMulmoScriptVersion },
     lang: "en",
     title: "Voice over longer than the movie",
     beats: [

--- a/test/actions/test_images.ts
+++ b/test/actions/test_images.ts
@@ -11,12 +11,13 @@ import { addSessionProgressCallback } from "../../src/methods/mulmo_studio_conte
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
-    version: "1.0",
+    version: currentMulmoScriptVersion,
     credit: "closing",
   },
   title: "MASAI: A Modular Future for Software Engineering AI",

--- a/test/actions/test_images_error.ts
+++ b/test/actions/test_images_error.ts
@@ -11,12 +11,13 @@ import { addSessionProgressCallback } from "../../src/methods/mulmo_studio_conte
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const testMulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
-    version: "1.1",
+    version: currentMulmoScriptVersion,
   },
   canvasSize: {
     width: 1280,

--- a/test/actions/test_movie.ts
+++ b/test/actions/test_movie.ts
@@ -8,6 +8,7 @@ import { audio, images, movie } from "../../src/actions/index.js";
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -21,7 +22,7 @@ const audioData = {
 
 const mulmoScript = MulmoScriptMethods.validate({
   $mulmocast: {
-    version: "1.0",
+    version: currentMulmoScriptVersion,
     credit: "closing",
   },
   title: "MASAI: A Modular Future for Software Engineering AI",

--- a/test/actions/test_viewer.ts
+++ b/test/actions/test_viewer.ts
@@ -8,6 +8,7 @@ import { viewer, viewerFilePath } from "../../src/actions/viewer.js";
 import { createStudioData } from "../../src/utils/context.js";
 import { MulmoScriptMethods } from "../../src/methods/index.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 // Minimal valid 1x1 transparent PNG (base64). Self-contained so the test does
 // not depend on any image file being checked into the repo.
@@ -21,7 +22,7 @@ const writeSamplePng = (dir: string, name: string): string => {
 
 const buildContext = (tmpDir: string, beatImageFiles: (string | undefined)[]): MulmoStudioContext => {
   const mulmoScript = MulmoScriptMethods.validate({
-    $mulmocast: { version: "1.0", credit: "closing" },
+    $mulmocast: { version: currentMulmoScriptVersion, credit: "closing" },
     title: "Viewer Test Deck",
     description: "",
     beats: beatImageFiles.map((_, i) => ({
@@ -173,7 +174,7 @@ test("viewer escapes HTML in title and caption", async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "viewer-test-"));
   try {
     const mulmoScript = MulmoScriptMethods.validate({
-      $mulmocast: { version: "1.0", credit: "closing" },
+      $mulmocast: { version: currentMulmoScriptVersion, credit: "closing" },
       title: "<script>alert(1)</script>",
       description: "",
       beats: [

--- a/test/actions/utils.ts
+++ b/test/actions/utils.ts
@@ -1,5 +1,6 @@
 import { type MulmoStudioContext, type MulmoBeat } from "../../src/types/index.js";
 import { mulmoScriptSchema, mulmoPresentationStyleSchema } from "../../src/types/schema.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 /**
  * A context shaped like the one the app builds.
@@ -32,7 +33,7 @@ export const createMockContext = (): MulmoStudioContext => ({
     // schema defaults is kept, which is what a real script carries.
     script: {
       ...mulmoScriptSchema.parse({
-        $mulmocast: { version: "1.1" },
+        $mulmocast: { version: currentMulmoScriptVersion },
         title: "Test Script",
         beats: [{ text: "" }],
         lang: "en",
@@ -46,7 +47,7 @@ export const createMockContext = (): MulmoStudioContext => ({
   lang: "en",
   multiLingual: [],
   presentationStyle: mulmoPresentationStyleSchema.parse({
-    $mulmocast: { version: "1.1" },
+    $mulmocast: { version: currentMulmoScriptVersion },
     imageParams: { provider: "openai", model: "gpt-image-1", style: "natural", moderation: "auto" },
   }),
   sessionState: {

--- a/test/agents/test_validate_schema_agent.ts
+++ b/test/agents/test_validate_schema_agent.ts
@@ -3,10 +3,11 @@ import test from "node:test";
 import assert from "node:assert";
 import { mulmoScriptSchema } from "../../src/types/schema.js";
 import { agentCallContext } from "../fixtures.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 const validMulmoScriptJson = JSON.stringify({
   $mulmocast: {
-    version: "1.1",
+    version: currentMulmoScriptVersion,
     credit: "closing",
   },
   title: "Test Script",

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -3,6 +3,7 @@ import type { ImageProcessorParams, MulmoBeat, MulmoPresentationStyle, MulmoStud
 import { mulmoPresentationStyleSchema } from "../src/types/schema.js";
 import type { SlideTheme } from "@mulmocast/deck";
 import { createMockContext } from "./actions/utils.js";
+import { currentMulmoScriptVersion } from "../src/types/const.js";
 
 /**
  * A complete `ImageProcessorParams` around a beat.
@@ -58,7 +59,7 @@ export const contextWithSlideTheme = (theme?: SlideTheme): MulmoStudioContext =>
  * which is not a state production can produce.
  */
 export const presentationStyleFixture = (partial: Record<string, unknown> = {}): MulmoPresentationStyle =>
-  mulmoPresentationStyleSchema.parse({ $mulmocast: { version: "1.1" }, ...partial });
+  mulmoPresentationStyleSchema.parse({ $mulmocast: { version: currentMulmoScriptVersion }, ...partial });
 
 /**
  * The GraphAI plumbing an `AgentFunctionContext` carries and no mulmo agent reads.

--- a/test/utils/test_cli.ts
+++ b/test/utils/test_cli.ts
@@ -9,6 +9,7 @@ import type { MulmoStudioContext } from "../../src/types/index.js";
 
 import path from "path";
 import { fileURLToPath } from "url";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -88,7 +89,7 @@ test("test createStudioData", async () => {
   const studio = createStudioData(
     MulmoScriptMethods.validate({
       $mulmocast: {
-        version: "1.1",
+        version: currentMulmoScriptVersion,
         credit: "closing",
       },
       lang: "en",
@@ -99,7 +100,7 @@ test("test createStudioData", async () => {
   // console.log(JSON.stringify(ret));
   const expect = {
     script: {
-      $mulmocast: { version: "1.1", credit: "closing" },
+      $mulmocast: { version: currentMulmoScriptVersion, credit: "closing" },
       lang: "en",
       canvasSize: { width: 1280, height: 720 },
       speechParams: { speakers: { Presenter: { displayName: { en: "Presenter" }, voiceId: "shimmer", provider: "openai" } } },
@@ -144,7 +145,7 @@ test("test createStudioData", async () => {
   const studio = createStudioData(
     MulmoScriptMethods.validate({
       $mulmocast: {
-        version: "1.1",
+        version: currentMulmoScriptVersion,
         credit: "closing",
       },
       lang: "en",
@@ -156,7 +157,7 @@ test("test createStudioData", async () => {
   // console.log(JSON.stringify(ret));
   const expect = {
     script: {
-      $mulmocast: { version: "1.1", credit: "closing" },
+      $mulmocast: { version: currentMulmoScriptVersion, credit: "closing" },
       lang: "en",
       canvasSize: { width: 1280, height: 720 },
       speechParams: { speakers: { Test: { displayName: { en: "Test" }, voiceId: "shimmer", provider: "openai" } } },

--- a/test/utils/test_estimate_usage.ts
+++ b/test/utils/test_estimate_usage.ts
@@ -3,12 +3,13 @@ import assert from "node:assert/strict";
 import { estimateUsage } from "../../src/utils/estimate_usage.js";
 import { mulmoScriptSchema } from "../../src/types/schema.js";
 import type { UsageEstimate } from "../../src/types/usage.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 type BeatInput = Record<string, unknown>;
 
 const makeScript = (beats: BeatInput[], extra: Record<string, unknown> = {}) => {
   return mulmoScriptSchema.parse({
-    $mulmocast: { version: "1.1" },
+    $mulmocast: { version: currentMulmoScriptVersion },
     lang: "en",
     speechParams: { speakers: { Presenter: { voiceId: "shimmer", displayName: { en: "Presenter" } } } },
     beats,

--- a/test/utils/test_estimate_usage_cli.ts
+++ b/test/utils/test_estimate_usage_cli.ts
@@ -4,9 +4,10 @@ import { estimateUsage, actionEstimateProcesses } from "../../src/utils/estimate
 import { formatUsageEstimates } from "../../src/utils/estimate_usage_format.js";
 import { mulmoScriptSchema } from "../../src/types/schema.js";
 import type { UsageEstimate } from "../../src/types/usage.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 const fullScript = mulmoScriptSchema.parse({
-  $mulmocast: { version: "1.1" },
+  $mulmocast: { version: currentMulmoScriptVersion },
   lang: "en",
   captionParams: { lang: "ja" },
   speechParams: { speakers: { Presenter: { voiceId: "shimmer", displayName: { en: "Presenter" } } } },
@@ -68,7 +69,7 @@ describe("formatUsageEstimates", () => {
 
   it("notes records without pricing data", () => {
     const script = mulmoScriptSchema.parse({
-      $mulmocast: { version: "1.1" },
+      $mulmocast: { version: currentMulmoScriptVersion },
       lang: "en",
       speechParams: { speakers: { Presenter: { voiceId: "Atla", provider: "kotodama", displayName: { en: "Presenter" } } } },
       beats: [{ speaker: "Presenter", text: "Hello" }],

--- a/test/zod/test_zod.ts
+++ b/test/zod/test_zod.ts
@@ -1,13 +1,14 @@
 import test from "node:test";
 import assert from "node:assert";
 import { mulmoScriptSchema, mediaSourceSchema } from "../../src/types/schema.js";
+import { currentMulmoScriptVersion } from "../../src/types/const.js";
 
 test("test zod", async () => {
   const initMulmoScript = {
     title: "title",
     description: "INITIAL_DESCRIPTION",
     $mulmocast: {
-      version: "1.1",
+      version: currentMulmoScriptVersion,
       credit: "closing",
     },
     lang: "en",
@@ -24,7 +25,7 @@ test("test zod", async () => {
   const expected = {
     success: true,
     data: {
-      $mulmocast: { version: "1.1", credit: "closing" },
+      $mulmocast: { version: currentMulmoScriptVersion, credit: "closing" },
       canvasSize: { width: 1280, height: 720 },
       speechParams: { speakers: { Presenter: { displayName: { en: "Presenter" }, voiceId: "shimmer", provider: "openai" } } },
       imageParams: { provider: "openai", images: {} },


### PR DESCRIPTION
## Summary

`#1563`。テストが組む MulmoScript の `$mulmocast.version` を `currentMulmoScriptVersion`（`src/types/const.ts`）に揃えます。

**① 後方互換テストでもないのに `"1.0"` だったもの（5ファイル・6箇所）**

`test/actions/test_viewer.ts` (2) / `test_images.ts` / `test_movie.ts` / `run_audio.ts` / `run_translate.ts`。

`createStudioData` は内部で `MulmoScriptMethods.validate()` を呼ぶので、これらは「1.0 のファイルを読み込んだアプリ」を偶然テストしていました。どれもそのファイルの主題ではありません（viewer のテスト、images のテスト…）。

**挙動が変わらないことは実行して確認しました。** `validate_1_0` がするのは `speechParams.provider` を各 speaker へ移して削除することだけで、この5つはどれも `speechParams` を持ちません。`defaultLang` も `"1.0"` / `"1.1"` の両方で `{ lang: "en" }` です。使い捨てのハーネスで両方を `validate()` に通し、`deepStrictEqual` で一致することを確認しています:

```
identical after validate: {"version":"1.1","credit":"closing"} lang: en
```

**② `"1.1"` のリテラルも定数に（9ファイル・18箇所）**

`test/actions/utils.ts` / `test_images_error.ts` / `test_create_video.ts` / `test/agents/test_validate_schema_agent.ts` / `test/fixtures.ts` / `test/utils/test_cli.ts` / `test_estimate_usage.ts` / `test_estimate_usage_cli.ts` / `test/zod/test_zod.ts`。

`currentMulmoScriptVersion` は `as const` な `"1.1"` なので、置換後の**実行時の値は同一**です。`src/` 側は `schema.ts` / `complete_script.ts` / `translate.ts` が既にこの定数を使っています。

**残したもの（バージョンそのものが主題）**

- `test/utils/test_versioning.ts` — 1.0 → 1.1 の移行テスト。`script_10` の `"1.0"` はもちろん、`script_11` の `"1.1"` も「移行先」であって「最新」ではないのでリテラルのまま
- `test/tools/test_complete_script.ts` の `preserves existing version` — 「既にあるバージョンを保つ」テストなので `"1.0"` のまま（同ファイルの「無ければ足す」側は既に定数を使っています）
- `test/json/*.json`（7ファイル）— JSON なので定数を書けません

これでバージョンを上げるとき、テスト側の追随漏れは**移行テストと JSON fixture だけ**に絞られます。

## Items to Confirm / Review

- **`test/utils/test_cli.ts` は期待値（golden）側も定数にしました。** `createStudioData` は「そのときの現行バージョン」を刻むので、入力を定数にした以上こちらも定数が筋、という判断です。「golden はリテラルで固定したい」ならそこだけ戻します
- **`test/fixtures.ts` / `test/actions/utils.ts` は `mulmoPresentationStyleSchema` 側の `$mulmocast.version`** です。`schema.ts` はスクリプトと presentation style の両方を `z.literal(currentMulmoScriptVersion)` で縛っているので、同じ定数で正しいはずですが、将来分かれる可能性があるなら別定数にする余地はあります
- **`test/utils/test_versioning.ts` の `script_11` を定数にしなかった理由**は上記のとおりです。ここを定数にすると、バージョンが 1.2 になったとき「1.0 → 1.1 の移行テスト」が黙って別物になります

## 検証

- `npx tsc --noEmit -p tsconfig.test.json` — **0件**（`#1551` 完了後の状態を維持）
- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `validate()` の差分ハーネス — 1.0 入力と 1.1 入力の結果が `deepStrictEqual`
- 全テスト（1166本）— **pass 1162 / fail 0 / skip 4**（変更前と同一）

> 途中、フルスイートが `test_images` / `test_movie` あたりで20分止まりました。**マシン側の負荷**で、chrome/ffmpeg が別作業で119プロセス動いている状態でした。該当ファイルを単体で走らせるといずれも pass（`test_viewer` + `test_images_error` 6本、`test_images` + `test_movie` 3本、軽い方の8ファイル120本）。その後 chrome が減ってからフルスイートも通っています。

## User Prompt

> 別途気がついた。`test/actions/run_audio.ts` の version 1.0 って古い。後方互換テストコードじゃない限り 1.1 にするし、なんなら latestVersion という変数（名前違うかも）をつかったほうがよい。別 PR で。

Closes #1563


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use the current MulmoScript version consistently.
  * Improved test reliability when the supported script version changes.
  * No user-facing functionality or behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->