### PR TITLE
fix: regenerate the bundled schema and keep it honest with a test

### DIFF
--- a/assets/schemas/mulmo_script.json
+++ b/assets/schemas/mulmo_script.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
     "$mulmocast": {
@@ -6,115 +7,1855 @@
       "properties": {
         "version": {
           "type": "string",
-          "const": "1.0"
+          "const": "1.1"
         },
         "credit": {
           "type": "string",
           "const": "closing"
         }
       },
-      "required": ["version"],
+      "required": [
+        "version"
+      ],
       "additionalProperties": false
     },
     "canvasSize": {
+      "default": {
+        "width": 1280,
+        "height": 720
+      },
       "type": "object",
       "properties": {
-        "width": { "type": "number" },
-        "height": { "type": "number" }
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
       },
-      "required": ["width", "height"],
-      "additionalProperties": false,
-      "default": { "width": 1280, "height": 720 }
+      "required": [
+        "width",
+        "height"
+      ],
+      "additionalProperties": false
     },
     "speechParams": {
+      "default": {
+        "speakers": {
+          "Presenter": {
+            "provider": "openai",
+            "voiceId": "shimmer",
+            "displayName": {
+              "en": "Presenter"
+            }
+          }
+        }
+      },
       "type": "object",
       "properties": {
-        "provider": {
-          "type": "string",
-          "enum": ["openai", "google", "elevenlabs"],
-          "default": "openai"
-        },
         "speakers": {
           "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
           "additionalProperties": {
             "type": "object",
             "properties": {
               "displayName": {
                 "type": "object",
-                "additionalProperties": { "type": "string" }
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "string"
+                }
               },
-              "voiceId": { "type": "string" },
+              "voiceId": {
+                "type": "string"
+              },
+              "isDefault": {
+                "type": "boolean"
+              },
               "speechOptions": {
                 "type": "object",
                 "properties": {
-                  "speed": { "type": "number" },
-                  "instruction": { "type": "string" }
+                  "speed": {
+                    "type": "number"
+                  },
+                  "instruction": {
+                    "type": "string"
+                  },
+                  "decoration": {
+                    "type": "string"
+                  },
+                  "stability": {
+                    "type": "number"
+                  },
+                  "similarity_boost": {
+                    "type": "number"
+                  }
                 },
                 "additionalProperties": false
               },
               "provider": {
+                "default": "openai",
                 "type": "string",
-                "enum": ["openai", "google", "elevenlabs"]
+                "enum": [
+                  "openai",
+                  "google",
+                  "gemini",
+                  "elevenlabs",
+                  "kotodama",
+                  "mock"
+                ]
+              },
+              "model": {
+                "description": "TTS model to use for this speaker",
+                "type": "string"
+              },
+              "baseURL": {
+                "type": "string"
+              },
+              "apiVersion": {
+                "type": "string"
+              },
+              "lang": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "object",
+                  "properties": {
+                    "displayName": {
+                      "type": "object",
+                      "propertyNames": {
+                        "type": "string"
+                      },
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "voiceId": {
+                      "type": "string"
+                    },
+                    "isDefault": {
+                      "type": "boolean"
+                    },
+                    "speechOptions": {
+                      "type": "object",
+                      "properties": {
+                        "speed": {
+                          "type": "number"
+                        },
+                        "instruction": {
+                          "type": "string"
+                        },
+                        "decoration": {
+                          "type": "string"
+                        },
+                        "stability": {
+                          "type": "number"
+                        },
+                        "similarity_boost": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "provider": {
+                      "default": "openai",
+                      "type": "string",
+                      "enum": [
+                        "openai",
+                        "google",
+                        "gemini",
+                        "elevenlabs",
+                        "kotodama",
+                        "mock"
+                      ]
+                    },
+                    "model": {
+                      "description": "TTS model to use for this speaker",
+                      "type": "string"
+                    },
+                    "baseURL": {
+                      "type": "string"
+                    },
+                    "apiVersion": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "voiceId"
+                  ],
+                  "additionalProperties": false
+                }
               }
             },
-            "required": ["voiceId"],
+            "required": [
+              "voiceId"
+            ],
             "additionalProperties": false
           }
         }
       },
-      "required": ["speakers"],
+      "required": [
+        "speakers"
+      ],
       "additionalProperties": false
     },
     "imageParams": {
+      "default": {
+        "provider": "openai",
+        "images": {}
+      },
       "type": "object",
       "properties": {
-        "model": { "type": "string" },
-        "style": { "type": "string" },
-        "moderation": { "type": "string" },
         "provider": {
           "type": "string",
-          "enum": ["openai", "google"],
-          "default": "openai"
+          "enum": [
+            "openai",
+            "google",
+            "replicate",
+            "mock"
+          ]
+        },
+        "model": {
+          "type": "string"
+        },
+        "quality": {
+          "type": "string"
+        },
+        "style": {
+          "type": "string"
+        },
+        "moderation": {
+          "type": "string"
+        },
+        "baseURL": {
+          "type": "string"
+        },
+        "apiVersion": {
+          "type": "string"
+        },
+        "vertexai_project": {
+          "type": "string"
+        },
+        "vertexai_location": {
+          "type": "string"
+        },
+        "images": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string"
+          },
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "image"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "imagePrompt"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "canvasSize": {
+                    "type": "object",
+                    "properties": {
+                      "width": {
+                        "type": "number"
+                      },
+                      "height": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "width",
+                      "height"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "referenceImageName": {
+                    "description": "Reference another imageRefs key as input for image generation. Sugar for references[0].name",
+                    "type": "string"
+                  },
+                  "referenceImage": {
+                    "description": "Direct source (path/url/base64) as reference image for generation. Sugar for references[0].source",
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "references": {
+                    "description": "Reference images (by imageRefs key or direct source) with optional role labels",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "An imageRefs key to use as a reference image",
+                          "type": "string"
+                        },
+                        "source": {
+                          "description": "Direct source (path/url) to use as a reference image",
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "url"
+                                },
+                                "url": {
+                                  "type": "string",
+                                  "format": "uri"
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "url"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "base64"
+                                },
+                                "data": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "data"
+                              ],
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "const": "path"
+                                },
+                                "path": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "kind",
+                                "path"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        },
+                        "label": {
+                          "description": "Role of this reference (e.g. 'the firefighter Travis Kane'), injected into the prompt as a preamble",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "required": [
+                  "type",
+                  "prompt"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "movie"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "moviePrompt"
+                  },
+                  "prompt": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "imageName": {
+                    "description": "Reference an imageRefs key to use as image-to-video input",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "prompt"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "backgroundImage": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "source": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "url"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "url"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "base64"
+                            },
+                            "data": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "data"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "path"
+                            },
+                            "path": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "path"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "size": {
+                      "type": "string",
+                      "enum": [
+                        "cover",
+                        "contain",
+                        "fill",
+                        "auto"
+                      ]
+                    },
+                    "opacity": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "required": [
+                    "source"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "concurrency": {
+          "description": "Max concurrent image generation requests",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
         }
       },
       "additionalProperties": false
     },
     "movieParams": {
+      "default": {
+        "provider": "replicate"
+      },
       "type": "object",
       "properties": {
         "provider": {
           "type": "string",
-          "enum": ["openai", "google", "replicate"],
-          "default": "google"
+          "enum": [
+            "replicate",
+            "google",
+            "mock"
+          ]
         },
-        "model": { "type": "string" },
-        "transition": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": ["fade", "slideout_left"]
-            },
-            "duration": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 2,
-              "default": 0.3
-            }
-          },
-          "required": ["type"],
-          "additionalProperties": false
+        "model": {
+          "type": "string"
         },
         "fillOption": {
           "type": "object",
           "properties": {
             "style": {
+              "default": "aspectFit",
               "type": "string",
-              "enum": ["aspectFit", "aspectFill"],
-              "default": "aspectFit"
+              "enum": [
+                "aspectFit",
+                "aspectFill"
+              ]
             }
           },
+          "required": [
+            "style"
+          ],
+          "additionalProperties": false,
+          "description": "How to handle aspect ratio differences between image and canvas"
+        },
+        "transition": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "fade",
+                "slideout_left",
+                "slideout_right",
+                "slideout_up",
+                "slideout_down",
+                "slidein_left",
+                "slidein_right",
+                "slidein_up",
+                "slidein_down",
+                "wipeleft",
+                "wiperight",
+                "wipeup",
+                "wipedown",
+                "wipetl",
+                "wipetr",
+                "wipebl",
+                "wipebr"
+              ]
+            },
+            "duration": {
+              "default": 0.3,
+              "type": "number",
+              "minimum": 0,
+              "maximum": 2
+            }
+          },
+          "required": [
+            "type",
+            "duration"
+          ],
           "additionalProperties": false
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "mono"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "sepia"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "brightness_contrast"
+                  },
+                  "brightness": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "contrast": {
+                    "default": 1,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 3
+                  }
+                },
+                "required": [
+                  "type",
+                  "brightness",
+                  "contrast"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "hue"
+                  },
+                  "hue": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -180,
+                    "maximum": 180
+                  },
+                  "saturation": {
+                    "default": 1,
+                    "type": "number",
+                    "minimum": -10,
+                    "maximum": 10
+                  },
+                  "brightness": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -10,
+                    "maximum": 10
+                  }
+                },
+                "required": [
+                  "type",
+                  "hue",
+                  "saturation",
+                  "brightness"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "colorbalance"
+                  },
+                  "rs": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "gs": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "bs": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "rm": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "gm": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "bm": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "rh": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "gh": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "bh": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "rs",
+                  "gs",
+                  "bs",
+                  "rm",
+                  "gm",
+                  "bm",
+                  "rh",
+                  "gh",
+                  "bh"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "vibrance"
+                  },
+                  "intensity": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -2,
+                    "maximum": 2
+                  }
+                },
+                "required": [
+                  "type",
+                  "intensity"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "negate"
+                  },
+                  "negate_alpha": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "type",
+                  "negate_alpha"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "colorhold"
+                  },
+                  "color": {
+                    "default": "red",
+                    "type": "string"
+                  },
+                  "similarity": {
+                    "default": 0.01,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "blend": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "color",
+                  "similarity",
+                  "blend"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "colorkey"
+                  },
+                  "color": {
+                    "default": "green",
+                    "type": "string"
+                  },
+                  "similarity": {
+                    "default": 0.01,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "blend": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "color",
+                  "similarity",
+                  "blend"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "blur"
+                  },
+                  "radius": {
+                    "default": 10,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 50
+                  },
+                  "power": {
+                    "default": 1,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 10
+                  }
+                },
+                "required": [
+                  "type",
+                  "radius",
+                  "power"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "gblur"
+                  },
+                  "sigma": {
+                    "default": 30,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "type",
+                  "sigma"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "avgblur"
+                  },
+                  "sizeX": {
+                    "default": 10,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "sizeY": {
+                    "default": 10,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "type",
+                  "sizeX",
+                  "sizeY"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "unsharp"
+                  },
+                  "luma_msize_x": {
+                    "default": 5,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 23
+                  },
+                  "luma_msize_y": {
+                    "default": 5,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 23
+                  },
+                  "luma_amount": {
+                    "default": 1,
+                    "type": "number",
+                    "minimum": -2,
+                    "maximum": 5
+                  },
+                  "chroma_msize_x": {
+                    "default": 5,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 23
+                  },
+                  "chroma_msize_y": {
+                    "default": 5,
+                    "type": "number",
+                    "minimum": 3,
+                    "maximum": 23
+                  },
+                  "chroma_amount": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -2,
+                    "maximum": 5
+                  }
+                },
+                "required": [
+                  "type",
+                  "luma_msize_x",
+                  "luma_msize_y",
+                  "luma_amount",
+                  "chroma_msize_x",
+                  "chroma_msize_y",
+                  "chroma_amount"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "edgedetect"
+                  },
+                  "low": {
+                    "default": 0.2,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "high": {
+                    "default": 0.4,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "mode": {
+                    "default": "wires",
+                    "type": "string",
+                    "enum": [
+                      "wires",
+                      "colormix",
+                      "canny"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "low",
+                  "high",
+                  "mode"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "sobel"
+                  },
+                  "planes": {
+                    "default": 15,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 15
+                  },
+                  "scale": {
+                    "default": 1,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "delta": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -65535,
+                    "maximum": 65535
+                  }
+                },
+                "required": [
+                  "type",
+                  "planes",
+                  "scale",
+                  "delta"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "emboss"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "glitch"
+                  },
+                  "intensity": {
+                    "default": 20,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100
+                  },
+                  "style": {
+                    "default": "noise",
+                    "type": "string",
+                    "enum": [
+                      "noise",
+                      "blend"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "intensity",
+                  "style"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "grain"
+                  },
+                  "intensity": {
+                    "default": 10,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100
+                  }
+                },
+                "required": [
+                  "type",
+                  "intensity"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "hflip"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "vflip"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "rotate"
+                  },
+                  "angle": {
+                    "default": 0,
+                    "type": "number"
+                  },
+                  "fillcolor": {
+                    "default": "black",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "angle",
+                  "fillcolor"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "transpose"
+                  },
+                  "dir": {
+                    "default": "clock",
+                    "type": "string",
+                    "enum": [
+                      "cclock",
+                      "clock",
+                      "cclock_flip",
+                      "clock_flip"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "dir"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "vignette"
+                  },
+                  "angle": {
+                    "default": 0.6283185307179586,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 3.141592653589793
+                  },
+                  "x0": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "y0": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "mode": {
+                    "default": "forward",
+                    "type": "string",
+                    "enum": [
+                      "forward",
+                      "backward"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "angle",
+                  "mode"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "fade"
+                  },
+                  "mode": {
+                    "default": "in",
+                    "type": "string",
+                    "enum": [
+                      "in",
+                      "out"
+                    ]
+                  },
+                  "start_frame": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": 0
+                  },
+                  "nb_frames": {
+                    "default": 25,
+                    "type": "number",
+                    "minimum": 1
+                  },
+                  "alpha": {
+                    "default": false,
+                    "type": "boolean"
+                  },
+                  "color": {
+                    "default": "black",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "mode",
+                  "start_frame",
+                  "nb_frames",
+                  "alpha",
+                  "color"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "pixelize"
+                  },
+                  "width": {
+                    "default": 16,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 1000
+                  },
+                  "height": {
+                    "default": 16,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 1000
+                  },
+                  "mode": {
+                    "default": "avg",
+                    "type": "string",
+                    "enum": [
+                      "avg",
+                      "min",
+                      "max"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "width",
+                  "height",
+                  "mode"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "pseudocolor"
+                  },
+                  "preset": {
+                    "default": "magma",
+                    "type": "string",
+                    "enum": [
+                      "magma",
+                      "inferno",
+                      "plasma",
+                      "viridis",
+                      "turbo",
+                      "cividis",
+                      "range1",
+                      "range2",
+                      "shadows",
+                      "highlights",
+                      "solar",
+                      "nominal",
+                      "preferred",
+                      "total"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "preset"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "tmix"
+                  },
+                  "frames": {
+                    "default": 3,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 1024
+                  },
+                  "weights": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "frames"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "lagfun"
+                  },
+                  "decay": {
+                    "default": 0.95,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                  },
+                  "planes": {
+                    "default": 15,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 15
+                  }
+                },
+                "required": [
+                  "type",
+                  "decay",
+                  "planes"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "threshold"
+                  },
+                  "planes": {
+                    "default": 15,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 15
+                  }
+                },
+                "required": [
+                  "type",
+                  "planes"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "elbg"
+                  },
+                  "codebook_length": {
+                    "default": 256,
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 256
+                  }
+                },
+                "required": [
+                  "type",
+                  "codebook_length"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "lensdistortion"
+                  },
+                  "k1": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  },
+                  "k2": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -1,
+                    "maximum": 1
+                  }
+                },
+                "required": [
+                  "type",
+                  "k1",
+                  "k2"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "chromashift"
+                  },
+                  "cbh": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -255,
+                    "maximum": 255
+                  },
+                  "cbv": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -255,
+                    "maximum": 255
+                  },
+                  "crh": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -255,
+                    "maximum": 255
+                  },
+                  "crv": {
+                    "default": 0,
+                    "type": "number",
+                    "minimum": -255,
+                    "maximum": 255
+                  },
+                  "edge": {
+                    "default": "smear",
+                    "type": "string",
+                    "enum": [
+                      "smear",
+                      "wrap"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "cbh",
+                  "cbv",
+                  "crh",
+                  "crv",
+                  "edge"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "deflicker"
+                  },
+                  "size": {
+                    "default": 5,
+                    "type": "number",
+                    "minimum": 2,
+                    "maximum": 129
+                  },
+                  "mode": {
+                    "default": "am",
+                    "type": "string",
+                    "enum": [
+                      "am",
+                      "gm",
+                      "hm",
+                      "qm",
+                      "cm",
+                      "pm",
+                      "median"
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "size",
+                  "mode"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "dctdnoiz"
+                  },
+                  "sigma": {
+                    "default": 10,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 999
+                  }
+                },
+                "required": [
+                  "type",
+                  "sigma"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "custom"
+                  },
+                  "filter": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "filter"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          }
+        },
+        "vertexai_project": {
+          "type": "string"
+        },
+        "vertexai_location": {
+          "type": "string"
+        },
+        "firstFrameImageName": {
+          "description": "Reference an imageRefs key for the first frame (image-to-video input), or '$beatImage' for the beat's own generated image",
+          "type": "string"
+        },
+        "lastFrameImageName": {
+          "description": "Reference an imageRefs key for the last frame (image-to-video interpolation), or '$beatImage' for the beat's own generated image",
+          "type": "string"
+        },
+        "frameFillColor": {
+          "description": "Fill color used when padding firstFrame/lastFrame reference images to the canvas aspect ratio (e.g. '#F7F6F4'). Default: black",
+          "type": "string",
+          "pattern": "^(#|0x)?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$|^[a-zA-Z]+$"
+        },
+        "referenceImages": {
+          "description": "Style/asset reference images (Veo 3.1). Mutually exclusive with imageName/lastFrameImageName",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "imageName": {
+                "type": "string",
+                "description": "Reference an imageRefs key"
+              },
+              "referenceType": {
+                "type": "string",
+                "enum": [
+                  "ASSET",
+                  "STYLE"
+                ],
+                "description": "ASSET: scene/object/character, STYLE: aesthetics/lighting"
+              }
+            },
+            "required": [
+              "imageName",
+              "referenceType"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "concurrency": {
+          "description": "Max concurrent movie generation requests",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        },
+        "generateAudio": {
+          "description": "Request audio generation in the video (model-dependent)",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "soundEffectParams": {
+      "default": {
+        "provider": "replicate"
+      },
+      "type": "object",
+      "properties": {
+        "provider": {
+          "default": "replicate",
+          "type": "string",
+          "enum": [
+            "replicate"
+          ]
+        },
+        "model": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "lipSyncParams": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -122,13 +1863,22 @@
     "htmlImageParams": {
       "type": "object",
       "properties": {
-        "model": { "type": "string" },
+        "model": {
+          "type": "string"
+        },
         "provider": {
+          "default": "openai",
           "type": "string",
-          "enum": ["openai", "anthropic"],
-          "default": "openai"
+          "enum": [
+            "openai",
+            "anthropic",
+            "mock"
+          ]
         }
       },
+      "required": [
+        "provider"
+      ],
       "additionalProperties": false
     },
     "textSlideParams": {
@@ -136,148 +1886,13639 @@
       "properties": {
         "cssStyles": {
           "anyOf": [
-            { "type": "string" },
+            {
+              "type": "string"
+            },
             {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             }
           ]
         }
       },
-      "required": ["cssStyles"],
+      "required": [
+        "cssStyles"
+      ],
+      "additionalProperties": false
+    },
+    "slideParams": {
+      "type": "object",
+      "properties": {
+        "theme": {
+          "type": "object",
+          "properties": {
+            "colors": {
+              "type": "object",
+              "properties": {
+                "bg": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "bgCard": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "bgCardAlt": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "text": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "textMuted": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "textDim": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "primary": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "accent": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "success": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "warning": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "danger": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "info": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                },
+                "highlight": {
+                  "type": "string",
+                  "pattern": "^[0-9A-Fa-f]{6}$"
+                }
+              },
+              "required": [
+                "bg",
+                "bgCard",
+                "bgCardAlt",
+                "text",
+                "textMuted",
+                "textDim",
+                "primary",
+                "accent",
+                "success",
+                "warning",
+                "danger",
+                "info",
+                "highlight"
+              ],
+              "additionalProperties": false
+            },
+            "fonts": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "type": "string"
+                },
+                "body": {
+                  "type": "string"
+                },
+                "mono": {
+                  "type": "string"
+                },
+                "accent": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "title",
+                "body",
+                "mono"
+              ],
+              "additionalProperties": false
+            },
+            "bgGradient": {
+              "type": "string"
+            },
+            "titleGradient": {
+              "type": "string"
+            },
+            "cardStyle": {
+              "type": "string",
+              "enum": [
+                "glass",
+                "solid"
+              ]
+            }
+          },
+          "required": [
+            "colors",
+            "fonts"
+          ],
+          "additionalProperties": false
+        },
+        "branding": {
+          "type": "object",
+          "properties": {
+            "logo": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "url"
+                        },
+                        "url": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "url"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "base64"
+                        },
+                        "data": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "data"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "path"
+                        },
+                        "path": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "path"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "position": {
+                  "default": "top-right",
+                  "type": "string",
+                  "enum": [
+                    "top-left",
+                    "top-right",
+                    "bottom-left",
+                    "bottom-right"
+                  ]
+                },
+                "width": {
+                  "default": 120,
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                }
+              },
+              "required": [
+                "source",
+                "position",
+                "width"
+              ],
+              "additionalProperties": false
+            },
+            "backgroundImage": {
+              "type": "object",
+              "properties": {
+                "source": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "url"
+                        },
+                        "url": {
+                          "type": "string",
+                          "format": "uri"
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "url"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "base64"
+                        },
+                        "data": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "data"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "const": "path"
+                        },
+                        "path": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": [
+                        "kind",
+                        "path"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "size": {
+                  "type": "string",
+                  "enum": [
+                    "cover",
+                    "contain",
+                    "fill",
+                    "auto"
+                  ]
+                },
+                "opacity": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                "bgOpacity": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                }
+              },
+              "required": [
+                "source"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "theme"
+      ],
       "additionalProperties": false
     },
     "captionParams": {
       "type": "object",
       "properties": {
-        "lang": { "type": "string" },
+        "lang": {
+          "type": "string"
+        },
         "styles": {
           "type": "array",
-          "items": { "type": "string" },
-          "default": []
+          "items": {
+            "type": "string"
+          }
+        },
+        "captionSplit": {
+          "default": "none",
+          "type": "string",
+          "enum": [
+            "none",
+            "estimate"
+          ]
+        },
+        "textSplit": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "none"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "const": "delimiters"
+                },
+                "delimiters": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "bottomOffset": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
         }
       },
       "additionalProperties": false
     },
     "audioParams": {
+      "default": {
+        "introPadding": 1,
+        "padding": 0.3,
+        "closingPadding": 0.8,
+        "outroPadding": 1,
+        "bgmVolume": 0.2,
+        "audioVolume": 1,
+        "suppressSpeech": false
+      },
       "type": "object",
       "properties": {
-        "padding": { "type": "number", "default": 0.3 },
-        "introPadding": { "type": "number", "default": 1 },
-        "closingPadding": { "type": "number", "default": 0.8 },
-        "outroPadding": { "type": "number", "default": 1 },
-        "bgmVolume": { "type": "number", "default": 0.2 },
-        "audioVolume": { "type": "number", "default": 1 }
+        "padding": {
+          "default": 0.3,
+          "description": "Padding between beats",
+          "type": "number"
+        },
+        "introPadding": {
+          "default": 1,
+          "description": "Padding at the beginning of the audio",
+          "type": "number"
+        },
+        "closingPadding": {
+          "default": 0.8,
+          "description": "Padding before the last beat (typically the closing credit). For padding after the last beat, use outroPadding",
+          "type": "number"
+        },
+        "outroPadding": {
+          "default": 1,
+          "description": "Padding after the last beat, at the very end of the audio where the BGM fades out (distinct from closingPadding, which comes before the last beat)",
+          "type": "number"
+        },
+        "bgm": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "url"
+                },
+                "url": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              },
+              "required": [
+                "kind",
+                "url"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "base64"
+                },
+                "data": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "kind",
+                "data"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "path"
+                },
+                "path": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "kind",
+                "path"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "bgmVolume": {
+          "default": 0.2,
+          "description": "Volume of the background music",
+          "type": "number"
+        },
+        "audioVolume": {
+          "default": 1,
+          "description": "Volume of the audio",
+          "type": "number"
+        },
+        "suppressSpeech": {
+          "default": false,
+          "description": "Suppress speech generation",
+          "type": "boolean"
+        },
+        "movieVolume": {
+          "description": "Default movie audio volume for all beats",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "ttsVolume": {
+          "description": "TTS narration volume before mixing with BGM/movie audio",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 2
+        },
+        "ducking": {
+          "description": "Auto-reduce movie audio when TTS is playing",
+          "type": "object",
+          "properties": {
+            "ratio": {
+              "description": "Movie volume ratio during TTS beats (default 0.3)",
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "concurrency": {
+          "description": "Max concurrent TTS generation requests",
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "maximum": 9007199254740991
+        }
       },
+      "required": [
+        "padding",
+        "introPadding",
+        "closingPadding",
+        "outroPadding",
+        "bgmVolume",
+        "audioVolume",
+        "suppressSpeech"
+      ],
       "additionalProperties": false
     },
-    "title": { "type": "string" },
-    "description": { "type": "string" },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
     "references": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "url": { "type": "string", "format": "uri" },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "type": {
+          "url": {
             "type": "string",
-            "enum": ["article", "paper", "image", "video", "audio"],
-            "default": "article"
+            "format": "uri"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "default": "article",
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "article",
+                  "paper",
+                  "image",
+                  "video",
+                  "audio"
+                ]
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         },
-        "required": ["url"],
+        "required": [
+          "url",
+          "type"
+        ],
         "additionalProperties": false
       }
     },
