### PR TITLE
fix: build types with the same TypeScript root uses

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@receptron/test_utils": "^2.0.3",
     "@types/archiver": "^8.0.0",
     "@types/jsdom": "^28.0.3",
+    "@types/node": "^26.0.0",
     "@types/yargs": "^17.0.35",
     "cross-env": "^10.1.0",
     "esbuild": "^0.28.2",

--- a/plans/fix-types-typescript-alignment.md
+++ b/plans/fix-types-typescript-alignment.md
@@ -1,0 +1,65 @@
+# types サブパッケージを root と同じ TypeScript でビルドする
+
+`#1547`。
+
+## 現状
+
+`types/src/*.ts` は `src/types/*.ts` への **symlink** なので、**同じソースを2つの別のコンパイラでビルドしている**:
+
+| | root | types |
+|---|---|---|
+| `typescript` | `6.0.3` | `^5.7.2`（解決 5.9.3） |
+| `@types/node` | 宣言なし（transitive で 18.19.130） | 無し |
+
+`~/ss/llm/CLAUDE.md` の「TypeScript は `^6.0.3` で全レポ統一」にも反する。
+
+## 上げると出るもの（実測）
+
+`types/` を 6.0.3 にすると:
+
+```
+src/agent.ts(19,44): error TS2591: Cannot find name 'Buffer'.
+```
+
+**`@types/node` を入れただけでは消えない。** 原因は root の `tsconfig.json` に既に書いてあった:
+
+```jsonc
+"types": ["archiver", "jsdom", "yargs"],  /* Explicit for TS 6.0 compatibility (new default: []) */
+```
+
+**TS 6.0 で `types` の既定が `[]` になった**ので、`@types/*` は自動で入らない。root は対応済みで、`types/` だけが TS 5.9 に留まっていたため露見していなかった。
+
+## やること
+
+1. `types/` に `@types/node` を追加し、`typescript` を `6.0.3` に
+2. `types/tsconfig.json` に `"types": ["node"]`（コンパイラ自身が要求する形）
+3. **生成物が変わらないことを diff で確認**
+4. root も `@types/node` を宣言し、`types` に `node` を足す
+
+### 4 の理由
+
+root は `engines: ">=22.0.0"`、CI は 22.x / 24.x で走るのに、**`@types/node` は 18.19.130 が transitive で入っているだけ**だった。
+つまり **Node 22 以上を要求しながら Node 18 の型で型検査していた**。
+
+なお「root の `Buffer` は `@types/archiver` / `@types/jsdom` 経由で偶然入っている」という仮説は
+**実測して否定された** — `types` を `["yargs"]` だけにしてもエラー0。`types` 配列は `@types` の
+自動取り込みしか制御せず、他パッケージの `.d.ts` にある `/// <reference types="node" />` は
+無関係に辿られるため。どの経路であれ「宣言せずに効いている」ことは変わらないので、宣言する。
+
+### バージョンは最新（`^26.0.0`）
+
+`@types/node` は **TypeScript バージョン別の dist-tag** を持ち、**`ts6.0` → `26.2.0`**（`ts5.0` は 22.13.14）。
+このリポジトリの TypeScript は 6.0.3 なので、対応するのは 26 系。
+
+`engines: ">=22"` に合わせて 22 系に留める案も検討したが、**その利点を実証できなかった**:
+Node 23.11 で入った `process.execve` を型検査させても `@types/node@22` はエラーを出さず、
+「古い型に固定すれば新しい API の誤用を捕まえられる」という想定は少なくともこの例では成立しなかった。
+根拠のない制約を入れるより、TS のバージョンに対応した最新を使う。
+
+22 と 26 のどちらでも root の build / typecheck / lint と `types/lib` の出力は同一であることは確認済み。
+
+## 確認すること
+
+- `types/lib` が **TS 5.9 版とバイト単位で同一**であること（同一なら `@mulmocast/types` の再 publish は不要）
+- **クリーン install**（`rm -rf node_modules && yarn install --frozen-lockfile`）から
+  lint / build / typecheck / 全テストが緑であること。lockfile が変わる PR なので必須

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
     // },                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    "types": ["archiver", "jsdom", "yargs"],  /* Explicit for TS 6.0 compatibility (new default: []) */
+    "types": ["archiver", "jsdom", "node", "yargs"],  /* Explicit for TS 6.0 compatibility (new default: []) */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/types/package.json
+++ b/types/package.json
@@ -29,7 +29,8 @@
     }
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "@types/node": "^26.0.0",
+    "typescript": "6.0.3"
   },
   "keywords": [
     "mulmocast",

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -11,6 +11,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    // TS6 does not pick @types/node up implicitly here, and the compiler asks for this by name
+    // (TS2591 on `Buffer`). Root does the same in tsconfig.test.json.
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],

--- a/types/yarn.lock
+++ b/types/yarn.lock
@@ -9,10 +9,22 @@
   dependencies:
     zod "^4.4.3"
 
-typescript@^5.7.2:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+"@types/node@^26.0.0":
+  version "26.2.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.2.0.tgz#5a4875a862fda8fdc57de8faa579bb81ecba1685"
+  integrity sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==
+  dependencies:
+    undici-types "~8.3.0"
+
+typescript@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 zod@^4.4.3:
   version "4.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -868,6 +868,13 @@
   dependencies:
     undici-types "~5.26.4"
 
