### PR TITLE
security: escape the CSS url() and the values mulmo html puts in attributes

### DIFF
--- a/src/actions/html.ts
+++ b/src/actions/html.ts
@@ -1,12 +1,20 @@
 import fs from "fs";
 import path from "path";
 import { isNull } from "graphai";
+import { escapeHtml } from "@mulmocast/deck";
 import { MulmoStudioContext } from "../types/index.js";
 import { localizedText } from "../utils/utils.js";
 import { writingMessage } from "../utils/file.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
-const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): string => {
+/**
+ * The exported HTML document for a studio.
+ *
+ * Exported so the escaping below is reachable without writing a file: every value that
+ * reaches an attribute or `<title>` comes from the script, and a beat with a
+ * `source: { kind: "path" }` image puts the author's own path into `src`.
+ */
+export const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): string => {
   const { studio, multiLingual, lang = "en" } = context;
 
   const title = studio.script.title || "MulmoCast Content";
@@ -26,11 +34,14 @@ const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): 
       if (studioBeat?.html) {
         html += `${studioBeat.html}\n\n`;
       } else if (studioBeat?.imageFile && isNull(studioBeat.html)) {
-        const imagePath = path.relative(context.fileDirs.outDirPath, studioBeat.imageFile);
-        const altText = `Beat ${index + 1}`;
+        // A `source: { kind: "path" }` beat puts the author's own path here, so it reaches an
+        // HTML attribute unfiltered unless it is escaped. Every value in these attributes goes
+        // through the same rule rather than each being argued safe on its own.
+        const imagePath = escapeHtml(path.relative(context.fileDirs.outDirPath, studioBeat.imageFile));
+        const altText = escapeHtml(`Beat ${index + 1}`);
         if (imageWidth) {
           // Use HTML img tag for width control
-          html += `<img src="${imagePath}" alt="${altText}" width="${imageWidth}" />\n\n`;
+          html += `<img src="${imagePath}" alt="${altText}" width="${escapeHtml(imageWidth)}" />\n\n`;
         } else {
           // Use standard html image syntax
           html += `<img src="${imagePath}" alt="${altText}" />\n\n`;
@@ -49,7 +60,7 @@ const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): 
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>${title}</title>
+    <title>${escapeHtml(title)}</title>
     <!-- Tailwind CSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Chart.js CDN -->

--- a/src/actions/html.ts
+++ b/src/actions/html.ts
@@ -8,13 +8,17 @@ import { writingMessage } from "../utils/file.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 
 /**
- * The exported HTML document for a studio.
+ * The HTML document for a studio.
  *
- * Exported so the escaping below is reachable without writing a file: every value that
- * reaches an attribute or `<title>` comes from the script, and a beat with a
- * `source: { kind: "path" }` image puts the author's own path into `src`.
+ * Every value that reaches an attribute or `<title>` comes from the script, and a beat with a
+ * `source: { kind: "path" }` image puts the author's own path into `src`, so each one is
+ * escaped for the context it lands in.
+ *
+ * Not exported: `actions/index.ts` re-exports this module with `export *` and `index.node.ts`
+ * re-exports that, so anything exported here becomes public API of the published package. The
+ * tests drive it through `html()` instead.
  */
-export const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): string => {
+const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): string => {
   const { studio, multiLingual, lang = "en" } = context;
 
   const title = studio.script.title || "MulmoCast Content";

--- a/src/actions/markdown.ts
+++ b/src/actions/markdown.ts
@@ -4,6 +4,7 @@ import { localizedText } from "../utils/utils.js";
 import { writingMessage } from "../utils/file.js";
 import { MulmoStudioContextMethods } from "../methods/mulmo_studio_context.js";
 import path from "path";
+import { escapeHtml } from "@mulmocast/deck";
 
 const generateMarkdownContent = (context: MulmoStudioContext, imageWidth?: string): string => {
   const { studio, multiLingual, lang = "en" } = context;
@@ -27,9 +28,11 @@ const generateMarkdownContent = (context: MulmoStudioContext, imageWidth?: strin
       } else if (studioBeat?.imageFile) {
         const imagePath = path.relative(context.fileDirs.outDirPath, studioBeat.imageFile);
         if (imageWidth) {
-          // Use HTML img tag for width control
+          // An HTML tag is HTML wherever the markdown is rendered, and a
+          // `source: { kind: "path" }` beat puts the author's own path here — the same shape
+          // and the same input as the `<img>` in actions/html.ts.
           const altText = `Beat ${index + 1}`;
-          markdown += `<img src="${imagePath}" alt="${altText}" width="${imageWidth}" />\n\n`;
+          markdown += `<img src="${escapeHtml(imagePath)}" alt="${escapeHtml(altText)}" width="${escapeHtml(imageWidth)}" />\n\n`;
         } else {
           // Use standard markdown image syntax
           markdown += `![Beat ${index + 1}](${imagePath})\n\n`;

--- a/src/utils/html_escape.ts
+++ b/src/utils/html_escape.ts
@@ -25,6 +25,24 @@ const SCRIPT_JSON_ESCAPES = new Map([
 /** Neutralize the output of JSON.stringify for embedding inside an inline `<script>`. */
 export const escapeJsonForScript = (json: string): string => json.replace(/[<>&\u2028\u2029]/g, (character) => SCRIPT_JSON_ESCAPES.get(character) ?? character);
 
+// A CSS string ends at the first unescaped quote of the kind that opened it, and a raw
+// newline ends the declaration outright, so a value carrying either escapes the string it
+// was placed in. Backslash is what CSS defines for both; a line break becomes its hex escape
+// with the terminating space CSS requires. Both quote characters are escaped so a caller may
+// use either, and every other character — including the base64 body of a data URL — is left
+// exactly as it was.
+const CSS_STRING_ESCAPES = new Map([
+  ["\\", "\\\\"],
+  ["'", "\\'"],
+  ['"', '\\"'],
+  ["\n", "\\a "],
+  ["\r", "\\d "],
+  ["\f", "\\c "],
+]);
+
+/** Neutralize a value placed inside a quoted CSS string, such as the argument of `url()`. */
+export const escapeCssString = (value: string): string => value.replace(/[\\'"\n\r\f]/g, (character) => CSS_STRING_ESCAPES.get(character) ?? character);
+
 // A <style> element holds raw text: nothing inside it is parsed as markup except the closing
 // tag, so `</style` is the only sequence that can end it. Neutralizing just that keeps
 // author-supplied CSS working, which escaping the whole string would not. `\3c ` is the CSS

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -75,11 +75,9 @@ export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | un
   }
 
   const isSimpleUrl = typeof backgroundImage === "string";
-  // The data URL carries a content-type the remote server chose, so a quote in it would end
-  // the CSS string this is placed in — the base64 body cannot, but the header can.
-  const imageUrl = escapeCssString(
-    isSimpleUrl ? await fetchUrlAsDataUrl(backgroundImage) : await MulmoMediaSourceMethods.toDataUrl(backgroundImage.source, context),
-  );
+  // Escaped at each use rather than here: the base64 body cannot carry a quote, but the
+  // content-type in front of it is whatever the remote server's response header said.
+  const imageUrl = isSimpleUrl ? await fetchUrlAsDataUrl(backgroundImage) : await MulmoMediaSourceMethods.toDataUrl(backgroundImage.source, context);
   const size = sizeToCSS(isSimpleUrl ? "cover" : (backgroundImage.size ?? "cover"));
   const opacity = isSimpleUrl ? 1 : (backgroundImage.opacity ?? 1);
 
@@ -97,7 +95,7 @@ export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | un
         left: 0;
         right: 0;
         bottom: 0;
-        background-image: url('${imageUrl}');
+        background-image: url('${escapeCssString(imageUrl)}');
         background-size: ${size};
         background-position: center;
         background-repeat: no-repeat;
@@ -113,7 +111,7 @@ export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | un
       margin: 0;
     }
     body {
-      background-image: url('${imageUrl}');
+      background-image: url('${escapeCssString(imageUrl)}');
       background-size: ${size};
       background-position: center;
       background-repeat: no-repeat;

--- a/src/utils/image_plugins/bg_image_util.ts
+++ b/src/utils/image_plugins/bg_image_util.ts
@@ -2,7 +2,7 @@ import { BackgroundImage, MulmoStudioContext, ImageProcessorParams } from "../..
 import { MulmoMediaSourceMethods } from "../../methods/mulmo_media_source.js";
 import { resolveStyle } from "./utils.js";
 import { safeFetch, DEFAULT_FETCH_TIMEOUT_MS } from "../fetch.js";
-import { neutralizeStyleTerminator } from "../html_escape.js";
+import { escapeCssString, neutralizeStyleTerminator } from "../html_escape.js";
 
 /**
  * Resolve background image from beat level and global level settings.
@@ -75,7 +75,11 @@ export const backgroundImageToCSS = async (backgroundImage: BackgroundImage | un
   }
 
   const isSimpleUrl = typeof backgroundImage === "string";
-  const imageUrl = isSimpleUrl ? await fetchUrlAsDataUrl(backgroundImage) : await MulmoMediaSourceMethods.toDataUrl(backgroundImage.source, context);
+  // The data URL carries a content-type the remote server chose, so a quote in it would end
+  // the CSS string this is placed in — the base64 body cannot, but the header can.
+  const imageUrl = escapeCssString(
+    isSimpleUrl ? await fetchUrlAsDataUrl(backgroundImage) : await MulmoMediaSourceMethods.toDataUrl(backgroundImage.source, context),
+  );
   const size = sizeToCSS(isSimpleUrl ? "cover" : (backgroundImage.size ?? "cover"));
   const opacity = isSimpleUrl ? 1 : (backgroundImage.opacity ?? 1);
 

--- a/test/actions/test_html_escaping.ts
+++ b/test/actions/test_html_escaping.ts
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert";
+import fs from "fs";
+import os from "os";
+import path from "path";
 
-import { generateHtmlContent } from "../../src/actions/html.js";
+import { html, htmlFilePath } from "../../src/actions/html.js";
 import { createMockContext } from "./utils.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
 
@@ -11,35 +14,46 @@ import type { MulmoStudioContext } from "../../src/types/index.js";
  * `title`, and a beat image's path — which for `source: { kind: "path" }` is whatever the
  * author wrote, resolved but not filtered.
  *
- * The output is opened in a browser, so this is not only a rendering question.
+ * Driven through the exported `html()` rather than the generator behind it. That generator is
+ * deliberately not exported — `actions/index.ts` re-exports this module with `export *`, so
+ * exporting it to reach it from here would put it in the published package's public API — and
+ * going through `html()` covers the path that actually ships, file write included.
  */
-const contextWith = (title: string, imageFile?: string): MulmoStudioContext => {
-  const context = createMockContext();
-  context.studio.script.title = title;
-  context.studio.script.beats = [{ text: "a beat" }];
-  context.studio.beats = [imageFile ? { imageFile } : {}];
-  return context;
+const run = async (title: string, imageFile?: string, imageWidth?: string): Promise<string> => {
+  const outDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-html-escape-"));
+  try {
+    const context: MulmoStudioContext = createMockContext();
+    context.fileDirs = { ...context.fileDirs, outDirPath };
+    context.studio.script.title = title;
+    context.studio.script.beats = [{ text: "a beat" }];
+    context.studio.beats = [imageFile ? { imageFile: path.join(outDirPath, imageFile) } : {}];
+    await html(context, imageWidth);
+    return fs.readFileSync(htmlFilePath(context), "utf8");
+  } finally {
+    fs.rmSync(outDirPath, { recursive: true, force: true });
+  }
 };
 
-test("a title cannot close the element it is placed in", () => {
-  const html = generateHtmlContent(contextWith("</title><script>alert(1)</script>"));
-  assert.ok(!/<title>[^<]*<\/title>\s*<script>alert/.test(html), "the injected script must not survive as markup");
-  assert.ok(html.includes("&lt;/title&gt;&lt;script&gt;"), "it survives as text");
+test("a title cannot close the element it is placed in", async () => {
+  const written = await run("</title><script>alert(1)</script>");
+  assert.ok(!/<title>[^<]*<\/title>\s*<script>alert/.test(written), "the injected script must not survive as markup");
+  assert.ok(written.includes("&lt;/title&gt;&lt;script&gt;"), "it survives as text");
 });
 
-test("an author's image path cannot escape the src attribute", () => {
-  const html = generateHtmlContent(contextWith("T", '/test/output/a" onerror="alert(1)'));
-  assert.ok(!/onerror="alert\(1\)"/.test(html), "no attribute may be forged");
-  assert.ok(html.includes("&quot; onerror=&quot;"), "the path survives as an attribute value");
+test("an author's image path cannot escape the src attribute", async () => {
+  const written = await run("T", 'a" onerror="alert(1)');
+  assert.ok(!/onerror="alert\(1\)"/.test(written), "no attribute may be forged");
+  assert.ok(written.includes("&quot; onerror=&quot;"), "the path survives as an attribute value");
 });
 
-test("an ordinary title and path are emitted unchanged", () => {
-  const html = generateHtmlContent(contextWith("Quarterly Review", "/test/output/images/0p.png"));
-  assert.ok(html.includes("<title>Quarterly Review</title>"), "title");
-  assert.ok(html.includes('src="images/0p.png"'), "path, relative to the out dir");
+test("an ordinary title and path are emitted unchanged", async () => {
+  const written = await run("Quarterly Review", "0p.png");
+  assert.ok(written.includes("<title>Quarterly Review</title>"), "title");
+  assert.ok(written.includes('src="0p.png"'), "path, relative to the out dir");
 });
 
-test("the width option is an attribute too", () => {
-  const html = generateHtmlContent(contextWith("T", "/test/output/a.png"), '600" onload="alert(1)');
-  assert.ok(!/onload="alert\(1\)"/.test(html));
+test("the width option is an attribute too", async () => {
+  const written = await run("T", "a.png", '600" onload="alert(1)');
+  assert.ok(!/onload="alert\(1\)"/.test(written));
+  assert.ok(written.includes("&quot; onload=&quot;"));
 });

--- a/test/actions/test_html_escaping.ts
+++ b/test/actions/test_html_escaping.ts
@@ -5,6 +5,7 @@ import os from "os";
 import path from "path";
 
 import { html, htmlFilePath } from "../../src/actions/html.js";
+import { markdown, markdownFilePath } from "../../src/actions/markdown.js";
 import { createMockContext } from "./utils.js";
 import type { MulmoStudioContext } from "../../src/types/index.js";
 
@@ -56,4 +57,45 @@ test("the width option is an attribute too", async () => {
   const written = await run("T", "a.png", '600" onload="alert(1)');
   assert.ok(!/onload="alert\(1\)"/.test(written));
   assert.ok(written.includes("&quot; onload=&quot;"));
+});
+
+/**
+ * `mulmo markdown` emits the same `<img>` tag from the same author-controlled path when a
+ * width is given, and an HTML tag is HTML wherever the markdown is rendered. Same class, same
+ * input, same shape — found by sweeping for the pattern rather than by a review comment.
+ *
+ * The other branch writes `![alt](path)`, which is markdown syntax rather than HTML and needs
+ * a different escape; that is not this PR and is reported on #1535.
+ */
+const runMarkdown = async (imageFile: string, imageWidth: string): Promise<string> => {
+  const outDirPath = fs.mkdtempSync(path.join(os.tmpdir(), "mulmo-md-escape-"));
+  try {
+    const context: MulmoStudioContext = createMockContext();
+    context.fileDirs = { ...context.fileDirs, outDirPath };
+    context.studio.script.beats = [{ text: "a beat" }];
+    context.studio.beats = [{ imageFile: path.join(outDirPath, imageFile) }];
+    await markdown(context, imageWidth);
+    return fs.readFileSync(markdownFilePath(context), "utf8");
+  } finally {
+    fs.rmSync(outDirPath, { recursive: true, force: true });
+  }
+};
+
+test("the markdown export escapes the same img attributes the html export does", async () => {
+  const written = await runMarkdown('a" onerror="alert(1)', "600");
+  assert.ok(!/onerror="alert\(1\)"/.test(written), "no attribute may be forged");
+  assert.ok(written.includes("&quot; onerror=&quot;"), "the path survives as an attribute value");
+});
+
+test("the markdown width option is an attribute too", async () => {
+  // Not covered by the test above: that one puts the payload in the PATH, and a width of
+  // "600" is unchanged by escaping — so mutating the width escape alone stayed green.
+  const written = await runMarkdown("a.png", '600" onload="alert(1)');
+  assert.ok(!/onload="alert\(1\)"/.test(written));
+  assert.ok(written.includes("&quot; onload=&quot;"));
+});
+
+test("an ordinary markdown img is emitted unchanged", async () => {
+  const written = await runMarkdown("0p.png", "600");
+  assert.ok(written.includes('<img src="0p.png" alt="Beat 1" width="600" />'), "ordinary output untouched");
 });

--- a/test/actions/test_html_escaping.ts
+++ b/test/actions/test_html_escaping.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { generateHtmlContent } from "../../src/actions/html.js";
+import { createMockContext } from "./utils.js";
+import type { MulmoStudioContext } from "../../src/types/index.js";
+
+/**
+ * `mulmo html` writes a complete document and every value in it comes from the script. Two
+ * of them reach a context where a quote or an angle bracket changes the markup: the script's
+ * `title`, and a beat image's path — which for `source: { kind: "path" }` is whatever the
+ * author wrote, resolved but not filtered.
+ *
+ * The output is opened in a browser, so this is not only a rendering question.
+ */
+const contextWith = (title: string, imageFile?: string): MulmoStudioContext => {
+  const context = createMockContext();
+  context.studio.script.title = title;
+  context.studio.script.beats = [{ text: "a beat" }];
+  context.studio.beats = [imageFile ? { imageFile } : {}];
+  return context;
+};
+
+test("a title cannot close the element it is placed in", () => {
+  const html = generateHtmlContent(contextWith("</title><script>alert(1)</script>"));
+  assert.ok(!/<title>[^<]*<\/title>\s*<script>alert/.test(html), "the injected script must not survive as markup");
+  assert.ok(html.includes("&lt;/title&gt;&lt;script&gt;"), "it survives as text");
+});
+
+test("an author's image path cannot escape the src attribute", () => {
+  const html = generateHtmlContent(contextWith("T", '/test/output/a" onerror="alert(1)'));
+  assert.ok(!/onerror="alert\(1\)"/.test(html), "no attribute may be forged");
+  assert.ok(html.includes("&quot; onerror=&quot;"), "the path survives as an attribute value");
+});
+
+test("an ordinary title and path are emitted unchanged", () => {
+  const html = generateHtmlContent(contextWith("Quarterly Review", "/test/output/images/0p.png"));
+  assert.ok(html.includes("<title>Quarterly Review</title>"), "title");
+  assert.ok(html.includes('src="images/0p.png"'), "path, relative to the out dir");
+});
+
+test("the width option is an attribute too", () => {
+  const html = generateHtmlContent(contextWith("T", "/test/output/a.png"), '600" onload="alert(1)');
+  assert.ok(!/onload="alert\(1\)"/.test(html));
+});

--- a/test/css_unescape.ts
+++ b/test/css_unescape.ts
@@ -1,0 +1,16 @@
+/**
+ * What a CSS parser reads back out of a quoted string: an escaped character is that character.
+ *
+ * Tests use this instead of re-implementing `escapeCssString` to compute an expected value.
+ * Re-implementing it makes the assertion only as good as the copy — it silently stops
+ * describing the real rule the moment a fixture grows a character the copy does not handle,
+ * which is what CodeQL's js/incomplete-sanitization flagged about the first version of these
+ * tests. Asserting the ROUND TRIP instead states the property that actually matters: whatever
+ * went in comes back out.
+ */
+export const cssUnescape = (value: string): string =>
+  value
+    .replace(/\\a /g, "\n")
+    .replace(/\\d /g, "\r")
+    .replace(/\\c /g, "\f")
+    .replace(/\\([\\'"])/g, "$1");

--- a/test/image_plugins/test_bg_image_util.ts
+++ b/test/image_plugins/test_bg_image_util.ts
@@ -67,6 +67,18 @@ test("a background image cannot break out of the url() it is placed in", async (
   assert.strictEqual(urlArgument(css), BREAKOUT.replace(/'/g, "\\'"), "the whole payload stays inside the string, quotes escaped");
 });
 
+/**
+ * `backgroundImageToCSS` has TWO url() sinks — this one, and the default branch above.
+ * Mutating them together says nothing about either: with only the default-branch test in
+ * place, removing the escape from line 98 alone left the suite green (25 pass / 0 fail),
+ * while removing it from line 114 alone went red. A sweep has to move one site at a time.
+ */
+test("the opacity branch cannot break out of its url() either", async () => {
+  const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: BREAKOUT }, opacity: 0.5 }, undefined);
+  assert.ok(css.includes("body::before"), "this is the pseudo-element branch, not the default one");
+  assert.strictEqual(urlArgument(css), BREAKOUT.replace(/'/g, "\\'"), "the whole payload stays inside the string, quotes escaped");
+});
+
 test("an ordinary background image is emitted unescaped", async () => {
   const ordinary = "data:image/png;base64,iVBORw0KGgo=";
   const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: ordinary } }, undefined);

--- a/test/image_plugins/test_bg_image_util.ts
+++ b/test/image_plugins/test_bg_image_util.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert";
 import { resolveCombinedStyle } from "../../src/utils/image_plugins/bg_image_util.js";
 import { createMockContext } from "../actions/utils.js";
+import { cssUnescape } from "../css_unescape.js";
 
 /**
  * resolveCombinedStyle is the only producer of the CSS that chart, mermaid, markdown and
@@ -44,17 +45,19 @@ test("ordinary CSS passes through resolveCombinedStyle unchanged", async () => {
  * guard stops guarding without anything going red.
  *
  * `base64ToDataUrl` returns a value that already starts with `data:` verbatim, so this
- * reaches `url('...')` untouched and needs no network. It is also the reason the attack
+ * reaches `url('...')` untouched and needs no network. The fixture carries a backslash as
+ * well as quotes, because escaping the quote and not the backslash is exactly the mistake
+ * CodeQL's js/incomplete-sanitization names — the round trip is what proves both are handled. It is also the reason the attack
  * surface is not only a remote server's content-type header: an author's own base64 source
  * can carry the whole data URL.
  */
-const BREAKOUT = "data:image/png;');} body{display:none} .x{background:url('x";
+const BREAKOUT = "data:image/png;');} body{display:none} .x{background:url('x\\y";
 
 /** Where the CSS string opened by `url('` actually ends: the first quote CSS does not read as escaped. */
 const urlArgument = (css: string): string => {
   const start = css.indexOf("url('") + "url('".length;
-  // The fixture carries no backslash of its own, so a preceding backslash here is always one
-  // the escaper added.
+  // A preceding backslash is one the escaper added: the round-trip assertion below is what
+  // proves that, so this scan does not have to be a second escaper.
   for (let index = start; index < css.length; index++) {
     if (css[index] === "'" && css[index - 1] !== "\\") return css.slice(start, index);
   }
@@ -64,7 +67,7 @@ const urlArgument = (css: string): string => {
 test("a background image cannot break out of the url() it is placed in", async () => {
   const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: BREAKOUT } }, undefined);
   assert.ok(css.includes("body{display:none}"), "the value is carried through, not stripped");
-  assert.strictEqual(urlArgument(css), BREAKOUT.replace(/'/g, "\\'"), "the whole payload stays inside the string, quotes escaped");
+  assert.strictEqual(cssUnescape(urlArgument(css)), BREAKOUT, "the whole payload stays inside the string and round-trips");
 });
 
 /**
@@ -76,7 +79,7 @@ test("a background image cannot break out of the url() it is placed in", async (
 test("the opacity branch cannot break out of its url() either", async () => {
   const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: BREAKOUT }, opacity: 0.5 }, undefined);
   assert.ok(css.includes("body::before"), "this is the pseudo-element branch, not the default one");
-  assert.strictEqual(urlArgument(css), BREAKOUT.replace(/'/g, "\\'"), "the whole payload stays inside the string, quotes escaped");
+  assert.strictEqual(cssUnescape(urlArgument(css)), BREAKOUT, "the whole payload stays inside the string and round-trips");
 });
 
 test("an ordinary background image is emitted unescaped", async () => {

--- a/test/image_plugins/test_bg_image_util.ts
+++ b/test/image_plugins/test_bg_image_util.ts
@@ -35,3 +35,40 @@ test("ordinary CSS passes through resolveCombinedStyle unchanged", async () => {
   const style = "h1 { color: rgb(9, 9, 9); }";
   assert.strictEqual(await resolveCombinedStyle(paramsWith(style), undefined, undefined), style);
 });
+
+/**
+ * The wiring, not the helper.
+ *
+ * escapeCssString has its own tests, but those pass whether or not resolveCombinedStyle
+ * calls it — removing the call at both sites left the whole suite green, which is how a
+ * guard stops guarding without anything going red.
+ *
+ * `base64ToDataUrl` returns a value that already starts with `data:` verbatim, so this
+ * reaches `url('...')` untouched and needs no network. It is also the reason the attack
+ * surface is not only a remote server's content-type header: an author's own base64 source
+ * can carry the whole data URL.
+ */
+const BREAKOUT = "data:image/png;');} body{display:none} .x{background:url('x";
+
+/** Where the CSS string opened by `url('` actually ends: the first quote CSS does not read as escaped. */
+const urlArgument = (css: string): string => {
+  const start = css.indexOf("url('") + "url('".length;
+  // The fixture carries no backslash of its own, so a preceding backslash here is always one
+  // the escaper added.
+  for (let index = start; index < css.length; index++) {
+    if (css[index] === "'" && css[index - 1] !== "\\") return css.slice(start, index);
+  }
+  return css.slice(start);
+};
+
+test("a background image cannot break out of the url() it is placed in", async () => {
+  const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: BREAKOUT } }, undefined);
+  assert.ok(css.includes("body{display:none}"), "the value is carried through, not stripped");
+  assert.strictEqual(urlArgument(css), BREAKOUT.replace(/'/g, "\\'"), "the whole payload stays inside the string, quotes escaped");
+});
+
+test("an ordinary background image is emitted unescaped", async () => {
+  const ordinary = "data:image/png;base64,iVBORw0KGgo=";
+  const css = await resolveCombinedStyle(paramsWith(""), { source: { kind: "base64", data: ordinary } }, undefined);
+  assert.ok(css.includes(`url('${ordinary}')`), "byte for byte, so the escaping is not paid by ordinary input");
+});

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -153,3 +153,30 @@ test("escapeCssString leaves every other character alone", () => {
   const ordinary = "https://example.com/a-b_c.png?x=1&y=2#z <>&";
   assert.strictEqual(escapeCssString(ordinary), ordinary);
 });
+
+/**
+ * A quoted Content-Type parameter is valid and non-hostile — `image/svg+xml;charset="utf-8"`
+ * is what a server may legitimately send — and it does NOT survive byte for byte, because the
+ * quote is exactly what has to be escaped. What survives is the value a CSS parser reads back,
+ * which is the property that matters and the one this pins. Raised by Codex in round 2 against
+ * a byte-for-byte claim that was true only of unquoted types.
+ */
+const cssUnescape = (value: string): string =>
+  value
+    .replace(/\\([\\'"])/g, "$1")
+    .replace(/\\a /g, "\n")
+    .replace(/\\d /g, "\r")
+    .replace(/\\c /g, "\f");
+
+test("a quoted content-type parameter changes bytes but not the URL CSS reads back", () => {
+  const url = 'data:image/svg+xml;charset="utf-8";base64,PHN2Zy8+';
+  const escaped = escapeCssString(url);
+  assert.notStrictEqual(escaped, url, "the quote must be escaped — that is the whole point");
+  assert.strictEqual(cssUnescape(escaped), url, "and the value survives the round trip");
+});
+
+test("the escapes this helper writes all round-trip", () => {
+  ["a'b", 'a"b', "a\\b", "a\nb", "a\rb", "a\fb", "'\"\\\n"].forEach((value) => {
+    assert.strictEqual(cssUnescape(escapeCssString(value)), value, JSON.stringify(value));
+  });
+});

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert";
-import { escapeJsonForScript, neutralizeStyleTerminator } from "../../src/utils/html_escape.js";
+import { escapeCssString, escapeJsonForScript, neutralizeStyleTerminator } from "../../src/utils/html_escape.js";
 
 const LINE_SEPARATOR = " ";
 const PARAGRAPH_SEPARATOR = " ";
@@ -112,4 +112,44 @@ test("neutralizeStyleTerminator leaves ordinary CSS byte-identical", () => {
   ].forEach((css) => {
     assert.strictEqual(neutralizeStyleTerminator(css), css, `${JSON.stringify(css)} must pass through`);
   });
+});
+
+// ─── escapeCssString ───
+//
+// bg_image_util places a data URL inside `url('...')`. The base64 body cannot carry a quote,
+// but the content-type in front of it comes from the remote server's response header — so a
+// hostile host is what reaches this, not a hostile author.
+
+const ATTACK_URL = "data:image/png;') ;} body{display:none} .x{background:url('x";
+
+test("escapeCssString keeps a value from ending the CSS string it is placed in", () => {
+  const escaped = escapeCssString(ATTACK_URL);
+  assert.ok(/[';}]/.test(ATTACK_URL), "the fixture is hostile to begin with");
+  assert.ok(!/(^|[^\\])'/.test(escaped), "no quote survives without a backslash in front of it");
+  assert.ok(escaped.includes("body{display:none}"), "the rest of the value is carried through, not stripped");
+});
+
+test("escapeCssString escapes both quote characters, so either may open the string", () => {
+  assert.strictEqual(escapeCssString(`a'b"c`), `a\\'b\\"c`);
+});
+
+test("escapeCssString escapes a backslash before anything else, so an escape cannot be forged", () => {
+  // Without this order, \' would arrive as a literal backslash followed by a live quote.
+  assert.strictEqual(escapeCssString("a\\'b"), "a\\\\\\'b");
+});
+
+test("escapeCssString turns a line break into the hex escape CSS needs, with its terminator", () => {
+  assert.strictEqual(escapeCssString("a\nb"), "a\\a b");
+  assert.strictEqual(escapeCssString("a\rb"), "a\\d b");
+  assert.strictEqual(escapeCssString("a\fb"), "a\\c b");
+});
+
+test("escapeCssString leaves an ordinary data URL byte for byte", () => {
+  const url = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
+  assert.strictEqual(escapeCssString(url), url);
+});
+
+test("escapeCssString leaves every other character alone", () => {
+  const ordinary = "https://example.com/a-b_c.png?x=1&y=2#z <>&";
+  assert.strictEqual(escapeCssString(ordinary), ordinary);
 });

--- a/test/utils/test_html_escape.ts
+++ b/test/utils/test_html_escape.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert";
 import { escapeCssString, escapeJsonForScript, neutralizeStyleTerminator } from "../../src/utils/html_escape.js";
+import { cssUnescape } from "../css_unescape.js";
 
 const LINE_SEPARATOR = " ";
 const PARAGRAPH_SEPARATOR = " ";
@@ -161,12 +162,6 @@ test("escapeCssString leaves every other character alone", () => {
  * which is the property that matters and the one this pins. Raised by Codex in round 2 against
  * a byte-for-byte claim that was true only of unquoted types.
  */
-const cssUnescape = (value: string): string =>
-  value
-    .replace(/\\([\\'"])/g, "$1")
-    .replace(/\\a /g, "\n")
-    .replace(/\\d /g, "\r")
-    .replace(/\\c /g, "\f");
 
 test("a quoted content-type parameter changes bytes but not the URL CSS reads back", () => {
   const url = 'data:image/svg+xml;charset="utf-8";base64,PHN2Zy8+';


### PR DESCRIPTION
## Summary

`#1535` の**残り2件**、プラス**掃引で見つけた同クラス2件**です。

### ① `bg_image_util` の `url('${imageUrl}')`

値は常に data URL なので base64 本体は引用符を持てませんが、**その前にある content-type は fetch 先のレスポンスヘッダそのもの**です:

```ts
const contentType = response.headers.get("content-type") || "image/png";
return `data:${contentType};base64,${...}`;
```

引用符1つで CSS 文字列が終わり、その後は生の宣言になります。

**攻撃者は2種類います**（round 1 で自分の記述を訂正）。1つはこの content-type を返すリモートホスト。もう1つは**著者自身**で、`base64ToDataUrl` は `data:` で始まる値を**そのまま返す**ため:

```ts
const base64ToDataUrl = (data: string): string => (data.startsWith("data:") ? data : `data:image/png;base64,${data}`);
```

`source: { kind: "base64" }` に書いた値が data URL 全体（content-type 込み）になります。これはネットワーク無しで配線をテストできる経路でもあります。

`escapeCssString` を足しました。両方の引用符と改行系を扱い、**バックスラッシュを最初に置換**するので、既にバックスラッシュを含む値からエスケープを偽造できません。**エスケープは2つのシンクそれぞれで**行います（`backgroundImageToCSS` には `opacity < 1` の `body::before` 分岐と既定分岐の2つがあります）。

### ② `html.ts` の `<title>${title}</title>`

スクリプトの title がそのまま入ります。

### ③ `html.ts` の `<img src="...">` — **issue に載っていなかったもの**

`source: { kind: "path" }` の beat では `imagePluginSourcePath` が `MulmoMediaSourceMethods.resolve(...)`、つまり**著者が書いたパス**を返し、それが `studioBeat.imageFile` → `src` 属性に届きます。引用符1つで属性を偽造できます。`alt` と `width` も、値ごとに「これは安全だ」と論じるのではなく**同じ規則を通す**形にしました。

### ④ `markdown.ts` の `<img src="...">` — ③ の完全な双子（round 3 の掃引で発見）

```ts
const imagePath = path.relative(context.fileDirs.outDirPath, studioBeat.imageFile);
markdown += `<img src="${imagePath}" alt="${altText}" width="${imageWidth}" />`;
```

③ と**一字一句同じ式・同じ著者制御入力**で、HTML タグは markdown がどこでレンダされても HTML です。同じ規則でエスケープしました。

`generateHtmlContent` は **export しません** — `actions/index.ts` が `export *` で再輸出し `index.node.ts` がさらに再輸出するので、export すると公開パッケージの API になってしまいます（round 1 で一度やって戻しました）。テストは公開されている `html()` / `markdown()` を tmpdir に対して駆動します（`test/actions/test_viewer.ts` と同じやり方）。**このファイルにはテストが1本もありませんでした。**

## やらなかったこと、とその理由

**`generateHtmlContent` は beat の `text` とスクリプトの `description` も生の HTML として連結しています。** 同じクラスですが、これが `html_tailwind` / `markdown`（`#1549` で「契約として sanitize しない」と決着）と同じ**意図的なマークアップ**なのか、エスケープすべき**データ**なのかは issue が「決めること」に挙げている設計判断で、名指しの2件を直す PR の中で決めるべきではありません。

掃引で見つかった残り2サイトも、Codex と合意のうえ **`#1535` に送りました**（[コメント](https://github.com/receptron/mulmocast-cli/issues/1535#issuecomment-5384317134)）:

- **`pdf.ts:58/69/91`** — 到達には**引用符を含む名前の読めるファイル**がディスク上に必要で、敵性 mulmoscript だけでは足りません（別の到達性クラス）
- **`markdown.ts:35`** の `![alt](path)` — markdown リンク構文なので `escapeHtml` は誤った規則です（`)` が破綻文字で、`&` を `&amp;` にしてはいけない）

掃引して**非該当**と判断したもの（Codex も同意）: `media_html.ts`（代入時に `escapeHtml` 済み）/ `viewer.ts`（MIME がルックアップテーブル）/ `chart_html.ts`（モジュール定数）。

## Items to Confirm / Review

- **`escapeCssString` はバックスラッシュを先に置換します。** 「`\` を含む値からエスケープを偽造できない」ことをテストで固定しています
- **`width` もエスケープしました。** 現状の呼び出し元は CLI オプション経由ですが、属性境界の規則を値ごとに例外にしない方針です
- **`alt` は生成値（`Beat N`）なので安全**ですが、同じ理由で通しています。Codex はこれを「変異で捕まらない」と指摘し、`Beat ${index + 1}` は決定論的 ASCII なので load-bearing ではない、という判断で合意しました
- **テストの期待値はエスケーパを再実装しません。** CSS 側は往復性（`cssUnescape(url引数) === 入力`）で、`cssUnescape` は `test/css_unescape.ts` に1つだけ定義しています

## 検証

- **6サイトすべてを1つずつ変異させて赤くなることを確認**（title / `src` / `width` / `url()` opacity 分岐 / `url()` 既定分岐 / markdown `src` / markdown `width`）。**同時に潰すと片方の無検証を見逃す**ことが実際に起きたので、シンク単位でも個別に確認しています
- **通常の出力が変わらないことは、実行して確認しました**:
  - **引用符なしの content-type**: content-type 6 × body 5 × scheme 3 = **90 URL がバイト単位で同一**
  - **引用符付きパラメータ**（`image/svg+xml;charset="utf-8"` など、正当で非敵性）: 45件中15件で**ソースバイトは変化**する — 引用符こそエスケープ対象なので当然です。ただし **semantic loss は 0**、つまり CSS がアンエスケープして読む URL は同一。この往復性は性質としてテストに固定しました
  - 敵性の3形はすべて変化
- `yarn lint` error 0 / `yarn build` OK / `typecheck:test` **0件**
- 全テスト **1168 → 1186 pass / 0 fail**

## レビュー経緯

`/codex-cross-review` を5ラウンド。round 1〜4 はいずれも clean ではなく、**Codex の LGTM の後に見つかったもの**が各ラウンドで1件ずつありました。詳細は各ラウンドの triage コメントにあります。

## User Prompt

> 1527以降のissueをまとめてなおしてからpublishだね

（`#1527` / `#1535` / `#1542` / `#1547` の4件を順に。これは `#1535` の残件です。）

Refs #1535