-    "lang": { "type": "string" },
+    "lang": {
+      "default": "en",
+      "type": "string"
+    },
     "beats": {
+      "minItems": 1,
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "speaker": { "type": "string", "default": "Presenter" },
-          "text": { "type": "string", "default": "" },
-          "id": { "type": "string" },
-          "description": { "type": "string" },
+          "speaker": {
+            "type": "string"
+          },
+          "text": {
+            "default": "",
+            "description": "Text to be spoken. If empty, the audio is not generated.",
+            "type": "string"
+          },
+          "texts": {
+            "description": "Manually split texts for captions. Takes precedence over text for caption display.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "description": "Unique identifier for the beat.",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
           "image": {
             "anyOf": [
               {
                 "type": "object",
                 "properties": {
-                  "type": { "type": "string", "const": "markdown" },
+                  "type": {
+                    "type": "string",
+                    "const": "markdown"
+                  },
                   "markdown": {
-                    "anyOf": [{ "type": "string" }, { "type": "array", "items": { "type": "string" } }]
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "allOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "header": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              },
+                              "sidebar-left": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "row-2": {
+                                    "type": "array",
+                                    "prefixItems": [
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "row-2"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "2x2": {
+                                    "type": "array",
+                                    "prefixItems": [
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "2x2"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "content": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "content"
+                                ],
+                                "additionalProperties": false
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "style": {
+                    "type": "string"
+                  },
+                  "backgroundImage": {
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "cover",
+                                  "contain",
+                                  "fill",
+                                  "auto"
+                                ]
+                              },
+                              "opacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": [
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
-                "required": ["type", "markdown"],
+                "required": [
+                  "type",
+                  "markdown"
+                ],
                 "additionalProperties": false
               },
               {
                 "type": "object",
                 "properties": {
-                  "type": { "type": "string", "const": "textSlide" },
+                  "type": {
+                    "type": "string",
+                    "const": "web"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                },
+                "required": [
+                  "type",
+                  "url"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "pdf"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "image"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "svg"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "movie"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "textSlide"
+                  },
                   "slide": {
                     "type": "object",
                     "properties": {
-                      "title": { "type": "string" },
-                      "subtitle": { "type": "string" },
+                      "title": {
+                        "type": "string"
+                      },
+                      "subtitle": {
+                        "type": "string"
+                      },
                       "bullets": {
                         "type": "array",
-                        "items": { "type": "string" }
+                        "items": {
+                          "type": "string"
+                        }
                       }
                     },
-                    "required": ["title"],
+                    "required": [
+                      "title"
+                    ],
                     "additionalProperties": false
+                  },
+                  "style": {
+                    "type": "string"
+                  },
+                  "backgroundImage": {
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "cover",
+                                  "contain",
+                                  "fill",
+                                  "auto"
+                                ]
+                              },
+                              "opacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": [
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
-                "required": ["type", "slide"],
+                "required": [
+                  "type",
+                  "slide"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "chart"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "chartData": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  },
+                  "style": {
+                    "type": "string"
+                  },
+                  "backgroundImage": {
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "cover",
+                                  "contain",
+                                  "fill",
+                                  "auto"
+                                ]
+                              },
+                              "opacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": [
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "title",
+                  "chartData"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "mermaid"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "The title of the diagram"
+                  },
+                  "code": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "text"
+                          },
+                          "text": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "text"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ],
+                    "description": "The code of the mermaid diagram"
+                  },
+                  "appendix": {
+                    "description": "The appendix of the mermaid diagram; typically, style information.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "style": {
+                    "type": "string"
+                  },
+                  "backgroundImage": {
+                    "anyOf": [
+                      {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "cover",
+                                  "contain",
+                                  "fill",
+                                  "auto"
+                                ]
+                              },
+                              "opacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": [
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "title",
+                  "code"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "html_tailwind"
+                  },
+                  "html": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "script": {
+                    "description": "JavaScript code for the beat. Injected as a <script> tag after html. Use for render() function etc.",
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    ]
+                  },
+                  "elements": {
+                    "description": "Swipe-style declarative animation elements. Converted to HTML + render() automatically. Use this OR html, not both.",
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/__schema0"
+                    }
+                  },
+                  "animation": {
+                    "description": "Enable frame-based animation (Remotion-style). true for defaults (30fps), or { fps: N } for custom frame rate.",
+                    "anyOf": [
+                      {
+                        "type": "boolean",
+                        "const": true
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "fps": {
+                            "default": 30,
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 60
+                          },
+                          "movie": {
+                            "description": "Use CDP screencast for real-time recording (experimental, faster). Default: false (frame-by-frame screenshot).",
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "fps"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "beat"
+                  },
+                  "id": {
+                    "description": "Specifies the beat to reference.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "voice_over"
+                  },
+                  "startAt": {
+                    "description": "The time to start the voice over the video in seconds.",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "vision"
+                  },
+                  "style": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "data": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "type",
+                  "style",
+                  "data"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "slide"
+                  },
+                  "theme": {
+                    "type": "object",
+                    "properties": {
+                      "colors": {
+                        "type": "object",
+                        "properties": {
+                          "bg": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "bgCard": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "bgCardAlt": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "text": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "textMuted": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "textDim": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "primary": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "accent": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "success": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "warning": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "danger": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "info": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          },
+                          "highlight": {
+                            "type": "string",
+                            "pattern": "^[0-9A-Fa-f]{6}$"
+                          }
+                        },
+                        "required": [
+                          "bg",
+                          "bgCard",
+                          "bgCardAlt",
+                          "text",
+                          "textMuted",
+                          "textDim",
+                          "primary",
+                          "accent",
+                          "success",
+                          "warning",
+                          "danger",
+                          "info",
+                          "highlight"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "fonts": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "body": {
+                            "type": "string"
+                          },
+                          "mono": {
+                            "type": "string"
+                          },
+                          "accent": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "title",
+                          "body",
+                          "mono"
+                        ],
+                        "additionalProperties": false
+                      },
+                      "bgGradient": {
+                        "type": "string"
+                      },
+                      "titleGradient": {
+                        "type": "string"
+                      },
+                      "cardStyle": {
+                        "type": "string",
+                        "enum": [
+                          "glass",
+                          "solid"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "colors",
+                      "fonts"
+                    ],
+                    "additionalProperties": false
+                  },
+                  "slide": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "title"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "author": {
+                            "type": "string"
+                          },
+                          "note": {
+                            "type": "string"
+                          },
+                          "chips": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "columns"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "columns": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "type": "string"
+                                },
+                                "accentColor": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                },
+                                "content": {
+                                  "type": "array",
+                                  "items": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "text"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "align": {
+                                            "type": "string",
+                                            "enum": [
+                                              "left",
+                                              "center",
+                                              "right"
+                                            ]
+                                          },
+                                          "bold": {
+                                            "type": "boolean"
+                                          },
+                                          "dim": {
+                                            "type": "boolean"
+                                          },
+                                          "fontSize": {
+                                            "type": "number"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "bullets"
+                                          },
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "icon": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "ok",
+                                                        "no",
+                                                        "warn"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ordered": {
+                                            "type": "boolean"
+                                          },
+                                          "icon": {
+                                            "type": "string"
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "items"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "code"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "language": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "callout"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "style": {
+                                            "type": "string",
+                                            "enum": [
+                                              "quote",
+                                              "info",
+                                              "warning"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "metric"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "change": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "divider"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "image"
+                                          },
+                                          "src": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "src"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "imageRef"
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "ref"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "chart"
+                                          },
+                                          "chartData": {
+                                            "type": "object",
+                                            "propertyNames": {
+                                              "type": "string"
+                                            },
+                                            "additionalProperties": {}
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "chartData"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "mermaid"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "table"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "rows": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      },
+                                                      "color": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "primary",
+                                                          "accent",
+                                                          "success",
+                                                          "warning",
+                                                          "danger",
+                                                          "info",
+                                                          "highlight"
+                                                        ]
+                                                      },
+                                                      "bold": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "badge": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "text"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "rowHeaders": {
+                                            "type": "boolean"
+                                          },
+                                          "striped": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "rows"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "tag"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "section"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "content": {
+                                            "type": "array",
+                                            "items": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "text"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "align": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "left",
+                                                        "center",
+                                                        "right"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "dim": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "fontSize": {
+                                                      "type": "number"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "bullets"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "items": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "text"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "icon": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "ok",
+                                                                  "no",
+                                                                  "warn"
+                                                                ]
+                                                              },
+                                                              "size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "lead",
+                                                                  "big",
+                                                                  "sub"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "ordered": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "icon": {
+                                                      "type": "string"
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "items"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "code"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "language": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "callout"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "style": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "quote",
+                                                        "info",
+                                                        "warning"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "metric"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "change": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value",
+                                                    "label"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "divider"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "image"
+                                                    },
+                                                    "src": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "src"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "imageRef"
+                                                    },
+                                                    "ref": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "ref"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "chart"
+                                                    },
+                                                    "chartData": {
+                                                      "type": "object",
+                                                      "propertyNames": {
+                                                        "type": "string"
+                                                      },
+                                                      "additionalProperties": {}
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "chartData"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "mermaid"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "table"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    },
+                                                    "headers": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "rows": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                },
+                                                                "color": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "primary",
+                                                                    "accent",
+                                                                    "success",
+                                                                    "warning",
+                                                                    "danger",
+                                                                    "info",
+                                                                    "highlight"
+                                                                  ]
+                                                                },
+                                                                "bold": {
+                                                                  "type": "boolean"
+                                                                },
+                                                                "badge": {
+                                                                  "type": "boolean"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "text"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "rowHeaders": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "striped": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "rows"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "tag"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "sidebar": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "footer": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "num": {
+                                  "type": "number"
+                                },
+                                "numLabel": {
+                                  "type": "string"
+                                },
+                                "icon": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "title"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "showArrows": {
+                            "type": "boolean"
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "bottomText": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "columns"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "comparison"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "left": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "accentColor": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "content": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "text"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "align": {
+                                          "type": "string",
+                                          "enum": [
+                                            "left",
+                                            "center",
+                                            "right"
+                                          ]
+                                        },
+                                        "bold": {
+                                          "type": "boolean"
+                                        },
+                                        "dim": {
+                                          "type": "boolean"
+                                        },
+                                        "fontSize": {
+                                          "type": "number"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "bullets"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "icon": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "ok",
+                                                      "no",
+                                                      "warn"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "ordered": {
+                                          "type": "boolean"
+                                        },
+                                        "icon": {
+                                          "type": "string"
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "language": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "callout"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "style": {
+                                          "type": "string",
+                                          "enum": [
+                                            "quote",
+                                            "info",
+                                            "warning"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "metric"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "change": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "divider"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "image"
+                                        },
+                                        "src": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "src"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "imageRef"
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "ref"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "chart"
+                                        },
+                                        "chartData": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {}
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "chartData"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "mermaid"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "table"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "rows": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "badge": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "rowHeaders": {
+                                          "type": "boolean"
+                                        },
+                                        "striped": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "rows"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "tag"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "section"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "content": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "text"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "align": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "left",
+                                                      "center",
+                                                      "right"
+                                                    ]
+                                                  },
+                                                  "bold": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "dim": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "fontSize": {
+                                                    "type": "number"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "bullets"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "text": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "text"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "icon": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "ok",
+                                                                "no",
+                                                                "warn"
+                                                              ]
+                                                            },
+                                                            "size": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "lead",
+                                                                "big",
+                                                                "sub"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "ordered": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "icon": {
+                                                    "type": "string"
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "items"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "code"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "language": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "callout"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "style": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "quote",
+                                                      "info",
+                                                      "warning"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "metric"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "change": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value",
+                                                  "label"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "divider"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "image"
+                                                  },
+                                                  "src": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "src"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "imageRef"
+                                                  },
+                                                  "ref": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "ref"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "chart"
+                                                  },
+                                                  "chartData": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {}
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "chartData"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "mermaid"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "table"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "color": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "primary",
+                                                                  "accent",
+                                                                  "success",
+                                                                  "warning",
+                                                                  "danger",
+                                                                  "info",
+                                                                  "highlight"
+                                                                ]
+                                                              },
+                                                              "bold": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "badge": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "rowHeaders": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "striped": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "rows"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "tag"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "sidebar": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "footer": {
+                                "type": "string"
+                              },
+                              "ratio": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              },
+                              "cardless": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "title"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "right": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "accentColor": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "content": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "text"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "align": {
+                                          "type": "string",
+                                          "enum": [
+                                            "left",
+                                            "center",
+                                            "right"
+                                          ]
+                                        },
+                                        "bold": {
+                                          "type": "boolean"
+                                        },
+                                        "dim": {
+                                          "type": "boolean"
+                                        },
+                                        "fontSize": {
+                                          "type": "number"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "bullets"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "icon": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "ok",
+                                                      "no",
+                                                      "warn"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "ordered": {
+                                          "type": "boolean"
+                                        },
+                                        "icon": {
+                                          "type": "string"
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "language": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "callout"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "style": {
+                                          "type": "string",
+                                          "enum": [
+                                            "quote",
+                                            "info",
+                                            "warning"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "metric"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "change": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "divider"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "image"
+                                        },
+                                        "src": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "src"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "imageRef"
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "ref"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "chart"
+                                        },
+                                        "chartData": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {}
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "chartData"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "mermaid"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "table"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "rows": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "badge": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "rowHeaders": {
+                                          "type": "boolean"
+                                        },
+                                        "striped": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "rows"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "tag"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "section"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "content": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "text"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "align": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "left",
+                                                      "center",
+                                                      "right"
+                                                    ]
+                                                  },
+                                                  "bold": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "dim": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "fontSize": {
+                                                    "type": "number"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "bullets"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "text": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "text"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "icon": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "ok",
+                                                                "no",
+                                                                "warn"
+                                                              ]
+                                                            },
+                                                            "size": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "lead",
+                                                                "big",
+                                                                "sub"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "ordered": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "icon": {
+                                                    "type": "string"
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "items"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "code"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "language": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "callout"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "style": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "quote",
+                                                      "info",
+                                                      "warning"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "metric"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "change": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value",
+                                                  "label"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "divider"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "image"
+                                                  },
+                                                  "src": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "src"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "imageRef"
+                                                  },
+                                                  "ref": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "ref"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "chart"
+                                                  },
+                                                  "chartData": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {}
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "chartData"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "mermaid"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "table"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "color": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "primary",
+                                                                  "accent",
+                                                                  "success",
+                                                                  "warning",
+                                                                  "danger",
+                                                                  "info",
+                                                                  "highlight"
+                                                                ]
+                                                              },
+                                                              "bold": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "badge": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "rowHeaders": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "striped": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "rows"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "tag"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "sidebar": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "footer": {
+                                "type": "string"
+                              },
+                              "ratio": {
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              },
+                              "cardless": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "title"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "left",
+                          "right"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "grid"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "gridColumns": {
+                            "type": "number"
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "accentColor": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                },
+                                "num": {
+                                  "type": "number"
+                                },
+                                "icon": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "array",
+                                  "items": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "text"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "align": {
+                                            "type": "string",
+                                            "enum": [
+                                              "left",
+                                              "center",
+                                              "right"
+                                            ]
+                                          },
+                                          "bold": {
+                                            "type": "boolean"
+                                          },
+                                          "dim": {
+                                            "type": "boolean"
+                                          },
+                                          "fontSize": {
+                                            "type": "number"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "bullets"
+                                          },
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "icon": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "ok",
+                                                        "no",
+                                                        "warn"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ordered": {
+                                            "type": "boolean"
+                                          },
+                                          "icon": {
+                                            "type": "string"
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "items"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "code"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "language": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "callout"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "style": {
+                                            "type": "string",
+                                            "enum": [
+                                              "quote",
+                                              "info",
+                                              "warning"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "metric"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "change": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "divider"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "image"
+                                          },
+                                          "src": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "src"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "imageRef"
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "ref"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "chart"
+                                          },
+                                          "chartData": {
+                                            "type": "object",
+                                            "propertyNames": {
+                                              "type": "string"
+                                            },
+                                            "additionalProperties": {}
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "chartData"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "mermaid"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "table"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "rows": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      },
+                                                      "color": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "primary",
+                                                          "accent",
+                                                          "success",
+                                                          "warning",
+                                                          "danger",
+                                                          "info",
+                                                          "highlight"
+                                                        ]
+                                                      },
+                                                      "bold": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "badge": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "text"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "rowHeaders": {
+                                            "type": "boolean"
+                                          },
+                                          "striped": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "rows"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "tag"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "section"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "content": {
+                                            "type": "array",
+                                            "items": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "text"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "align": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "left",
+                                                        "center",
+                                                        "right"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "dim": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "fontSize": {
+                                                      "type": "number"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "bullets"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "items": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "text"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "icon": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "ok",
+                                                                  "no",
+                                                                  "warn"
+                                                                ]
+                                                              },
+                                                              "size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "lead",
+                                                                  "big",
+                                                                  "sub"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "ordered": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "icon": {
+                                                      "type": "string"
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "items"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "code"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "language": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "callout"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "style": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "quote",
+                                                        "info",
+                                                        "warning"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "metric"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "change": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value",
+                                                    "label"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "divider"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "image"
+                                                    },
+                                                    "src": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "src"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "imageRef"
+                                                    },
+                                                    "ref": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "ref"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "chart"
+                                                    },
+                                                    "chartData": {
+                                                      "type": "object",
+                                                      "propertyNames": {
+                                                        "type": "string"
+                                                      },
+                                                      "additionalProperties": {}
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "chartData"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "mermaid"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "table"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    },
+                                                    "headers": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "rows": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                },
+                                                                "color": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "primary",
+                                                                    "accent",
+                                                                    "success",
+                                                                    "warning",
+                                                                    "danger",
+                                                                    "info",
+                                                                    "highlight"
+                                                                  ]
+                                                                },
+                                                                "bold": {
+                                                                  "type": "boolean"
+                                                                },
+                                                                "badge": {
+                                                                  "type": "boolean"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "text"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "rowHeaders": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "striped": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "rows"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "tag"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "sidebar": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "span": {
+                                  "type": "integer",
+                                  "minimum": 1,
+                                  "maximum": 4
+                                }
+                              },
+                              "required": [
+                                "title"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "footer": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "items"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "bigQuote"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "quote": {
+                            "type": "string"
+                          },
+                          "author": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "quote"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "stats"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "stats": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string"
+                                },
+                                "label": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                },
+                                "change": {
+                                  "type": "string"
+                                },
+                                "numLabel": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "label"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "stats"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "timeline"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "date": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                },
+                                "done": {
+                                  "type": "boolean"
+                                },
+                                "hot": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "date",
+                                "title"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "items"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "split"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "left": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "subtitle": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "labelBadge": {
+                                "type": "boolean"
+                              },
+                              "accentColor": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "content": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "text"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "align": {
+                                          "type": "string",
+                                          "enum": [
+                                            "left",
+                                            "center",
+                                            "right"
+                                          ]
+                                        },
+                                        "bold": {
+                                          "type": "boolean"
+                                        },
+                                        "dim": {
+                                          "type": "boolean"
+                                        },
+                                        "fontSize": {
+                                          "type": "number"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "bullets"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "icon": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "ok",
+                                                      "no",
+                                                      "warn"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "ordered": {
+                                          "type": "boolean"
+                                        },
+                                        "icon": {
+                                          "type": "string"
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "language": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "callout"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "style": {
+                                          "type": "string",
+                                          "enum": [
+                                            "quote",
+                                            "info",
+                                            "warning"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "metric"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "change": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "divider"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "image"
+                                        },
+                                        "src": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "src"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "imageRef"
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "ref"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "chart"
+                                        },
+                                        "chartData": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {}
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "chartData"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "mermaid"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "table"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "rows": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "badge": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "rowHeaders": {
+                                          "type": "boolean"
+                                        },
+                                        "striped": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "rows"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "tag"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "section"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "content": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "text"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "align": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "left",
+                                                      "center",
+                                                      "right"
+                                                    ]
+                                                  },
+                                                  "bold": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "dim": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "fontSize": {
+                                                    "type": "number"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "bullets"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "text": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "text"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "icon": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "ok",
+                                                                "no",
+                                                                "warn"
+                                                              ]
+                                                            },
+                                                            "size": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "lead",
+                                                                "big",
+                                                                "sub"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "ordered": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "icon": {
+                                                    "type": "string"
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "items"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "code"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "language": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "callout"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "style": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "quote",
+                                                      "info",
+                                                      "warning"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "metric"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "change": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value",
+                                                  "label"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "divider"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "image"
+                                                  },
+                                                  "src": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "src"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "imageRef"
+                                                  },
+                                                  "ref": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "ref"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "chart"
+                                                  },
+                                                  "chartData": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {}
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "chartData"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "mermaid"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "table"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "color": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "primary",
+                                                                  "accent",
+                                                                  "success",
+                                                                  "warning",
+                                                                  "danger",
+                                                                  "info",
+                                                                  "highlight"
+                                                                ]
+                                                              },
+                                                              "bold": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "badge": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "rowHeaders": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "striped": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "rows"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "tag"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "sidebar": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "dark": {
+                                "type": "boolean"
+                              },
+                              "ratio": {
+                                "type": "number"
+                              },
+                              "valign": {
+                                "type": "string",
+                                "enum": [
+                                  "top",
+                                  "center",
+                                  "bottom"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "right": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "subtitle": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "labelBadge": {
+                                "type": "boolean"
+                              },
+                              "accentColor": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "content": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "text"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "align": {
+                                          "type": "string",
+                                          "enum": [
+                                            "left",
+                                            "center",
+                                            "right"
+                                          ]
+                                        },
+                                        "bold": {
+                                          "type": "boolean"
+                                        },
+                                        "dim": {
+                                          "type": "boolean"
+                                        },
+                                        "fontSize": {
+                                          "type": "number"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "bullets"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "icon": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "ok",
+                                                      "no",
+                                                      "warn"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "ordered": {
+                                          "type": "boolean"
+                                        },
+                                        "icon": {
+                                          "type": "string"
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "items"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "code"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "language": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "callout"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "style": {
+                                          "type": "string",
+                                          "enum": [
+                                            "quote",
+                                            "info",
+                                            "warning"
+                                          ]
+                                        },
+                                        "size": {
+                                          "type": "string",
+                                          "enum": [
+                                            "lead",
+                                            "big",
+                                            "sub"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "metric"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "change": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "divider"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "image"
+                                        },
+                                        "src": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "src"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "imageRef"
+                                        },
+                                        "ref": {
+                                          "type": "string"
+                                        },
+                                        "alt": {
+                                          "type": "string"
+                                        },
+                                        "fit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "contain",
+                                            "cover"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "ref"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "chart"
+                                        },
+                                        "chartData": {
+                                          "type": "object",
+                                          "propertyNames": {
+                                            "type": "string"
+                                          },
+                                          "additionalProperties": {}
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "chartData"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "mermaid"
+                                        },
+                                        "code": {
+                                          "type": "string"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "code"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "table"
+                                        },
+                                        "title": {
+                                          "type": "string"
+                                        },
+                                        "headers": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "rows": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "badge": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        },
+                                        "rowHeaders": {
+                                          "type": "boolean"
+                                        },
+                                        "striped": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "rows"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "tag"
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "text"
+                                      ],
+                                      "additionalProperties": false
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "type": {
+                                          "type": "string",
+                                          "const": "section"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "color": {
+                                          "type": "string",
+                                          "enum": [
+                                            "primary",
+                                            "accent",
+                                            "success",
+                                            "warning",
+                                            "danger",
+                                            "info",
+                                            "highlight"
+                                          ]
+                                        },
+                                        "content": {
+                                          "type": "array",
+                                          "items": {
+                                            "oneOf": [
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "text"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "align": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "left",
+                                                      "center",
+                                                      "right"
+                                                    ]
+                                                  },
+                                                  "bold": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "dim": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "fontSize": {
+                                                    "type": "number"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "bullets"
+                                                  },
+                                                  "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "string"
+                                                        },
+                                                        {
+                                                          "type": "object",
+                                                          "properties": {
+                                                            "text": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "type": "array",
+                                                              "items": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "object",
+                                                                    "properties": {
+                                                                      "text": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "required": [
+                                                                      "text"
+                                                                    ],
+                                                                    "additionalProperties": false
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "icon": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "ok",
+                                                                "no",
+                                                                "warn"
+                                                              ]
+                                                            },
+                                                            "size": {
+                                                              "type": "string",
+                                                              "enum": [
+                                                                "lead",
+                                                                "big",
+                                                                "sub"
+                                                              ]
+                                                            }
+                                                          },
+                                                          "required": [
+                                                            "text"
+                                                          ],
+                                                          "additionalProperties": false
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "ordered": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "icon": {
+                                                    "type": "string"
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "items"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "code"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "language": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "callout"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "style": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "quote",
+                                                      "info",
+                                                      "warning"
+                                                    ]
+                                                  },
+                                                  "size": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "lead",
+                                                      "big",
+                                                      "sub"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "metric"
+                                                  },
+                                                  "value": {
+                                                    "type": "string"
+                                                  },
+                                                  "label": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  },
+                                                  "change": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "value",
+                                                  "label"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "divider"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "image"
+                                                  },
+                                                  "src": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "src"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "imageRef"
+                                                  },
+                                                  "ref": {
+                                                    "type": "string"
+                                                  },
+                                                  "alt": {
+                                                    "type": "string"
+                                                  },
+                                                  "fit": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "contain",
+                                                      "cover"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "ref"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "chart"
+                                                  },
+                                                  "chartData": {
+                                                    "type": "object",
+                                                    "propertyNames": {
+                                                      "type": "string"
+                                                    },
+                                                    "additionalProperties": {}
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "chartData"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "mermaid"
+                                                  },
+                                                  "code": {
+                                                    "type": "string"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "code"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "table"
+                                                  },
+                                                  "title": {
+                                                    "type": "string"
+                                                  },
+                                                  "headers": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "rows": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "color": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "primary",
+                                                                  "accent",
+                                                                  "success",
+                                                                  "warning",
+                                                                  "danger",
+                                                                  "info",
+                                                                  "highlight"
+                                                                ]
+                                                              },
+                                                              "bold": {
+                                                                "type": "boolean"
+                                                              },
+                                                              "badge": {
+                                                                "type": "boolean"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  },
+                                                  "rowHeaders": {
+                                                    "type": "boolean"
+                                                  },
+                                                  "striped": {
+                                                    "type": "boolean"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "rows"
+                                                ],
+                                                "additionalProperties": false
+                                              },
+                                              {
+                                                "type": "object",
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string",
+                                                    "const": "tag"
+                                                  },
+                                                  "text": {
+                                                    "type": "string"
+                                                  },
+                                                  "color": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "primary",
+                                                      "accent",
+                                                      "success",
+                                                      "warning",
+                                                      "danger",
+                                                      "info",
+                                                      "highlight"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "additionalProperties": false
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "text": {
+                                          "type": "string"
+                                        },
+                                        "sidebar": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "label"
+                                      ],
+                                      "additionalProperties": false
+                                    }
+                                  ]
+                                }
+                              },
+                              "dark": {
+                                "type": "boolean"
+                              },
+                              "ratio": {
+                                "type": "number"
+                              },
+                              "valign": {
+                                "type": "string",
+                                "enum": [
+                                  "top",
+                                  "center",
+                                  "bottom"
+                                ]
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "matrix"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "rows": {
+                            "type": "number"
+                          },
+                          "cols": {
+                            "type": "number"
+                          },
+                          "xAxis": {
+                            "type": "object",
+                            "properties": {
+                              "low": {
+                                "type": "string"
+                              },
+                              "high": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "yAxis": {
+                            "type": "object",
+                            "properties": {
+                              "low": {
+                                "type": "string"
+                              },
+                              "high": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "cells": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "items": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "content": {
+                                  "type": "array",
+                                  "items": {
+                                    "oneOf": [
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "text"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "align": {
+                                            "type": "string",
+                                            "enum": [
+                                              "left",
+                                              "center",
+                                              "right"
+                                            ]
+                                          },
+                                          "bold": {
+                                            "type": "boolean"
+                                          },
+                                          "dim": {
+                                            "type": "boolean"
+                                          },
+                                          "fontSize": {
+                                            "type": "number"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "bullets"
+                                          },
+                                          "items": {
+                                            "type": "array",
+                                            "items": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "icon": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "ok",
+                                                        "no",
+                                                        "warn"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "ordered": {
+                                            "type": "boolean"
+                                          },
+                                          "icon": {
+                                            "type": "string"
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "items"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "code"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "language": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "callout"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "style": {
+                                            "type": "string",
+                                            "enum": [
+                                              "quote",
+                                              "info",
+                                              "warning"
+                                            ]
+                                          },
+                                          "size": {
+                                            "type": "string",
+                                            "enum": [
+                                              "lead",
+                                              "big",
+                                              "sub"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "metric"
+                                          },
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "change": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "value",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "divider"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "image"
+                                          },
+                                          "src": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "src"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "imageRef"
+                                          },
+                                          "ref": {
+                                            "type": "string"
+                                          },
+                                          "alt": {
+                                            "type": "string"
+                                          },
+                                          "fit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "contain",
+                                              "cover"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "ref"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "chart"
+                                          },
+                                          "chartData": {
+                                            "type": "object",
+                                            "propertyNames": {
+                                              "type": "string"
+                                            },
+                                            "additionalProperties": {}
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "chartData"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "mermaid"
+                                          },
+                                          "code": {
+                                            "type": "string"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "code"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "table"
+                                          },
+                                          "title": {
+                                            "type": "string"
+                                          },
+                                          "headers": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "rows": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "array",
+                                              "items": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "object",
+                                                    "properties": {
+                                                      "text": {
+                                                        "type": "string"
+                                                      },
+                                                      "color": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                          "primary",
+                                                          "accent",
+                                                          "success",
+                                                          "warning",
+                                                          "danger",
+                                                          "info",
+                                                          "highlight"
+                                                        ]
+                                                      },
+                                                      "bold": {
+                                                        "type": "boolean"
+                                                      },
+                                                      "badge": {
+                                                        "type": "boolean"
+                                                      }
+                                                    },
+                                                    "required": [
+                                                      "text"
+                                                    ],
+                                                    "additionalProperties": false
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          },
+                                          "rowHeaders": {
+                                            "type": "boolean"
+                                          },
+                                          "striped": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "rows"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "tag"
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "text"
+                                        ],
+                                        "additionalProperties": false
+                                      },
+                                      {
+                                        "type": "object",
+                                        "properties": {
+                                          "type": {
+                                            "type": "string",
+                                            "const": "section"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          },
+                                          "color": {
+                                            "type": "string",
+                                            "enum": [
+                                              "primary",
+                                              "accent",
+                                              "success",
+                                              "warning",
+                                              "danger",
+                                              "info",
+                                              "highlight"
+                                            ]
+                                          },
+                                          "content": {
+                                            "type": "array",
+                                            "items": {
+                                              "oneOf": [
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "text"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "align": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "left",
+                                                        "center",
+                                                        "right"
+                                                      ]
+                                                    },
+                                                    "bold": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "dim": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "fontSize": {
+                                                      "type": "number"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "bullets"
+                                                    },
+                                                    "items": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "object",
+                                                            "properties": {
+                                                              "text": {
+                                                                "type": "string"
+                                                              },
+                                                              "items": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "object",
+                                                                      "properties": {
+                                                                        "text": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "required": [
+                                                                        "text"
+                                                                      ],
+                                                                      "additionalProperties": false
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "icon": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "ok",
+                                                                  "no",
+                                                                  "warn"
+                                                                ]
+                                                              },
+                                                              "size": {
+                                                                "type": "string",
+                                                                "enum": [
+                                                                  "lead",
+                                                                  "big",
+                                                                  "sub"
+                                                                ]
+                                                              }
+                                                            },
+                                                            "required": [
+                                                              "text"
+                                                            ],
+                                                            "additionalProperties": false
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "ordered": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "icon": {
+                                                      "type": "string"
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "items"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "code"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "language": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "callout"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "style": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "quote",
+                                                        "info",
+                                                        "warning"
+                                                      ]
+                                                    },
+                                                    "size": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "lead",
+                                                        "big",
+                                                        "sub"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "metric"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    },
+                                                    "label": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    },
+                                                    "change": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "value",
+                                                    "label"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "divider"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "image"
+                                                    },
+                                                    "src": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "src"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "imageRef"
+                                                    },
+                                                    "ref": {
+                                                      "type": "string"
+                                                    },
+                                                    "alt": {
+                                                      "type": "string"
+                                                    },
+                                                    "fit": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "contain",
+                                                        "cover"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "ref"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "chart"
+                                                    },
+                                                    "chartData": {
+                                                      "type": "object",
+                                                      "propertyNames": {
+                                                        "type": "string"
+                                                      },
+                                                      "additionalProperties": {}
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "chartData"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "mermaid"
+                                                    },
+                                                    "code": {
+                                                      "type": "string"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "code"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "table"
+                                                    },
+                                                    "title": {
+                                                      "type": "string"
+                                                    },
+                                                    "headers": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "rows": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "string"
+                                                            },
+                                                            {
+                                                              "type": "object",
+                                                              "properties": {
+                                                                "text": {
+                                                                  "type": "string"
+                                                                },
+                                                                "color": {
+                                                                  "type": "string",
+                                                                  "enum": [
+                                                                    "primary",
+                                                                    "accent",
+                                                                    "success",
+                                                                    "warning",
+                                                                    "danger",
+                                                                    "info",
+                                                                    "highlight"
+                                                                  ]
+                                                                },
+                                                                "bold": {
+                                                                  "type": "boolean"
+                                                                },
+                                                                "badge": {
+                                                                  "type": "boolean"
+                                                                }
+                                                              },
+                                                              "required": [
+                                                                "text"
+                                                              ],
+                                                              "additionalProperties": false
+                                                            }
+                                                          ]
+                                                        }
+                                                      }
+                                                    },
+                                                    "rowHeaders": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "striped": {
+                                                      "type": "boolean"
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "rows"
+                                                  ],
+                                                  "additionalProperties": false
+                                                },
+                                                {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "type": {
+                                                      "type": "string",
+                                                      "const": "tag"
+                                                    },
+                                                    "text": {
+                                                      "type": "string"
+                                                    },
+                                                    "color": {
+                                                      "type": "string",
+                                                      "enum": [
+                                                        "primary",
+                                                        "accent",
+                                                        "success",
+                                                        "warning",
+                                                        "danger",
+                                                        "info",
+                                                        "highlight"
+                                                      ]
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "type",
+                                                    "text"
+                                                  ],
+                                                  "additionalProperties": false
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "text": {
+                                            "type": "string"
+                                          },
+                                          "sidebar": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "required": [
+                                          "type",
+                                          "label"
+                                        ],
+                                        "additionalProperties": false
+                                      }
+                                    ]
+                                  }
+                                },
+                                "accentColor": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "label"
+                              ],
+                              "additionalProperties": false
+                            }
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "cells"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "table"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "headers": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "rows": {
+                            "type": "array",
+                            "items": {
+                              "type": "array",
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "color": {
+                                        "type": "string",
+                                        "enum": [
+                                          "primary",
+                                          "accent",
+                                          "success",
+                                          "warning",
+                                          "danger",
+                                          "info",
+                                          "highlight"
+                                        ]
+                                      },
+                                      "bold": {
+                                        "type": "boolean"
+                                      },
+                                      "badge": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "required": [
+                                      "text"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "rowHeaders": {
+                            "type": "boolean"
+                          },
+                          "striped": {
+                            "type": "boolean"
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "headers",
+                          "rows"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "funnel"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "stages": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "label"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "stages"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "waterfall"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "label": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "number"
+                                },
+                                "isTotal": {
+                                  "type": "boolean"
+                                },
+                                "color": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "label",
+                                "value"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "unit": {
+                            "type": "string"
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "items"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "layout": {
+                            "type": "string",
+                            "const": "manifesto"
+                          },
+                          "accentColor": {
+                            "type": "string",
+                            "enum": [
+                              "primary",
+                              "accent",
+                              "success",
+                              "warning",
+                              "danger",
+                              "info",
+                              "highlight"
+                            ]
+                          },
+                          "style": {
+                            "type": "object",
+                            "properties": {
+                              "bgColor": {
+                                "type": "string"
+                              },
+                              "bgGradient": {
+                                "type": "string"
+                              },
+                              "decorations": {
+                                "type": "boolean"
+                              },
+                              "bgOpacity": {
+                                "type": "number"
+                              },
+                              "footer": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "eyebrow": {
+                            "type": "object",
+                            "properties": {
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "label"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "density": {
+                            "type": "string",
+                            "enum": [
+                              "compact",
+                              "default"
+                            ]
+                          },
+                          "titleSize": {
+                            "type": "string",
+                            "enum": [
+                              "small",
+                              "default",
+                              "large",
+                              "hero"
+                            ]
+                          },
+                          "subtitleSize": {
+                            "type": "string",
+                            "enum": [
+                              "default",
+                              "big",
+                              "lead"
+                            ]
+                          },
+                          "intro": {
+                            "type": "string",
+                            "enum": [
+                              "fade",
+                              "fade-up",
+                              "fade-down",
+                              "slide-left",
+                              "slide-right",
+                              "zoom-in"
+                            ]
+                          },
+                          "staggerMs": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 2000
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "stepLabel": {
+                            "type": "string"
+                          },
+                          "subtitle": {
+                            "type": "string"
+                          },
+                          "items": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "accentColor": {
+                                  "type": "string",
+                                  "enum": [
+                                    "primary",
+                                    "accent",
+                                    "success",
+                                    "warning",
+                                    "danger",
+                                    "info",
+                                    "highlight"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "title"
+                              ],
+                              "additionalProperties": false
+                            }
+                          },
+                          "columns": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4
+                          },
+                          "callout": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string"
+                              },
+                              "label": {
+                                "type": "string"
+                              },
+                              "color": {
+                                "type": "string",
+                                "enum": [
+                                  "primary",
+                                  "accent",
+                                  "success",
+                                  "warning",
+                                  "danger",
+                                  "info",
+                                  "highlight"
+                                ]
+                              },
+                              "align": {
+                                "type": "string",
+                                "enum": [
+                                  "left",
+                                  "center"
+                                ]
+                              },
+                              "leftBar": {
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [
+                              "text"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "required": [
+                          "layout",
+                          "title",
+                          "items"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "reference": {
+                    "type": "string"
+                  },
+                  "branding": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "logo": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "position": {
+                                "default": "top-right",
+                                "type": "string",
+                                "enum": [
+                                  "top-left",
+                                  "top-right",
+                                  "bottom-left",
+                                  "bottom-right"
+                                ]
+                              },
+                              "width": {
+                                "default": 120,
+                                "type": "number",
+                                "exclusiveMinimum": 0
+                              }
+                            },
+                            "required": [
+                              "source",
+                              "position",
+                              "width"
+                            ],
+                            "additionalProperties": false
+                          },
+                          "backgroundImage": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "url"
+                                      },
+                                      "url": {
+                                        "type": "string",
+                                        "format": "uri"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "url"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "base64"
+                                      },
+                                      "data": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "data"
+                                    ],
+                                    "additionalProperties": false
+                                  },
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "path"
+                                      },
+                                      "path": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "path"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                ]
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "cover",
+                                  "contain",
+                                  "fill",
+                                  "auto"
+                                ]
+                              },
+                              "opacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              },
+                              "bgOpacity": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1
+                              }
+                            },
+                            "required": [
+                              "source"
+                            ],
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "slide"
+                ],
                 "additionalProperties": false
               }
             ]
           },
           "audio": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "audio"
