### PR TITLE
fix: a slide beat contributes a fragment to mulmo html, not a document

### DIFF
--- a/plans/fix-slide-beat-fragment.md
+++ b/plans/fix-slide-beat-fragment.md
@@ -1,0 +1,42 @@
+# slide beat をフル HTML 文書ではなく fragment にする
+
+`#1527`。
+
+## 再現（報告や過去の出力ではなく、今のコードで）
+
+`image_plugins/slide.ts` の `html()` を4回呼んで連結した結果:
+
+| | before | after |
+|---|---:|---:|
+| `<!DOCTYPE html>` | 4 | **0** |
+| `cdn.tailwindcss.com` | 4 | **0** |
+| `tailwind.config = ` | 4 | **0** |
+| `html, body { ... }` | 4 | **0** |
+
+`actions/html.ts` はこれを `<body>` にそのまま連結するので、4スライドの export は
+**Tailwind CDN を5回**読み、`tailwind.config` を**4回上書き**し、
+`html, body { overflow: hidden }` が**ページ全体に漏れて**縦に並ぶ出力がスクロール不能になっていた。
+
+## 構図 — ブラウザ経路は既に解決済みだった
+
+`src/utils/beat_html/slide.ts`（**ブラウザ経路**）は既に `generateSlideFragment` を使っている。
+`src/utils/image_plugins/slide.ts` の **dump 経路だけ**が `generateSlideHTML` のままだった。
+つまり新しい設計を発明するのではなく、**同じ変更を dump 経路にも入れる**話。
+
+PNG 経路（`processSlide`）は `generateSlideHTML` のままでよい — **そこではスライドがページそのもの**だから。
+
+## 設計
+
+- `dumpHtml` は fragment を返す。**fragment 自身の css は隣に出す** — `scopeClass` に閉じており、
+  deck が呼び出しごとに一意な class を振るため（`mulmo-slide-0`, `mulmo-slide-1`, … を実測）
+- **共有物はページのもの**: Tailwind / chart / mermaid ランタイムは `actions/html.ts` が既に head に1回だけ置いている。
+  足りなかった `slideUtilityCss` を head に追加する
+- **箱は plugin 側で付ける**。fragment は `w-full h-full` なので箱が無いと**黙って潰れる**
+  （`#1567` の swipe root と同じクラスの失敗）。`actions/html.ts` は beat の種別を見ずに連結するので、
+  ホスト側に任せられない
+
+## 確認すること
+
+- 4サイトの計測（上の表）が実際に 0 になること
+- **実機**: export を作ってブラウザで開き、**スクロールできること**、4スライドが描画されること、
+  console error が無いこと。build が通ることではなく、これが症状の反対側

--- a/src/actions/html.ts
+++ b/src/actions/html.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { isNull } from "graphai";
-import { escapeHtml } from "@mulmocast/deck";
+import { escapeHtml, slideUtilityCss } from "@mulmocast/deck";
 import { MulmoStudioContext } from "../types/index.js";
 import { localizedText } from "../utils/utils.js";
 import { writingMessage } from "../utils/file.js";
@@ -71,6 +71,9 @@ const generateHtmlContent = (context: MulmoStudioContext, imageWidth?: string): 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <!-- Mermaid CDN -->
     <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+    <!-- The utilities every slide fragment is written against. Shared, so it belongs to the
+         page: a slide beat emits only its own scoped rules. -->
+    <style>${slideUtilityCss}</style>
   </head>
   <body class="min-h-screen flex flex-col">
 ${html}

--- a/src/utils/image_plugins/slide.ts
+++ b/src/utils/image_plugins/slide.ts
@@ -1,7 +1,7 @@
 import nodePath from "node:path";
 import { pathToFileURL } from "node:url";
 import { BeatRenderParams, ImageProcessorParams } from "../../types/index.js";
-import { generateSlideHTML } from "@mulmocast/deck";
+import { generateSlideFragment, generateSlideHTML } from "@mulmocast/deck";
 import type { SlideLayout, SlideTheme, ContentBlock, MulmoSlideMedia, SlideBranding, ResolvedBranding } from "@mulmocast/deck";
 import { renderHTMLToImage } from "../html_render.js";
 import { parrotingImagePath } from "./utils.js";
@@ -181,6 +181,24 @@ const processSlide = async (params: ImageProcessorParams) => {
   return imagePath;
 };
 
