### PR TITLE
chore: ignore the Playwright MCP output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 lib/
 output/
 my-scripts/
+.playwright-mcp/


### PR DESCRIPTION
## Summary

`.gitignore` に `.playwright-mcp/` を1行足します。

Playwright MCP で実アプリを動かして確認すると、実行したディレクトリの下に `.playwright-mcp/`（スクリーンショットと a11y スナップショット）が作られます。**UI の変更を実機で確認するのはこのリポジトリでは通常の作業**なので、その出力が毎回 `git status` に残るのは不適切です。今回は **79ファイル・904KB** が溜まっていました。

## Items to Confirm / Review

- **元の `.gitignore` は末尾に改行がありませんでした。** そのため今回の追加で改行が1つ入っています（diff の `\ No newline at end of file` の消滅）。**これは付随的な変更ではなく必要な修正**で、改行が無いまま append すると `my-scripts/` の行に連結されて `my-scripts/.playwright-mcp/` になり、**`my-scripts/` の ignore が黙って外れます**（実際に一度そうなったので直しました）
- 追加後、既存の4パターンが従来どおり効くことを `git check-ignore -v` で確認しています:

```
.gitignore:6:lib/              lib/b
.gitignore:7:output/           output/a
.gitignore:8:my-scripts/       my-scripts/foo.ts
.gitignore:9:.playwright-mcp/  .playwright-mcp/x.png
```

## User Prompt

> ここって cli だよね。（残骸ある？）
> .gitignore 追加

（`#1551` 関連の作業中に Playwright でブラウザ確認をした際、cwd が mulmocast-cli だったため出力がここに落ちていました。GitHub issue は立てていません — バグ修正でも機能追加でもない `.gitignore` の1行のためです。必要なら立てます。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded Playwright-generated files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->