+                  },
+                  "source": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "url"
+                          },
+                          "url": {
+                            "type": "string",
+                            "format": "uri"
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "url"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "base64"
+                          },
+                          "data": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "data"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "const": "path"
+                          },
+                          "path": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        },
+                        "required": [
+                          "kind",
+                          "path"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "const": "midi"
+                  },
+                  "source": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "type",
+                  "source"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "duration": {
+            "description": "Duration of the beat. Used only when the text is empty",
+            "type": "number"
+          },
+          "imageParams": {
             "type": "object",
             "properties": {
-              "type": { "type": "string", "const": "audio" },
-              "source": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "openai",
+                  "google",
+                  "replicate",
+                  "mock"
+                ]
+              },
+              "model": {
+                "type": "string"
+              },
+              "quality": {
+                "type": "string"
+              },
+              "style": {
+                "type": "string"
+              },
+              "moderation": {
+                "type": "string"
+              },
+              "baseURL": {
+                "type": "string"
+              },
+              "apiVersion": {
+                "type": "string"
+              },
+              "vertexai_project": {
+                "type": "string"
+              },
+              "vertexai_location": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "audioParams": {
+            "type": "object",
+            "properties": {
+              "padding": {
+                "description": "Padding between beats",
+                "type": "number"
+              },
+              "movieVolume": {
+                "description": "Audio volume of the imported or generated movie",
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              }
+            },
+            "additionalProperties": false
+          },
+          "movieParams": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string",
+                "enum": [
+                  "replicate",
+                  "google",
+                  "mock"
+                ]
+              },
+              "model": {
+                "type": "string"
+              },
+              "fillOption": {
+                "type": "object",
+                "properties": {
+                  "style": {
+                    "default": "aspectFit",
+                    "type": "string",
+                    "enum": [
+                      "aspectFit",
+                      "aspectFill"
+                    ]
+                  }
+                },
+                "required": [
+                  "style"
+                ],
+                "additionalProperties": false,
+                "description": "How to handle aspect ratio differences between image and canvas"
+              },
+              "transition": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "fade",
+                      "slideout_left",
+                      "slideout_right",
+                      "slideout_up",
+                      "slideout_down",
+                      "slidein_left",
+                      "slidein_right",
+                      "slidein_up",
+                      "slidein_down",
+                      "wipeleft",
+                      "wiperight",
+                      "wipeup",
+                      "wipedown",
+                      "wipetl",
+                      "wipetr",
+                      "wipebl",
+                      "wipebr"
+                    ]
+                  },
+                  "duration": {
+                    "default": 0.3,
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 2
+                  }
+                },
+                "required": [
+                  "type",
+                  "duration"
+                ],
+                "additionalProperties": false
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "mono"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "sepia"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "brightness_contrast"
+                        },
+                        "brightness": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "contrast": {
+                          "default": 1,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 3
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "brightness",
+                        "contrast"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "hue"
+                        },
+                        "hue": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -180,
+                          "maximum": 180
+                        },
+                        "saturation": {
+                          "default": 1,
+                          "type": "number",
+                          "minimum": -10,
+                          "maximum": 10
+                        },
+                        "brightness": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -10,
+                          "maximum": 10
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "hue",
+                        "saturation",
+                        "brightness"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "colorbalance"
+                        },
+                        "rs": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "gs": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "bs": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "rm": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "gm": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "bm": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "rh": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "gh": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "bh": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "rs",
+                        "gs",
+                        "bs",
+                        "rm",
+                        "gm",
+                        "bm",
+                        "rh",
+                        "gh",
+                        "bh"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "vibrance"
+                        },
+                        "intensity": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -2,
+                          "maximum": 2
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "intensity"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "negate"
+                        },
+                        "negate_alpha": {
+                          "default": false,
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "negate_alpha"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "colorhold"
+                        },
+                        "color": {
+                          "default": "red",
+                          "type": "string"
+                        },
+                        "similarity": {
+                          "default": 0.01,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "blend": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "color",
+                        "similarity",
+                        "blend"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "colorkey"
+                        },
+                        "color": {
+                          "default": "green",
+                          "type": "string"
+                        },
+                        "similarity": {
+                          "default": 0.01,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "blend": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "color",
+                        "similarity",
+                        "blend"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "blur"
+                        },
+                        "radius": {
+                          "default": 10,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 50
+                        },
+                        "power": {
+                          "default": 1,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 10
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "radius",
+                        "power"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "gblur"
+                        },
+                        "sigma": {
+                          "default": 30,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 100
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "sigma"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "avgblur"
+                        },
+                        "sizeX": {
+                          "default": 10,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100
+                        },
+                        "sizeY": {
+                          "default": 10,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "sizeX",
+                        "sizeY"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "unsharp"
+                        },
+                        "luma_msize_x": {
+                          "default": 5,
+                          "type": "number",
+                          "minimum": 3,
+                          "maximum": 23
+                        },
+                        "luma_msize_y": {
+                          "default": 5,
+                          "type": "number",
+                          "minimum": 3,
+                          "maximum": 23
+                        },
+                        "luma_amount": {
+                          "default": 1,
+                          "type": "number",
+                          "minimum": -2,
+                          "maximum": 5
+                        },
+                        "chroma_msize_x": {
+                          "default": 5,
+                          "type": "number",
+                          "minimum": 3,
+                          "maximum": 23
+                        },
+                        "chroma_msize_y": {
+                          "default": 5,
+                          "type": "number",
+                          "minimum": 3,
+                          "maximum": 23
+                        },
+                        "chroma_amount": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -2,
+                          "maximum": 5
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "luma_msize_x",
+                        "luma_msize_y",
+                        "luma_amount",
+                        "chroma_msize_x",
+                        "chroma_msize_y",
+                        "chroma_amount"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "edgedetect"
+                        },
+                        "low": {
+                          "default": 0.2,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "high": {
+                          "default": 0.4,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "mode": {
+                          "default": "wires",
+                          "type": "string",
+                          "enum": [
+                            "wires",
+                            "colormix",
+                            "canny"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "low",
+                        "high",
+                        "mode"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "sobel"
+                        },
+                        "planes": {
+                          "default": 15,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 15
+                        },
+                        "scale": {
+                          "default": 1,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 65535
+                        },
+                        "delta": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -65535,
+                          "maximum": 65535
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "planes",
+                        "scale",
+                        "delta"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "emboss"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "glitch"
+                        },
+                        "intensity": {
+                          "default": 20,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100
+                        },
+                        "style": {
+                          "default": "noise",
+                          "type": "string",
+                          "enum": [
+                            "noise",
+                            "blend"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "intensity",
+                        "style"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "grain"
+                        },
+                        "intensity": {
+                          "default": 10,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 100
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "intensity"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "hflip"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "vflip"
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "rotate"
+                        },
+                        "angle": {
+                          "default": 0,
+                          "type": "number"
+                        },
+                        "fillcolor": {
+                          "default": "black",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "angle",
+                        "fillcolor"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "transpose"
+                        },
+                        "dir": {
+                          "default": "clock",
+                          "type": "string",
+                          "enum": [
+                            "cclock",
+                            "clock",
+                            "cclock_flip",
+                            "clock_flip"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "dir"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "vignette"
+                        },
+                        "angle": {
+                          "default": 0.6283185307179586,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 3.141592653589793
+                        },
+                        "x0": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "y0": {
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "mode": {
+                          "default": "forward",
+                          "type": "string",
+                          "enum": [
+                            "forward",
+                            "backward"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "angle",
+                        "mode"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "fade"
+                        },
+                        "mode": {
+                          "default": "in",
+                          "type": "string",
+                          "enum": [
+                            "in",
+                            "out"
+                          ]
+                        },
+                        "start_frame": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": 0
+                        },
+                        "nb_frames": {
+                          "default": 25,
+                          "type": "number",
+                          "minimum": 1
+                        },
+                        "alpha": {
+                          "default": false,
+                          "type": "boolean"
+                        },
+                        "color": {
+                          "default": "black",
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "mode",
+                        "start_frame",
+                        "nb_frames",
+                        "alpha",
+                        "color"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "pixelize"
+                        },
+                        "width": {
+                          "default": 16,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 1000
+                        },
+                        "height": {
+                          "default": 16,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 1000
+                        },
+                        "mode": {
+                          "default": "avg",
+                          "type": "string",
+                          "enum": [
+                            "avg",
+                            "min",
+                            "max"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "width",
+                        "height",
+                        "mode"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "pseudocolor"
+                        },
+                        "preset": {
+                          "default": "magma",
+                          "type": "string",
+                          "enum": [
+                            "magma",
+                            "inferno",
+                            "plasma",
+                            "viridis",
+                            "turbo",
+                            "cividis",
+                            "range1",
+                            "range2",
+                            "shadows",
+                            "highlights",
+                            "solar",
+                            "nominal",
+                            "preferred",
+                            "total"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "preset"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "tmix"
+                        },
+                        "frames": {
+                          "default": 3,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 1024
+                        },
+                        "weights": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "frames"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "lagfun"
+                        },
+                        "decay": {
+                          "default": 0.95,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 1
+                        },
+                        "planes": {
+                          "default": 15,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 15
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "decay",
+                        "planes"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "threshold"
+                        },
+                        "planes": {
+                          "default": 15,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 15
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "planes"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "elbg"
+                        },
+                        "codebook_length": {
+                          "default": 256,
+                          "type": "number",
+                          "minimum": 1,
+                          "maximum": 256
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "codebook_length"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "lensdistortion"
+                        },
+                        "k1": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        },
+                        "k2": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -1,
+                          "maximum": 1
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "k1",
+                        "k2"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "chromashift"
+                        },
+                        "cbh": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -255,
+                          "maximum": 255
+                        },
+                        "cbv": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -255,
+                          "maximum": 255
+                        },
+                        "crh": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -255,
+                          "maximum": 255
+                        },
+                        "crv": {
+                          "default": 0,
+                          "type": "number",
+                          "minimum": -255,
+                          "maximum": 255
+                        },
+                        "edge": {
+                          "default": "smear",
+                          "type": "string",
+                          "enum": [
+                            "smear",
+                            "wrap"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "cbh",
+                        "cbv",
+                        "crh",
+                        "crv",
+                        "edge"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "deflicker"
+                        },
+                        "size": {
+                          "default": 5,
+                          "type": "number",
+                          "minimum": 2,
+                          "maximum": 129
+                        },
+                        "mode": {
+                          "default": "am",
+                          "type": "string",
+                          "enum": [
+                            "am",
+                            "gm",
+                            "hm",
+                            "qm",
+                            "cm",
+                            "pm",
+                            "median"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "size",
+                        "mode"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "dctdnoiz"
+                        },
+                        "sigma": {
+                          "default": 10,
+                          "type": "number",
+                          "minimum": 0,
+                          "maximum": 999
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "sigma"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "custom"
+                        },
+                        "filter": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "type",
+                        "filter"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              },
+              "vertexai_project": {
+                "type": "string"
+              },
+              "vertexai_location": {
+                "type": "string"
+              },
+              "firstFrameImageName": {
+                "description": "Reference an imageRefs key for the first frame (image-to-video input), or '$beatImage' for the beat's own generated image",
+                "type": "string"
+              },
+              "lastFrameImageName": {
+                "description": "Reference an imageRefs key for the last frame (image-to-video interpolation), or '$beatImage' for the beat's own generated image",
+                "type": "string"
+              },
+              "frameFillColor": {
+                "description": "Fill color used when padding firstFrame/lastFrame reference images to the canvas aspect ratio (e.g. '#F7F6F4'). Default: black",
+                "type": "string",
+                "pattern": "^(#|0x)?[0-9a-fA-F]{6}([0-9a-fA-F]{2})?$|^[a-zA-Z]+$"
+              },
+              "referenceImages": {
+                "description": "Style/asset reference images (Veo 3.1). Mutually exclusive with imageName/lastFrameImageName",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "imageName": {
+                      "type": "string",
+                      "description": "Reference an imageRefs key"
+                    },
+                    "referenceType": {
+                      "type": "string",
+                      "enum": [
+                        "ASSET",
+                        "STYLE"
+                      ],
+                      "description": "ASSET: scene/object/character, STYLE: aesthetics/lighting"
+                    }
+                  },
+                  "required": [
+                    "imageName",
+                    "referenceType"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "concurrency": {
+                "description": "Max concurrent movie generation requests",
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "maximum": 9007199254740991
+              },
+              "generateAudio": {
+                "description": "Request audio generation in the video (model-dependent)",
+                "type": "boolean"
+              },
+              "speed": {
+                "description": "Speed of the video. 1.0 is normal speed. 0.5 is half speed. 2.0 is double speed.",
+                "type": "number"
+              }
+            },
+            "additionalProperties": false
+          },
+          "soundEffectParams": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "default": "replicate",
+                "type": "string",
+                "enum": [
+                  "replicate"
+                ]
+              },
+              "model": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "lipSyncParams": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "htmlImageParams": {
+            "type": "object",
+            "properties": {
+              "model": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "speechOptions": {
+            "type": "object",
+            "properties": {
+              "speed": {
+                "type": "number"
+              },
+              "instruction": {
+                "type": "string"
+              },
+              "decoration": {
+                "type": "string"
+              },
+              "stability": {
+                "type": "number"
+              },
+              "similarity_boost": {
+                "type": "number"
+              }
+            },
+            "additionalProperties": false
+          },
+          "textSlideParams": {
+            "type": "object",
+            "properties": {
+              "cssStyles": {
                 "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              }
+            },
+            "required": [
+              "cssStyles"
+            ],
+            "additionalProperties": false
+          },
+          "captionParams": {
+            "type": "object",
+            "properties": {
+              "lang": {
+                "type": "string"
+              },
+              "styles": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "captionSplit": {
+                "default": "none",
+                "type": "string",
+                "enum": [
+                  "none",
+                  "estimate"
+                ]
+              },
+              "textSplit": {
+                "oneOf": [
                   {
                     "type": "object",
                     "properties": {
-                      "kind": { "type": "string", "const": "url" },
-                      "url": { "type": "string", "format": "uri" }
+                      "type": {
+                        "type": "string",
+                        "const": "none"
+                      }
                     },
-                    "required": ["kind", "url"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   },
                   {
                     "type": "object",
                     "properties": {
-                      "kind": { "type": "string", "const": "path" },
-                      "path": { "type": "string" }
+                      "type": {
+                        "type": "string",
+                        "const": "delimiters"
+                      },
+                      "delimiters": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
-                    "required": ["kind", "path"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": false
                   }
                 ]
+              },
+              "bottomOffset": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 100
               }
             },
-            "required": ["type", "source"],
             "additionalProperties": false
           },
-          "duration": { "type": "number" },
-          "imagePrompt": { "type": "string" },
-          "moviePrompt": { "type": "string" }
+          "images": {
+            "description": "Beat-local media references. Same schema as imageParams.images. Merged with global refs (local takes precedence).",
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "image"
+                    },
+                    "source": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "url"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "url"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "base64"
+                            },
+                            "data": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "data"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "path"
+                            },
+                            "path": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "path"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "source"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "imagePrompt"
+                    },
+                    "prompt": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "canvasSize": {
+                      "type": "object",
+                      "properties": {
+                        "width": {
+                          "type": "number"
+                        },
+                        "height": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "width",
+                        "height"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "referenceImageName": {
+                      "description": "Reference another imageRefs key as input for image generation. Sugar for references[0].name",
+                      "type": "string"
+                    },
+                    "referenceImage": {
+                      "description": "Direct source (path/url/base64) as reference image for generation. Sugar for references[0].source",
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "url"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "url"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "base64"
+                            },
+                            "data": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "data"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "path"
+                            },
+                            "path": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "path"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "references": {
+                      "description": "Reference images (by imageRefs key or direct source) with optional role labels",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "An imageRefs key to use as a reference image",
+                            "type": "string"
+                          },
+                          "source": {
+                            "description": "Direct source (path/url) to use as a reference image",
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "url"
+                                  },
+                                  "url": {
+                                    "type": "string",
+                                    "format": "uri"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "url"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "base64"
+                                  },
+                                  "data": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "data"
+                                ],
+                                "additionalProperties": false
+                              },
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "path"
+                                  },
+                                  "path": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "path"
+                                ],
+                                "additionalProperties": false
+                              }
+                            ]
+                          },
+                          "label": {
+                            "description": "Role of this reference (e.g. 'the firefighter Travis Kane'), injected into the prompt as a preamble",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "prompt"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "movie"
+                    },
+                    "source": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "url"
+                            },
+                            "url": {
+                              "type": "string",
+                              "format": "uri"
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "url"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "base64"
+                            },
+                            "data": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "data"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "const": "path"
+                            },
+                            "path": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "kind",
+                            "path"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "source"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "const": "moviePrompt"
+                    },
+                    "prompt": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "imageName": {
+                      "description": "Reference an imageRefs key to use as image-to-video input",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "type",
+                    "prompt"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          },
+          "imageNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "imagePrompt": {
+            "type": "string"
+          },
+          "moviePrompt": {
+            "type": "string"
+          },
+          "soundEffectPrompt": {
+            "type": "string"
+          },
+          "htmlPrompt": {
+            "type": "object",
+            "properties": {
+              "systemPrompt": {
+                "default": "",
+                "type": "string"
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1
+              },
+              "data": {},
+              "images": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {}
+              }
+            },
+            "required": [
+              "systemPrompt",
+              "prompt"
+            ],
+            "additionalProperties": false
+          },
+          "enableLipSync": {
+            "description": "Enable lip sync generation for this beat",
+            "type": "boolean"
+          },
+          "hidden": {
+            "description": "Hide this beat from the presentation",
+            "type": "boolean"
+          }
         },