+/**
+ * A slide beat as markup for the export document, not as a document of its own.
+ *
+ * `generateSlideHTML` above is right for the PNG path, where the slide IS the page. Here the
+ * result is concatenated into one `<body>` alongside every other beat, so a full document per
+ * slide meant N Tailwind CDN loads, N `tailwind.config` assignments racing each other, and an
+ * `html, body { overflow: hidden }` escaping into the export page — which made a document of
+ * stacked slides unscrollable. `beat_html/slide.ts` already draws the browser path from
+ * `generateSlideFragment`; this is the same change for the dump path.
+ *
+ * The fragment's own css is emitted next to it because it is confined to `scopeClass`, which
+ * deck makes unique per call. What is SHARED — Tailwind, the chart and mermaid runtimes,
+ * `slideUtilityCss` — belongs to the page and is `actions/html.ts`'s job, once.
+ *
+ * The box is here rather than left to the host: the fragment is `w-full h-full`, so without
+ * one it collapses to nothing, and `actions/html.ts` concatenates beats without knowing which
+ * of them is a slide.
+ */
 const dumpHtml = async (params: BeatRenderParams) => {
   const { beat } = params;
   if (!beat.image || beat.image.type !== imageType) return;
@@ -189,7 +207,8 @@ const dumpHtml = async (params: BeatRenderParams) => {
   const slide = resolveSlide(params);
   const reference = (beat.image as MulmoSlideMedia).reference;
   const resolvedBranding = await resolveAndConvertBranding(params);
-  return generateSlideHTML(theme, slide, reference, resolvedBranding);
+  const fragment = generateSlideFragment(theme, slide, { reference, branding: resolvedBranding });
+  return `<style>${fragment.css}</style>\n<div style="aspect-ratio: 16 / 9;">${fragment.html}</div>`;
 };
 
 export const process = processSlide;

--- a/test/image_plugins/test_slide_dump_fragment.ts
+++ b/test/image_plugins/test_slide_dump_fragment.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert";
+
+import { html as slideHtml } from "../../src/utils/image_plugins/slide.js";
+import { createMockContext } from "../actions/utils.js";
+
+/**
+ * `mulmo html` concatenates every beat's `html()` into one `<body>`. A slide beat used to
+ * return what `generateSlideHTML` produces — a whole document — so an export with four slides
+ * loaded the Tailwind CDN five times, assigned `tailwind.config` four times over each other,
+ * and leaked `html, body { overflow: hidden }` into the page, which left a document of
+ * stacked slides unscrollable.
+ *
+ * The PNG path still uses `generateSlideHTML`, and should: there the slide IS the page.
+ */
+const slideBeat = (title: string) => ({
+  text: "",
+  image: { type: "slide" as const, slide: { layout: "title" as const, title, subtitle: "S" } },
+});
+
+const render = async (titles: string[]): Promise<string> => {
+  const context = createMockContext();
+  const parts: string[] = [];
+  for (const title of titles) {
+    parts.push(String((await slideHtml!({ beat: slideBeat(title), context })) ?? ""));
+  }
+  return parts.join("\n\n");
+};
+
+const occurrences = (body: string, pattern: RegExp): number => (body.match(pattern) ?? []).length;
+
+test("a slide beat contributes a fragment, not a document", async () => {
+  const body = await render(["A"]);
+  assert.strictEqual(occurrences(body, /<!DOCTYPE html>/gi), 0, "no doctype");
+  assert.strictEqual(occurrences(body, /<html[\s>]/gi), 0, "no <html>");
+  assert.strictEqual(occurrences(body, /<head[\s>]/gi), 0, "no <head>");
+  assert.ok(body.includes("mulmo-slide-"), "the slide's own markup is there");
+});
+
+test("nothing shared is emitted per beat", async () => {
+  // Each of these is what a whole document per slide brought with it, and each is the page's
+  // job exactly once — the CDN loads, the config assignment, and the global reset that made
+  // the export unscrollable.
+  const body = await render(["A", "B", "C", "D"]);
+  assert.strictEqual(occurrences(body, /cdn\.tailwindcss\.com/g), 0, "Tailwind belongs to the page");
+  assert.strictEqual(occurrences(body, /tailwind\.config\s*=/g), 0, "no config assignments to race");
+  assert.strictEqual(occurrences(body, /html,\s*body\s*\{/g), 0, "no global reset may escape");
+});
+
+test("each slide's rules are scoped to a class of its own", async () => {
+  const body = await render(["A", "B", "C", "D"]);
+  const classes = [...new Set(body.match(/mulmo-slide-\d+/g) ?? [])];
+  assert.strictEqual(classes.length, 4, `four slides, four scopes — got ${JSON.stringify(classes)}`);
+});
+
+test("the fragment gets a box, because it is sized to fill one", async () => {
+  // deck's fragment root is `w-full h-full`; in a host that gives it no height it renders
+  // nothing at all, silently. The same failure the swipe root had (#1567).
+  const body = await render(["A"]);
+  assert.match(body, /aspect-ratio:\s*16\s*\/\s*9/, "a slide-shaped container");
+});


### PR DESCRIPTION
## Summary

`#1527`。`mulmo html` で **slide beat がフル HTML 文書のまま `<body>` に入れ子**になる件。

### 再現（報告や過去の出力ではなく、今のコードで）

`image_plugins/slide.ts` の `html()` を4回呼んで連結:

| | before | after |
|---|---:|---:|
| `<!DOCTYPE html>` | 4 | **0** |
| `cdn.tailwindcss.com` | 4 | **0** |
| `tailwind.config = ` | 4 | **0** |
| `html, body { ... }` | 4 | **0** |

`actions/html.ts` はこれを `<body>` にそのまま連結するので、4スライドの export は **Tailwind CDN を5回**読み、`tailwind.config` を**4回上書き**し、`html, body { overflow: hidden }` が**ページ全体に漏れて**スクロール不能になっていました。

### 構図 — ブラウザ経路は既に解決済みでした

`src/utils/beat_html/slide.ts`（**ブラウザ経路**）は**既に `generateSlideFragment` を使っています**。`image_plugins/slide.ts` の **dump 経路だけ**が取り残されていました。新しい設計ではなく、**同じ変更を dump 経路にも入れる**話です。

**PNG 経路（`processSlide`）は `generateSlideHTML` のままです** — そこではスライドがページそのものなので、それが正しい。

### 設計

- **fragment 自身の css は隣に出す** — `scopeClass` に閉じており、deck が呼び出しごとに一意な class を振ります（`mulmo-slide-0..3` を実測）
- **共有物はページのもの** — Tailwind と chart/mermaid ランタイムは `actions/html.ts` の head に既にありました。足りていなかった **`slideUtilityCss` を追加**
- **箱は plugin 側で付けます**。fragment は `w-full h-full` なので、箱が無いと**黙って潰れます**（`#1567` の swipe root と同じ失敗）。`actions/html.ts` は beat の種別を見ずに連結するので、ホストに任せられません

## Items to Confirm / Review

- **箱を `aspect-ratio: 16 / 9` にしました。** deck のレイアウトは 1280px 設計なので 16:9 が自然という判断ですが、export の見せ方の好みがあれば変えられます
- **`<style>` が slide beat ごとに1つ出ます。** 中身は `scopeClass` に閉じたそのスライド固有のルールだけで、共有物は含みません（それがこの PR の要点です）
- **PNG 経路は変えていません。** 同じファイルの `processSlide` は `generateSlideHTML` のままです

## 検証

**build が通ることではなく、症状の反対側を確認しました。** `html()` 経由で実際の export を生成し、ブラウザで開いています:

| | |
|---|---|
| **スクロールできるか** | **true**（919px ビューポートに 2796px の内容） |
| `html` / `body` の `overflow` | **visible**（以前は `hidden` が漏れていた） |
| 描画されたスライド | **4**、各 675px の 16:9 ボックス、テーマ適用済み |
| console エラー | **favicon の 404 のみ**（ページが favicon を宣言していないだけ） |

生成された文書側の実測: **doctype 1 / Tailwind CDN 1 / config 代入 0 / グローバルリセット 0**。

**テスト4本はすべて変異で確認**しています:

| 変異 | 結果 |
|---|---|
| `dumpHtml` を `generateSlideHTML` に戻す（元のバグ） | **4 fail** |
| 箱を外す | 1 fail |
| 全スライドで `scopeClass` を共有 | 1 fail |

`yarn lint` error 0 / `yarn build` OK / `typecheck:test` **0件** / 全テスト **1192 pass / 0 fail / 4 skipped**。

## User Prompt

> 1527以降のissueをまとめてなおしてからpublishだね

（4件の最後です。`#1535`→`#1569` / `#1547`→`#1570` / `#1542`→`#1571` 完了済み。この後 2.11.1 リリースへ。）

Closes #1527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slide HTML exports to prevent layout and scrolling issues caused by duplicated page-level markup and styles.
  * Added a consistent 16:9 layout container for exported slide content.
  * Improved CSS scoping for slide-specific styles.

* **Tests**
  * Added coverage verifying fragment output, CSS handling, shared markup suppression, and slide dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->