### PR TITLE
feat: mark the swipe root so a browser host can give it a height

### DIFF
--- a/src/utils/beat_html/type.ts
+++ b/src/utils/beat_html/type.ts
@@ -22,7 +22,14 @@ export type BeatHtmlFragment = {
    * since it has no DOM and must stay dependency-light to remain bundleable.
    */
   html: string;
-  /** Rules the markup needs, scoped by the caller. Absent when the markup needs none. */
+  /**
+   * Rules the markup needs, scoped by the caller. Absent when the markup needs none.
+   *
+   * It cannot carry everything: an `html_tailwind` beat written with `elements` is a root
+   * asking for 100% of its parent, and how tall that parent should be is the host's layout,
+   * not the beat's. The root is marked `data-mulmo-swipe-root` so a host can give it one —
+   * and a host that does not gets an empty box, silently.
+   */
   css?: string;
   /** External runtimes the host must load once for the page, not once per beat. */
   requires?: BeatRuntime[];

--- a/src/utils/swipe_to_html.ts
+++ b/src/utils/swipe_to_html.ts
@@ -169,10 +169,18 @@ const elementToHtml = (el: SwipeElement, index: number): string => {
   return lines.join("\n");
 };
 
+/**
+ * The root the elements are positioned inside. Named so a browser host can give it a height:
+ * the root asks for 100% of its parent, and an inline height wins over any rule aimed at the
+ * root itself, so the parent is where the box has to come from. The document path has a
+ * viewport to fill and needs nothing.
+ */
+export const SWIPE_ROOT_ATTRIBUTE = "data-mulmo-swipe-root";
+
 /** Generate HTML from Swipe elements */
 export const swipeElementsToHtml = (elements: SwipeElement[]): string => {
   const html = elements.map((el, i) => elementToHtml(el, i)).join("\n");
-  return `<div style="position:relative; width:100%; height:100%; overflow:hidden;">\n${html}\n</div>`;
+  return `<div ${SWIPE_ROOT_ATTRIBUTE} style="position:relative; width:100%; height:100%; overflow:hidden;">\n${html}\n</div>`;
 };
 
 // --- Script generation for animations ---

--- a/test/utils/test_swipe_to_html.ts
+++ b/test/utils/test_swipe_to_html.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { swipeElementsToHtml, swipeElementsToScript, type SwipeElement } from "../../src/utils/swipe_to_html.js";
+import { swipeElementsToHtml, swipeElementsToScript, SWIPE_ROOT_ATTRIBUTE, type SwipeElement } from "../../src/utils/swipe_to_html.js";
 
 /**
  * A swipe element's id reaches an HTML attribute AND a raw CSS selector inside a JavaScript
@@ -30,4 +30,23 @@ test("elements without an id get a generated one that satisfies the rule", () =>
   const elements: SwipeElement[] = [{ text: "x", to: { opacity: 1 } }];
   assert.match(swipeElementsToHtml(elements), /<div id="swipe_el_0"/);
   assert.match(swipeElementsToScript(elements), /animation\.animate\('#swipe_el_0'/);
+});
+
+/**
+ * The root asks for 100% of its parent, so a browser host that gives it none renders nothing
+ * — and renders it silently, since no runtime is involved and nothing throws. The attribute
+ * is the only handle a host has: without it the alternative is matching on the inline style,
+ * which breaks on a whitespace change with the same silent, green result.
+ */
+test("the root carries the attribute a host targets to give it a box", () => {
+  const html = swipeElementsToHtml([{ id: "panel_1", text: "x" }]);
+  assert.match(html, new RegExp(`^<div ${SWIPE_ROOT_ATTRIBUTE} `), "the root is the first element and carries the hook");
+  assert.strictEqual(html.split(SWIPE_ROOT_ATTRIBUTE).length - 1, 1, "one root, so the host's selector cannot match twice");
+});
+
+test("the root still declares the size and clipping it always did", () => {
+  const html = swipeElementsToHtml([{ id: "panel_1", text: "x" }]);
+  ["position:relative", "width:100%", "height:100%", "overflow:hidden"].forEach((declaration) => {
+    assert.ok(html.includes(declaration), declaration);
+  });
 });


### PR DESCRIPTION
## Summary

`#1567`。**swipe の root に `data-mulmo-swipe-root` を付けます。**

`swipeElementsToHtml` は要素を `height:100%` の root で包みます。PNG 生成側はページ全体が箱になるので問題になりませんが、**fragment をブラウザに差し込む host は自分で箱を用意する必要があります**。用意しないと高さ 0 になり、**runtime も無く throw もしないので、ページが静かに空になり、テストは全部緑のまま**です。

root には class も data 属性も無かったため、host はインライン style を当てるしかありませんでした。`mulmocast-deck-web` は実際にこうなっています（[#36](https://github.com/receptron/mulmocast-deck-web/pull/36)）:

```css
.beat-fragment:has(> div[style*="height:100%"]) { height: 260px; }
```

上の文字列が**スペース1つ変わるだけで**、同じように**静かに**効かなくなります。（高さは **root の「親」** に与える必要があります。インラインの `height:100%` は、root 自身に当たるどんなスタイルシート規則より強いためです。）

`data-mulmo-swipe-root` は既存の慣習に合わせています（このリポジトリの `data-mulmo-chart`、`@mulmocast/deck` の `data-mulmo-path` / `data-mulmo-item-path`）。

## Items to Confirm / Review

- **追加のみです。** 既存の `style` 属性も、中の要素も1文字も変えていません。root の markup を固定しているテストは**この PR の前には存在しませんでした**
- **テストを2本足しました**（host に対する契約になったので）: 属性が**先頭要素にあること**と、**1回だけ現れること**（host のセレクタが二重に当たらない）。もう1本で **4つの style 宣言が残っていること**を固定しているので、「属性と引き換えにスタイルを落とす」変更は赤くなります
- **`BeatHtmlFragment.css` の doc に理由を1行**足しました。「親の高さは host のレイアウトの話で、beat が決められない」ので `css` では運べない、という説明です
- **`beatToHtml` 経由でも確認しました**（生成関数だけでなく、host が実際に受け取る fragment に属性が届いていること）:
  ```
  has hook: true
  <div data-mulmo-swipe-root style="position:relative; width:100%; height:100%; overflow:hidden;">
  ```

## 検証

- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `npx tsc --noEmit -p tsconfig.test.json` — **0件**
- 全テスト — **1168 pass / 0 fail / 4 skip**（1166 → 1168、追加2本）

## 次にやること（この PR の範囲外）

これが入ったら `mulmocast-deck-web` 側の host CSS を `[data-mulmo-swipe-root]` に付け替えます（別 PR）。

## User Prompt

> （`#32` の残件として挙げた「swipe elements のラッパに class か data 属性」）
> つづけて

Closes #1567


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated swipe markup now includes a dedicated attribute for targeting the swipe root element.
  * Added documentation describing CSS requirements and host-controlled sizing for swipe roots.

* **Tests**
  * Added coverage confirming the root attribute and existing positioning, sizing, and clipping styles are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->