+        "required": [
+          "text"
+        ],
         "additionalProperties": false
-      },
-      "minItems": 1
+      }
     },
-    "imagePath": { "type": "string" },
-    "__test_invalid__": { "type": "boolean" }
+    "imagePath": {
+      "type": "string"
+    },
+    "__test_invalid__": {
+      "type": "boolean"
+    }
   },
-  "required": ["$mulmocast", "beats"],
-  "additionalProperties": false
+  "required": [
+    "$mulmocast",
+    "canvasSize",
+    "speechParams",
+    "imageParams",
+    "movieParams",
+    "soundEffectParams",
+    "audioParams",
+    "lang",
+    "beats"
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "__schema0": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "Element id. Used as an HTML id and as a CSS selector in the generated animation script, so it must match [A-Za-z_][A-Za-z0-9_-]*.",
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+        },
+        "x": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "y": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "w": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "h": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "pos": {
+          "description": "Position by anchor point [x, y]",
+          "type": "array",
+          "prefixItems": [
+            {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          ]
+        },
+        "bc": {
+          "description": "Background color",
+          "type": "string"
+        },
+        "opacity": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "rotate": {
+          "type": "number"
+        },
+        "scale": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          ]
+        },
+        "translate": {
+          "type": "array",
+          "prefixItems": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "cornerRadius": {
+          "type": "number"
+        },
+        "borderWidth": {
+          "type": "number"
+        },
+        "borderColor": {
+          "type": "string"
+        },
+        "shadow": {
+          "type": "object",
+          "properties": {
+            "color": {
+              "default": "black",
+              "type": "string"
+            },
+            "offset": {
+              "default": [
+                1,
+                1
+              ],
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "opacity": {
+              "default": 0.5,
+              "type": "number"
+            },
+            "radius": {
+              "default": 1,
+              "type": "number"
+            }
+          },
+          "required": [
+            "color",
+            "offset",
+            "opacity",
+            "radius"
+          ],
+          "additionalProperties": false
+        },
+        "clip": {
+          "type": "boolean"
+        },
+        "text": {
+          "type": "string"
+        },
+        "fontSize": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "fontWeight": {
+          "type": "string"
+        },
+        "textColor": {
+          "type": "string"
+        },
+        "textAlign": {
+          "type": "string",
+          "enum": [
+            "center",
+            "left",
+            "right"
+          ]
+        },
+        "lineHeight": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "img": {
+          "description": "Image URL or image:ref",
+          "type": "string"
+        },
+        "imgFit": {
+          "default": "contain",
+          "type": "string",
+          "enum": [
+            "contain",
+            "cover",
+            "fill"
+          ]
+        },
+        "to": {
+          "description": "Transition animation",
+          "type": "object",
+          "properties": {
+            "opacity": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "rotate": {
+              "type": "number"
+            },
+            "scale": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "number"
+                    }
+                  ]
+                }
+              ]
+            },
+            "translate": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            },
+            "bc": {
+              "type": "string"
+            },
+            "timing": {
+              "description": "Animation timing [start, end] as ratio 0.0-1.0 of beat duration",
+              "default": [
+                0,
+                1
+              ],
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "loop": {
+          "description": "Loop animation",
+          "type": "object",
+          "properties": {
+            "style": {
+              "type": "string",
+              "enum": [
+                "vibrate",
+                "blink",
+                "wiggle",
+                "spin",
+                "shift",
+                "bounce",
+                "pulse"
+              ]
+            },
+            "count": {
+              "description": "Number of loop iterations. 0 = infinite",
+              "type": "number"
+            },
+            "delta": {
+              "description": "Distance for vibrate / angle for wiggle",
+              "type": "number"
+            },
+            "duration": {
+              "description": "Duration of one cycle in seconds",
+              "type": "number"
+            },
+            "direction": {
+              "description": "Direction for shift animation",
+              "type": "string",
+              "enum": [
+                "n",
+                "s",
+                "e",
+                "w"
+              ]
+            },
+            "clockwise": {
+              "description": "Spin direction. Default: true",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "style"
+          ],
+          "additionalProperties": false
+        },
+        "elements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/__schema0"
+          }
+        }
+      },
+      "required": [
+        "imgFit"
+      ],
+      "additionalProperties": false
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "scripting": "npx tsx ./src/cli/bin.ts tool scripting",
     "prompt": "npx tsx ./src/cli/bin.ts tool prompt",
     "schema": "npx tsx ./src/cli/bin.ts tool schema",
