### PR TITLE
chore: 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.11.0](https://github.com/receptron/mulmocast-cli/releases/tag/2.11.0) (2026-08-23)
+
+### plugin の引数型が、実際に読むものだけを宣言するようになりました
+
+image plugin の 4 つの操作は `ImageProcessorParams` という 1 つの型を共有していました。
+`process()` は 8 フィールドすべてを使いますが、`markdown()` と `html()` が読むのは `beat`
+（と mermaid / movie / vision / slide の `context`、slide の `imageRefs`）だけ、`path()` は
+`beat` / `context` / `imagePath` だけです。狭い操作が広い型の要求を相続していました。
+
+**公開型が 2 つ増えます**（追加のみ・既存の変更なし）:
+
+```ts
+import type { BeatRenderParams, BeatPathParams } from "mulmocast";
+
+// BeatRenderParams = Pick<ImageProcessorParams, "beat" | "context" | "imageRefs">
+// BeatPathParams   = Pick<ImageProcessorParams, "beat" | "context" | "imagePath">
+```
+
+`ImageProcessorParams` 自体は変わりません。plugin テーブルと `findImagePlugin` は
+export していないため、パッケージ利用者の呼び出し側に影響はありません。
+
+**挙動は変わりません。** `mulmo images` を 8 スクリプト（markdown / textSlide / chart /
+mermaid / slide / image / movie / html_tailwind / voice_over / beat を網羅）で変更前後に
+流し、生成物 114 件のうち 113 件が byte 一致することを確認しています。残る 1 件は JS 駆動の
+描画で、変更前のツリーを 2 回走らせても毎回変わる非決定的なものです。
+
+### `yarn test` が 16 か月ぶりに動くようになりました
+
+`c5e6dd6b`（2025-05-02）が `src/audio.ts` などを `src/actions/` へ移した際に `test` script が
+取り残され、`ERR_MODULE_NOT_FOUND` で即死していました。CI は `ci_test` を使うため
+気づかれていませんでした。あわせて、このスクリプトが TTS / 画像生成の API キーを必要とする
+ことを CLAUDE.md に明記しました。
+
+### `test/` が型検査されるようになりました
+
+`tsconfig.json` の `include` が `src` だけだったため、テストの型は eslint しか見ていません
+でした。非ブロッキングの CI job で件数を可視化したうえで、**279 件あった型エラーを 0 件まで
+解消**しています。fixture がスキーマの通らない形（必須の `title` を欠いた textSlide、
+16 進でない色、`MulmoStudioContext` ではないモック）を使っていた箇所を、実在しうる形に
+直しました。
+
 ## [2.10.0](https://github.com/receptron/mulmocast-cli/releases/tag/2.10.0) (2026-08-22)
 
 ### AI を使わない beat を、ブラウザだけで HTML にできるようになりました

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mulmocast",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "",
   "type": "module",
   "main": "lib/index.node.js",

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mulmocast/types",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Type definitions for MulmoCast",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary

`mulmocast` と `@mulmocast/types` をどちらも **2.10.0 → 2.11.0**（minor）に上げます。

## Items to Confirm / Review

### 1. なぜ minor か

`#1555` / `#1559` で **公開型が2つ増えます**（追加のみ、既存の変更なし）:

```ts
export type BeatRenderParams = Pick<ImageProcessorParams, "beat" | "context" | "imageRefs">;
export type BeatPathParams   = Pick<ImageProcessorParams, "beat" | "context" | "imagePath">;
```

`ImageProcessorParams` 自体は無変更です。plugin テーブルと `findImagePlugin` は export していないので、利用者の呼び出し側に影響はありません（現行 npm 版に対して `import { findImagePlugin } from "mulmocast"` が `TS2305` になることで確認済み）。

### 2. `@mulmocast/types` も上げる理由

`types/src/type.ts` は `src/types/type.ts` への**シンボリックリンク**なので、上記2型は自動的に `@mulmocast/types` にも入ります。**片方だけ上げると版と中身がずれます。**

### 3. 挙動は変わりません（実測）

`#1555` で `mulmo images` を8スクリプト（markdown / textSlide / chart / mermaid / slide / image / movie / html_tailwind / voice_over / beat を網羅）に流し、**生成物 114 件のうち 113 件が byte 一致**。残る1件は JS 駆動の描画で、変更前のツリーを2回走らせても毎回変わる非決定的なものです。比較自体の検出力も mutation で確認しています。

### 4. この範囲でマージされた PR

| PR | 内容 | 公開物への影響 |
|---|---|---|
| `#1555` | plugin の `markdown` / `html` / `path` の引数型を実態に合わせて絞る | **公開型 +2** |
| `#1559` | `resolveCombinedStyle` を同様に絞る | 内部のみ |
| `#1556` | `yarn test` のパス修正（16か月壊れていた） | script のみ |
| `#1552` | `test/` の型エラーを非ブロッキングで可視化する CI job | CI のみ |
| `#1553` `#1554` `#1557` `#1558` `#1560` `#1561` `#1562` | `test/` の型エラー解消（**279 → 0**） | 出荷物に含まれない |

## 検証

`lint` / `build` / `types` の build: green。`typecheck:test`: **0 件**。

## publish 手順（マージ後）

1. tag `2.11.0` と `@mulmocast/types@2.11.0`
2. `npm publish --access public --registry https://registry.npmjs.org/` を両方
3. GitHub release（英語、`--latest`）

## User Prompt

> mulmocast と @mulmocast/typesをマイナーでpublish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the package version to 2.11.0.
  * Updated the associated types package to 2.11.0.
* **Documentation**
  * Added release notes covering narrower plugin parameter types and restored test command support.
  * Documented type-checking and test fixture corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->