+"@types/node@^26.0.0":
+  version "26.2.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.2.0.tgz#5a4875a862fda8fdc57de8faa579bb81ecba1685"
+  integrity sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==
+  dependencies:
+    undici-types "~8.3.0"
+
 "@types/readdir-glob@*":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@types/readdir-glob/-/readdir-glob-1.1.5.tgz#21a4a98898fc606cb568ad815f2a0eedc24d412a"
@@ -4609,6 +4616,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://npm.flatt.tech/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
+  integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
 undici@^7.25.0:
   version "7.29.0"


### PR DESCRIPTION
## Summary

`#1547`。`types/src/*.ts` は `src/types/*.ts` への **symlink** なので、**同じソースを2つの別のコンパイラでビルドしていました** — root が 6.0.3、`types/` が `^5.7.2`（解決 5.9.3）。`~/ss/llm/CLAUDE.md` の「TypeScript は `^6.0.3` で全レポ統一」にも反していました。

### 真因は `@types/node` の不足ではなかった

`types/` を 6.0.3 に上げると issue の予測どおり:

```
src/agent.ts(19,44): error TS2591: Cannot find name 'Buffer'.
```

**`@types/node` を入れても消えません。** 理由は root 自身の `tsconfig.json` に既に書いてありました:

```jsonc
"types": ["archiver", "jsdom", "yargs"],  /* Explicit for TS 6.0 compatibility (new default: []) */
```

**TS 6.0 で `types` の既定が `[]` に変わった**のが原因です。root は対応済みで、**`types/` だけが TS 5.9 に留まっていたため露見していませんでした**。`types/tsconfig.json` に `["node"]`（コンパイラ自身が要求する形）を足しています。

### 公開物は変わりません

`diff -r` を `lib/` 全体に対して実行 — `.d.ts` / `.js` / 両 map の**40ファイルすべてがバイト単位で同一**（5.9.3 でビルドしたベースライン比）。**`@mulmocast/types` の再 publish は不要**です。

### root も `@types/node` を宣言（issue の項目4）

宣言が無く **18.19.130 を transitive で引いていました**。一方 `engines` は `>=22.0.0`、CI は 22.x / 24.x。**Node 22 以上を要求しながら Node 18 の型で型検査していた**ことになります。

## 測って、うち1つは自分が間違っていた

- **「root の `Buffer` は `@types/archiver` / `@types/jsdom` 経由で入っている」→ 誤り。** `types` を `["yargs"]` だけにしてもエラー0でした。`types` 配列は `@types` の**自動取り込みしか制御せず**、他パッケージの `.d.ts` にある `/// <reference types="node" />` は無関係に辿られるためです。結論（宣言せずに効いている）は変わりませんが、理由は違いました
- **バージョン**: `@types/node` は **TypeScript 別の dist-tag** を持ち、**`ts6.0` → `26.2.0`**（`ts5.0` は 22.13.14）。最初は `engines: ">=22"` に合わせて `^22` にし、「最古の対応ランタイムに対して型検査すれば新しい API の誤用を捕まえられる」と考えましたが、**実証できませんでした** — Node 23.11 で入った `process.execve` は `@types/node@22` でもエラーになりません。示せない制約は入れるべきでないので、**TypeScript のバージョンに追随して最新（`^26.0.0`）**にしています

## Items to Confirm / Review

- **`@types/node` は root と types/ の両方で `^26.0.0`** です。22 と 26 のどちらでも root の build / typecheck / lint と `types/lib` の出力が同一であることは確認済みなので、`engines` に合わせたい場合は `^22` へ変えても壊れません
- **`types/tsconfig.json` の `"types": ["node"]`** は自動取り込みを `node` だけに絞ります。`types/` が参照するのは Node の型だけなので十分ですが、将来増えたら追記が必要です
- **root の `types` に `"node"` を足しました。** これまで transitive な `/// <reference>` 頼りだったものを宣言に変えるだけで、build / typecheck とも差分なしです

## 検証

lockfile が変わる PR なので、`~/ss/llm/CLAUDE.md` の規則どおり **クリーン install から**検証しています:

```
rm -rf node_modules && yarn install --frozen-lockfile
```

- `yarn lint` — error 0（warning 28 は既存）
- `yarn build` — OK
- `npx tsc --noEmit -p tsconfig.test.json` — **0件**
- 全テスト — **1186 pass / 0 fail / 4 skipped**
- `types/lib` — 5.9.3 ベースラインと**バイト単位で同一**（22 / 26 のどちらでも）

## User Prompt

> 1527以降のissueをまとめてなおしてからpublishだね
> @types/node latest 22.20.1 ❯ 26.2.0 / 最新にしてくれ

（`#1527` / `#1535` / `#1542` / `#1547` の4件を順に。`#1535` は `#1569` で完了、これは `#1547`。）

Closes #1547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript tooling to version 6.0.3 for consistent builds.
  * Added Node.js type definitions to the project’s TypeScript configuration.
  * Aligned type-checking configurations across the project for more reliable compilation.

* **Documentation**
  * Added a plan outlining validation steps for the TypeScript configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->