+    "schema:write": "npx tsx ./src/cli/bin.ts tool schema > assets/schemas/mulmo_script.json",
     "markdown": "npx tsx ./src/cli/bin.ts markdown",
     "html": "npx tsx ./src/cli/bin.ts html",
     "story_to_script": "npx tsx ./src/cli/bin.ts tool story_to_script",

--- a/plans/fix-bundled-schema-freshness.md
+++ b/plans/fix-bundled-schema-freshness.md
@@ -1,0 +1,47 @@
+# 同梱スキーマを再生成し、鮮度を CI で守る
+
+`#1542`。
+
+## 実測した現状
+
+| | bytes |
+|---|---:|
+| live（`mulmo tool schema`） | **704,645** |
+| 同梱 `assets/schemas/mulmo_script.json` | **8,326** |
+
+issue 執筆時は 161KB vs 5KB。**live 側がさらに4倍以上に育っている**。
+
+## 到達性 — issue が書いていなかったこと
+
+`assets/schemas/mulmo_script.json` は v0.0.26 で **MCP サーバー用**に追加されたが、
+**`src/mcp/server.ts` は 2025-06-25（`19599951` "html prompt"）に読むのをやめて** `html_prompt.json` に切り替えている。
+
+変数名は今も `MULMO_SCRIPT_JSON_SCHEMA` のまま `html_prompt.json` を指しており、
+**これが14か月気づかれなかった直接の原因**。
+
+つまりこのファイルは **repo 内に読み手がいないまま npm パッケージに載り続けていた**。
+読み手が居ない以上、正しさを保てるのは**チェックだけ**であり、それが無かったから静かにずれた。
+
+## やること
+
+1. `assets/schemas/mulmo_script.json` を再生成（+696KB）
+2. `yarn schema:write` を追加（再生成の正式な手順を1つにする）
+3. **鮮度チェックをテストとして**追加。新しい CI ジョブは足さない —
+   生成は `z.toJSONSchema(mulmoScriptSchema)` の1呼び出しで、`mulmo tool schema` が
+   しているのと同じものなので、spawn するものが無い。既存の `ci_test` に載る
+4. `src/mcp/server.ts` の変数名を実態（`HTML_PROMPT_JSON_SCHEMA`）に合わせる
+
+### チェックが CLI と同じものを比べていること
+
+`GraphAILogger.info` は `console.log` 経由なので末尾に改行が付く。
+テストは `JSON.stringify(...) + "\n"` と比較する。**実測で `yarn schema` のリダイレクト出力と完全一致**。
+
+### `yarn format` との競合は無い
+
+`format` の glob は `assets/templates` / `assets/styles` / `assets/html/js` のみで、
+`assets/schemas` は対象外。
+
+## 確認すること
+
+- **チェックが実際に落ちること**を変異で確認する。特に「元の stale な 8KB ファイルに戻す」ケース
+- 出力が決定的であること（2回生成して同一）

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,8 +20,10 @@ dotenv.config({ quiet: true });
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Load MulmoScript JSON Schema from file
-const MULMO_SCRIPT_JSON_SCHEMA = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../../assets/schemas/html_prompt.json"), "utf8"));
+// The `mulmoScript` argument's shape, as advertised to an MCP client. It is html_prompt.json,
+// not mulmo_script.json — the switch was deliberate, but the old name outlived it and is why
+// nobody noticed that mulmo_script.json had no reader left for fourteen months.
+const HTML_PROMPT_JSON_SCHEMA = JSON.parse(fs.readFileSync(path.resolve(__dirname, "../../assets/schemas/html_prompt.json"), "utf8"));
 
 const server = new Server(
   {
@@ -68,7 +70,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               enum: ["movie", "pdf"],
               description: "Command to execute: 'movie' to generate video, 'pdf' to generate PDF",
             },
-            mulmoScript: MULMO_SCRIPT_JSON_SCHEMA,
+            mulmoScript: HTML_PROMPT_JSON_SCHEMA,
             options: {
               type: "object",
               description: "Optional generation parameters",

--- a/test/zod/test_bundled_schema_freshness.ts
+++ b/test/zod/test_bundled_schema_freshness.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { z } from "zod";
+
+import { mulmoScriptSchema } from "../../src/types/schema.js";
+
+/**
+ * `assets/schemas/mulmo_script.json` ships in the npm package, and nothing in this repository
+ * reads it — `src/mcp/server.ts` stopped doing so in June 2025 and still calls the value it
+ * loads MULMO_SCRIPT_JSON_SCHEMA while pointing at html_prompt.json, which is why nobody
+ * noticed. With no reader, the only thing that can keep it true is a check.
+ *
+ * It had drifted for fourteen months: 8,326 bytes against a live schema of 704,645, missing
+ * html_tailwind, elements and vision entirely.
+ *
+ * This runs in the ordinary suite rather than as its own CI job because the generation is one
+ * call — the same one `mulmo tool schema` makes — so there is nothing to spawn.
+ */
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const BUNDLED = path.resolve(__dirname, "../../assets/schemas/mulmo_script.json");
+
+/**
+ * The bytes `yarn schema:write` produces. `GraphAILogger.info` goes through console.log, which
+ * appends the newline — so the file is the JSON plus one, and this has to say so or every run
+ * would report a one-byte drift.
+ */
+const generated = (): string => JSON.stringify(z.toJSONSchema(mulmoScriptSchema), null, 2) + "\n";
+
+test("the bundled schema is what the current mulmoScriptSchema produces", () => {
+  const bundled = fs.readFileSync(BUNDLED, "utf8");
+  assert.strictEqual(bundled, generated(), "assets/schemas/mulmo_script.json is stale — regenerate it with `yarn schema:write` and commit the result");
+});
+
+test("the bundled schema carries the beat types the schema declares", () => {
+  // A whole-file comparison fails on a one-character change and says nothing about what moved.
+  // These are the three that had gone missing while the file sat unread, so they are the ones
+  // worth naming: a future drift that drops a beat type reads as this test, not as a diff.
+  const bundled = fs.readFileSync(BUNDLED, "utf8");
+  ["html_tailwind", "elements", "vision"].forEach((declared) => {
+    assert.ok(bundled.includes(`"${declared}"`), `${declared} is missing from the bundled schema`);
+  });
+});


### PR DESCRIPTION
## Summary

`#1542`。同梱スキーマを再生成し、**二度と静かにずれないようチェックを入れます**。

| | bytes |
|---|---:|
| live（`mulmo tool schema`） | **704,645** |
| 同梱（変更前） | **8,326** |

issue 執筆時は 161KB vs 5KB でした。**live 側がさらに4倍以上に育っています**。

## なぜ半年（実際は14か月）ずれたのか — issue に無かった部分

`assets/schemas/mulmo_script.json` は v0.0.26 で **MCP サーバー用**に追加されましたが、
**`src/mcp/server.ts` は 2025-06-25（`19599951` "html prompt"）に読むのをやめ**、`html_prompt.json` に切り替えています。

そして読み込み先の変数名は**今も `MULMO_SCRIPT_JSON_SCHEMA` のまま**でした。**これが気づかれなかった直接の原因**です。

つまりこのファイルは **14か月間、リポジトリ内に読み手が1つも無いまま npm パッケージに載り続けていました**。読み手が居ない以上、正しさを保てるのは**チェックだけ**で、それが無かったから静かにずれました。

## 入れたもの

1. **再生成**（+696KB）
2. **`yarn schema:write`** — 再生成の正式な手順を1つに
3. **鮮度チェックを「テスト」として** — 新しい CI ジョブは足していません。生成は `z.toJSONSchema(mulmoScriptSchema)` の**1呼び出し**で、`mulmo tool schema` がしているのと同じものなので spawn するものがなく、既存の `ci_test`（22.x / 24.x）に載ります
4. **`MULMO_SCRIPT_JSON_SCHEMA` → `HTML_PROMPT_JSON_SCHEMA`** — 1行ですが、14か月の直接の原因です。**MCP のワイヤ側のプロパティ名 `mulmoScript` は触っていません**

## Items to Confirm / Review

- **704KB のコミット**です。「読み手が無いなら消す」案もありましたが、**ご指示どおり「維持する」方**を採りました。以後スキーマを変えるたびにこのファイルの差分が出ます（`yarn schema:write` で再生成）
- **チェックは末尾改行込みで比較します。** `GraphAILogger.info` は `console.log` 経由なので出力に改行が付きます。テストは `JSON.stringify(...) + "\n"` と比べており、**CLI の実出力とバイト単位で一致することを実測**しています（想定ではなく）
- **`yarn format` とは競合しません。** glob は `assets/templates` / `assets/styles` / `assets/html/js` のみで `assets/schemas` は対象外
- **2本目のテストは `html_tailwind` / `elements` / `vision` を名指しします。** 全文比較は1文字で落ちる代わりに「何が動いたか」を何も言いません。この3つは**実際に欠落していたもの**なので、将来 beat 型が落ちたときに diff ではなくテスト名で分かります

## 検証

**チェックが実際に落ちることを変異で確認**しました（実際に起きていたバグそのものを含む）:

| 変異 | 結果 |
|---|---|
| **元の stale な 8KB ファイルに戻す** | **0 pass / 2 fail** |
| 1バイト削る | 1 pass / 1 fail |
| 末尾改行を削る | 1 pass / 1 fail |
| 同梱側で beat 型をリネーム | 0 pass / 2 fail |

- 出力は**決定的**（2回生成して同一）
- `yarn lint` error 0（warning 28 は既存）/ `yarn build` OK / `typecheck:test` **0件**
- 全テスト **1188 pass / 0 fail / 4 skipped**

## User Prompt

> 1527以降のissueをまとめてなおしてからpublishだね
> （同梱スキーマの扱いについて）再生成 + CI 鮮度チェック（issue の当初案）

（`#1527` / `#1535` / `#1542` / `#1547` の4件。`#1535`→`#1569`、`#1547`→`#1570` 完了済み。残りは `#1527`。）

Closes #1542
